### PR TITLE
Admin: move the chart editor tabs to antd

### DIFF
--- a/adminSiteClient/ChartEditorView.scss
+++ b/adminSiteClient/ChartEditorView.scss
@@ -1,8 +1,82 @@
+// Styling for the chart editor shell: the two-column page, the antd `Tabs`
+// strip that replaced the Bootstrap `nav nav-tabs` markup, and the scrolling
+// form column. The individual tabs bring their own companion stylesheets.
+.ChartEditorPage {
+    display: flex;
+    flex-grow: 1;
+
+    .form-field__label {
+        margin-bottom: 0;
+    }
+
+    > .chart-editor-settings {
+        min-width: 550px;
+        width: 550px;
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
+    > .chart-editor-view {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+
+        a.preview {
+            position: absolute;
+            top: 8px;
+            right: 16px;
+        }
+    }
+
+    section {
+        padding: 1.2em;
+        border-radius: 0.4em;
+        margin-bottom: 1.2em;
+        background-color: #f9f9f9;
+
+        > h5 {
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid #ccc;
+        }
+    }
+
+    figure[data-grapher-src],
+    figure.grapher-component {
+        line-height: 0; // remove extra space on the bottom
+    }
+}
+
+// The editor has up to eleven tabs in a 550px column, so the tab bar overflows
+// and antd folds the rest into its "more" dropdown; a tighter gutter than the
+// default 32px keeps most of them visible.
+.ChartEditorView__tabs {
+    flex: 1 1 auto;
+    min-height: 0;
+
+    > .ant-tabs-nav {
+        margin-bottom: 0;
+        padding: 0.5rem 0.5rem 0;
+    }
+
+    > .ant-tabs-content-holder {
+        overflow-y: scroll;
+    }
+}
+
+// The form column inside the active tab pane. Used to be a Bootstrap
+// `.container`, which in this column amounted to its 15px horizontal padding.
+.ChartEditorPage .innerForm {
+    padding: 0 15px;
+}
+
 // The mobile/desktop preview toggle underneath the chart preview. Used to be a
 // Bootstrap `.btn-group` sized by a `.ChartEditorPage .btn-group .btn` rule in
 // `admin.scss`; it is an antd `Radio.Group` now, so the width lives here.
-// The rest of `.ChartEditorPage`'s styling still lives in `admin.scss` and gets
-// moved here when the chart editor tabs themselves are migrated.
 .ChartEditorPage__preview-mode {
     white-space: nowrap;
 
@@ -10,4 +84,10 @@
         text-align: center;
         width: 50px;
     }
+}
+
+.ChartEditorView__vision-deficiency {
+    display: inline-block;
+    width: 250px;
+    margin-left: 15px;
 }

--- a/adminSiteClient/ChartEditorView.scss
+++ b/adminSiteClient/ChartEditorView.scss
@@ -68,6 +68,16 @@
     }
 }
 
+// Three of the tabs want a little air under their labels; the rest sit tight
+// against their control.
+.EditorScatterTab,
+.EditorMarimekkoTab,
+.EditorDataTab {
+    .form-field__label {
+        margin-bottom: 0.3rem;
+    }
+}
+
 // The form column inside the active tab pane. Used to be a Bootstrap
 // `.container`, which in this column amounted to its 15px horizontal padding.
 .ChartEditorPage .innerForm {

--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -489,6 +489,10 @@ export class ChartEditorView<
                         className="ChartEditorView__tabs"
                         activeKey={editor.tab}
                         onChange={this.onTabChange}
+                        // There are up to eleven tabs in a 550px column;
+                        // antd's default 32px gutter would push half of them
+                        // into the overflow dropdown.
+                        tabBarGutter={14}
                         // Only the active tab is mounted, the way the editor
                         // has always worked: every field writes straight
                         // through to `grapherState`, so there is no per-tab

--- a/adminSiteClient/ChartEditorView.tsx
+++ b/adminSiteClient/ChartEditorView.tsx
@@ -56,14 +56,14 @@ import {
 } from "./VisionDeficiencies.js"
 import { EditorMarimekkoTab } from "./EditorMarimekkoTab.js"
 import { EditorExportTab } from "./EditorExportTab.js"
-import { AbstractChartEditor } from "./AbstractChartEditor.js"
+import { AbstractChartEditor, EditorTab } from "./AbstractChartEditor.js"
 import {
     ErrorMessages,
     ErrorMessagesForDimensions,
     FieldWithDetailReferences,
 } from "./ChartEditorTypes.js"
 import { Dataset, EditorDatabase } from "./EditorDatabase.js"
-import { Radio } from "antd"
+import { Radio, Tabs } from "antd"
 
 export type DetailReferences = Record<FieldWithDetailReferences, string[]>
 
@@ -393,6 +393,78 @@ export class ChartEditorView<
         )
     }
 
+    @action.bound private onTabChange(key: string): void {
+        const editor = this.manager.editor
+        const tab = key as EditorTab
+        editor.tab = tab
+        editor.showStaticPreview = tab === "export"
+    }
+
+    private renderTabLabel(editor: Editor, tab: EditorTab): React.ReactNode {
+        const referencesCount =
+            tab === "refs" && editor.references
+                ? ` (${getFullReferencesCount(editor.references)})`
+                : ""
+        return `${_.capitalize(tab)}${referencesCount}`
+    }
+
+    private renderTabContent(
+        editor: Editor,
+        tab: EditorTab
+    ): React.ReactElement | null {
+        const chartEditor = isChartEditorInstance(editor) ? editor : undefined
+
+        switch (tab) {
+            case "basic":
+                return (
+                    <EditorBasicTab
+                        editor={editor}
+                        database={this.database}
+                        errorMessagesForDimensions={
+                            this.errorMessagesForDimensions
+                        }
+                    />
+                )
+            case "text":
+                return (
+                    <EditorTextTab
+                        editor={editor}
+                        errorMessages={this.errorMessages}
+                    />
+                )
+            case "data":
+                return <EditorDataTab editor={editor} />
+            case "customize":
+                return (
+                    <EditorCustomizeTab
+                        editor={editor}
+                        errorMessages={this.errorMessages}
+                    />
+                )
+            case "scatter":
+                return <EditorScatterTab editor={editor} />
+            case "marimekko":
+                return <EditorMarimekkoTab grapherState={editor.grapherState} />
+            case "map":
+                return (
+                    <EditorMapTab
+                        editor={editor}
+                        errorMessages={this.errorMessages}
+                    />
+                )
+            case "revisions":
+                return chartEditor ? (
+                    <EditorHistoryTab editor={chartEditor} />
+                ) : null
+            case "refs":
+                return <EditorReferencesTab editor={editor} />
+            case "export":
+                return <EditorExportTab editor={editor} />
+            case "debug":
+                return <EditorDebugTab editor={editor} />
+        }
+    }
+
     renderReady(editor: Editor): React.ReactElement {
         const { grapherState, availableTabs } = editor
 
@@ -413,84 +485,25 @@ export class ChartEditorView<
                     <Redirect to={`/charts/${chartEditor.newChartId}/edit`} />
                 )}
                 <div className="chart-editor-settings">
-                    <div className="p-2">
-                        <ul className="nav nav-tabs">
-                            {availableTabs.map((tab) => (
-                                <li key={tab} className="nav-item">
-                                    <a
-                                        className={
-                                            "nav-link" +
-                                            (tab === editor.tab
-                                                ? " active"
-                                                : "")
-                                        }
-                                        onClick={() => {
-                                            editor.tab = tab
-                                            editor.showStaticPreview =
-                                                tab === "export"
-                                        }}
-                                    >
-                                        {_.capitalize(tab)}
-                                        {tab === "refs" && editor?.references
-                                            ? ` (${getFullReferencesCount(
-                                                  editor.references
-                                              )})`
-                                            : ""}
-                                    </a>
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                    <div className="innerForm container">
-                        {editor.tab === "basic" && (
-                            <EditorBasicTab
-                                editor={editor}
-                                database={this.database}
-                                errorMessagesForDimensions={
-                                    this.errorMessagesForDimensions
-                                }
-                            />
-                        )}
-                        {editor.tab === "text" && (
-                            <EditorTextTab
-                                editor={editor}
-                                errorMessages={this.errorMessages}
-                            />
-                        )}
-                        {editor.tab === "data" && (
-                            <EditorDataTab editor={editor} />
-                        )}
-                        {editor.tab === "customize" && (
-                            <EditorCustomizeTab
-                                editor={editor}
-                                errorMessages={this.errorMessages}
-                            />
-                        )}
-                        {editor.tab === "scatter" && (
-                            <EditorScatterTab editor={editor} />
-                        )}
-                        {editor.tab === "marimekko" && (
-                            <EditorMarimekkoTab grapherState={grapherState} />
-                        )}
-                        {editor.tab === "map" && (
-                            <EditorMapTab
-                                editor={editor}
-                                errorMessages={this.errorMessages}
-                            />
-                        )}
-                        {chartEditor && chartEditor.tab === "revisions" && (
-                            <EditorHistoryTab editor={chartEditor} />
-                        )}
-                        {editor.tab === "refs" && (
-                            <EditorReferencesTab editor={editor} />
-                        )}
-                        {editor.tab === "export" && (
-                            <EditorExportTab editor={editor} />
-                        )}
-                        {editor.tab === "debug" && (
-                            <EditorDebugTab editor={editor} />
-                        )}
-                    </div>
+                    <Tabs
+                        className="ChartEditorView__tabs"
+                        activeKey={editor.tab}
+                        onChange={this.onTabChange}
+                        // Only the active tab is mounted, the way the editor
+                        // has always worked: every field writes straight
+                        // through to `grapherState`, so there is no per-tab
+                        // component state to preserve across a switch.
+                        destroyOnHidden
+                        items={availableTabs.map((tab) => ({
+                            key: tab,
+                            label: this.renderTabLabel(editor, tab),
+                            children: (
+                                <div className="innerForm">
+                                    {this.renderTabContent(editor, tab)}
+                                </div>
+                            ),
+                        }))}
+                    />
                     {editor.tab !== "export" && (
                         <SaveButtons
                             editor={editor}
@@ -556,10 +569,7 @@ export class ChartEditorView<
                                 },
                             ]}
                         />
-                        <div
-                            className="form-group d-inline-block"
-                            style={{ width: 250, marginLeft: 15 }}
-                        >
+                        <div className="ChartEditorView__vision-deficiency">
                             Emulate vision deficiency:{" "}
                             <VisionDeficiencyDropdown
                                 onChange={action(

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -39,7 +39,7 @@ import {
     faMagnifyingGlass,
     faChartColumn,
 } from "@fortawesome/free-solid-svg-icons"
-import { Button, Divider, Space, Typography } from "antd"
+import { Button, Divider, Space, Tabs, Typography } from "antd"
 
 interface ExplorerListItem {
     slug: string
@@ -580,12 +580,12 @@ class DatasetEditor extends Component<DatasetEditorProps> {
         )
     }
 
-    renderTabContent() {
+    renderTabContent(tab: string) {
         const { dataset } = this.props
-        const { newDataset, activeTab, searchInput, filteredVariables } = this
+        const { newDataset, searchInput, filteredVariables } = this
         const highlight = highlightFunctionForSearchWords(this.searchWords)
 
-        switch (activeTab) {
+        switch (tab) {
             case "metadata":
                 return (
                     <section>
@@ -937,29 +937,19 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                     </Space>
                 </section>
 
-                {/* TAB NAVIGATION */}
-                <div className="mt-4">
-                    <ul className="nav nav-tabs">
-                        {tabs.map((tab) => (
-                            <li key={tab.key} className="nav-item">
-                                <a
-                                    className={
-                                        "nav-link" +
-                                        (tab.key === activeTab ? " active" : "")
-                                    }
-                                    onClick={() => this.onTabChange(tab.key)}
-                                >
-                                    {tab.label}
-                                </a>
-                            </li>
-                        ))}
-                    </ul>
-                </div>
-
-                {/* TAB CONTENT */}
-                <div className="tab-content mt-3">
-                    {this.renderTabContent()}
-                </div>
+                <Tabs
+                    className="mt-4"
+                    activeKey={activeTab}
+                    onChange={this.onTabChange}
+                    // Matches how the tab strip has always behaved: only the
+                    // active tab is mounted.
+                    destroyOnHidden
+                    items={tabs.map((tab) => ({
+                        key: tab.key,
+                        label: tab.label,
+                        children: this.renderTabContent(tab.key),
+                    }))}
+                />
             </main>
         )
     }

--- a/adminSiteClient/DimensionCard.scss
+++ b/adminSiteClient/DimensionCard.scss
@@ -1,0 +1,36 @@
+// Styles for the indicator cards in the chart editor's basic tab, moved out
+// of `admin.scss`. Kept under `.EditorBasicTab` — the only place the card is
+// rendered — so that the specificity against `.editable-list__item` is the same
+// as it has always been.
+.EditorBasicTab {
+    .DimensionCard {
+        header {
+            display: flex;
+            color: #666;
+            align-items: center;
+            text-align: center;
+            gap: 1em;
+            justify-content: space-between;
+
+            > div {
+                display: flex;
+                align-items: center;
+                gap: 0.5em;
+            }
+        }
+
+        > div {
+            margin: 1em 0;
+        }
+
+        .dimensionLink {
+            color: inherit;
+            text-decoration: underline;
+            text-decoration-color: rgba(0, 0, 0, 0.2);
+
+            &:hover {
+                text-decoration-color: inherit;
+            }
+        }
+    }
+}

--- a/adminSiteClient/DimensionCard.tsx
+++ b/adminSiteClient/DimensionCard.tsx
@@ -126,7 +126,7 @@ export class DimensionCard<
         const columnDef = column.def as OwidColumnDef
 
         return (
-            <div className="DimensionCard list-group-item">
+            <div className="DimensionCard editable-list__item">
                 <header>
                     <div>
                         <span

--- a/adminSiteClient/EditorBasicTab.scss
+++ b/adminSiteClient/EditorBasicTab.scss
@@ -1,0 +1,72 @@
+// Styles for the chart editor's basic tab, moved out of `admin.scss`. The
+// indicator cards it renders are styled in `DimensionCard.scss`.
+.EditorBasicTab {
+    .dimensionSlot {
+        cursor: pointer;
+        min-height: 50px;
+        border: 1px dashed #bbb;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #666;
+    }
+
+    .VariableSlots {
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+    }
+
+    .DimensionSlotHeader {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .chart-type-group {
+        margin-bottom: 12px;
+
+        .chart-type-group__label {
+            display: block;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin-bottom: 4px;
+        }
+
+        .chart-type-group__description {
+            display: block;
+            font-size: 0.75rem;
+            font-style: italic;
+            margin-bottom: 7px;
+        }
+
+        .chart-type-group__grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 4px;
+
+            .ant-tag-checkable {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+                margin: 0;
+                padding: 5px 10px;
+                border: 1px solid #d9d9d9;
+                background: white;
+
+                &:hover {
+                    border-color: #396d8f;
+                    color: inherit;
+                }
+
+                &.ant-tag-checkable-checked {
+                    background: #e6f0f8;
+                    border-color: #396d8f;
+                    color: #2a4d65;
+                }
+            }
+        }
+    }
+}

--- a/adminSiteClient/EditorBasicTab.tsx
+++ b/adminSiteClient/EditorBasicTab.tsx
@@ -553,7 +553,7 @@ const TagsSection = (props: {
                             id: props.chartId,
                         }}
                     />
-                    <small className="form-text text-muted">
+                    <small className="form-field__help text-muted">
                         Changes to tags will be applied instantly, without the
                         need to save the chart.
                     </small>

--- a/adminSiteClient/EditorColorScaleSection.scss
+++ b/adminSiteClient/EditorColorScaleSection.scss
@@ -1,0 +1,42 @@
+// Styles for the colour scale editor shared by the customize and map tabs,
+// moved out of `admin.scss`.
+.ColorSchemeEditor {
+    padding-left: 0;
+    li {
+        display: flex;
+        align-items: center;
+
+        i {
+            font-size: 1.2rem;
+            color: #666;
+        }
+
+        > * {
+            margin-right: 8px;
+
+            &:last-child {
+                margin-right: 0;
+            }
+        }
+
+        .range {
+            display: flex;
+            flex: 1 0;
+            align-items: center;
+
+            span {
+                font-size: 0.85em;
+                margin: 0 3px;
+            }
+        }
+
+        .form-field {
+            flex: 1 1;
+            margin-bottom: 0;
+        }
+    }
+}
+
+.BinLabelView .FieldsRow {
+    margin-bottom: 0;
+}

--- a/adminSiteClient/EditorColorScaleSection.tsx
+++ b/adminSiteClient/EditorColorScaleSection.tsx
@@ -246,8 +246,10 @@ class ColorsSection extends Component<ColorsSectionProps> {
                     </p>
                 )}
                 <FieldsRow>
-                    <div className="form-group">
-                        <label>Color scheme</label>
+                    <div className="form-field">
+                        <label className="form-field__label">
+                            Color scheme
+                        </label>
                         <ColorSchemeDropdown
                             value={this.currentColorScheme}
                             onChange={this.onColorScheme}
@@ -273,8 +275,10 @@ class ColorsSection extends Component<ColorsSectionProps> {
                 </FieldsRow>
                 <hr />
                 <FieldsRow>
-                    <div className="form-group">
-                        <label>Binning strategy</label>
+                    <div className="form-field">
+                        <label className="form-field__label">
+                            Binning strategy
+                        </label>
                         <Select<BinningStrategyIncludingManual>
                             options={this.binningStrategyOptions}
                             onChange={this.onBinningStrategy}
@@ -332,8 +336,10 @@ class ColorsSection extends Component<ColorsSectionProps> {
                     />
                 </FieldsRow>
                 <FieldsRow>
-                    <div className="form-group">
-                        <label>Midpoint mode</label>
+                    <div className="form-field">
+                        <label className="form-field__label">
+                            Midpoint mode
+                        </label>
                         <Select<MidpointModeOptionValue>
                             options={this.midpointModeOptions}
                             onChange={(value) => {

--- a/adminSiteClient/EditorCustomizeTab.scss
+++ b/adminSiteClient/EditorCustomizeTab.scss
@@ -1,0 +1,23 @@
+// Styles for the chart editor's customize tab, moved out of `admin.scss`.
+
+// Make the x/y dropdown in the comparison line editor narrow
+.comparisonLine .form-field:first-of-type {
+    flex-grow: 0;
+    flex-basis: 65px;
+}
+
+.dumbbell-trend-colors {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    .dumbbell-trend-colors__invert {
+        margin-left: auto;
+    }
+
+    .dumbbell-trend-colors__invert-icon {
+        position: relative;
+        top: 1px;
+        margin-right: 6px;
+    }
+}

--- a/adminSiteClient/EditorCustomizeTab.tsx
+++ b/adminSiteClient/EditorCustomizeTab.tsx
@@ -180,8 +180,10 @@ export class ColorSchemeSelector extends React.Component<ColorSchemeSelectorProp
         return (
             <React.Fragment>
                 <FieldsRow>
-                    <div className="form-group">
-                        <label>Color scheme</label>
+                    <div className="form-field">
+                        <label className="form-field__label">
+                            Color scheme
+                        </label>
                         <ColorSchemeDropdown
                             value={grapherState.baseColorScheme}
                             onChange={this.onChange}
@@ -322,7 +324,7 @@ class SortOrderSection<
     override render() {
         return (
             <Section name="Sort Order">
-                <div className="form-group">
+                <div className="form-field">
                     Sort by
                     <Select
                         onChange={this.onSortByChange}
@@ -345,7 +347,7 @@ class SortOrderSection<
                         }
                     />
                 </div>
-                <div className="form-group">
+                <div className="form-field">
                     Sort order
                     <RadioGroup
                         options={[
@@ -408,7 +410,7 @@ class FacetSection<Editor extends AbstractChartEditor> extends React.Component<{
 
         return (
             <Section name="Faceting">
-                <div className="form-group">
+                <div className="form-field">
                     Faceting strategy
                     <Select
                         options={this.facetOptions}
@@ -796,8 +798,10 @@ class DumbbellSection<
                 />
                 {features.canConfigureDumbbellColors && (
                     <FieldsRow>
-                        <div className="form-group">
-                            <label>Trend colors</label>
+                        <div className="form-field">
+                            <label className="form-field__label">
+                                Trend colors
+                            </label>
                             <div className="dumbbell-trend-colors">
                                 <TrendColorField
                                     grapherState={grapherState}
@@ -934,7 +938,7 @@ export class EditorCustomizeTab<
                     <Section name="X Axis">
                         {/* If a scatter tab is present, then x-axis settings only apply to the scatter plot */}
                         {!grapherState.isScatter && grapherState.hasScatter && (
-                            <small className="form-text text-muted mt-0 mb-2">
+                            <small className="form-field__help text-muted mt-0 mb-2">
                                 X axis settings only apply to the scatter plot
                             </small>
                         )}

--- a/adminSiteClient/EditorDataTab.scss
+++ b/adminSiteClient/EditorDataTab.scss
@@ -82,3 +82,19 @@
         margin-top: 0.75rem;
     }
 }
+
+// The rows of the "data to show" list, moved out of `admin.scss`.
+.ListItem {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    > div {
+        display: flex;
+        align-items: center;
+    }
+
+    &.invalid {
+        background: #fce9e6;
+    }
+}

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -4,7 +4,7 @@ import { getRegionByName, checkIsCountry } from "@ourworldindata/utils"
 import { computed, action, observable, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import cx from "clsx"
-import { Button } from "antd"
+import { Button, Radio, Space } from "antd"
 import {
     EntitySelectionMode,
     MissingDataStrategy,
@@ -1036,63 +1036,27 @@ export class EditorDataTab<
         return (
             <div className="EditorDataTab">
                 <Section name="Can user add/change data?">
-                    <div className="form-check">
-                        <label className="form-check-label">
-                            <input
-                                className="form-check-input"
-                                type="radio"
-                                name="add-country-mode"
-                                value={EntitySelectionMode.MultipleEntities}
-                                checked={
-                                    grapherState.addCountryMode ===
-                                    EntitySelectionMode.MultipleEntities
-                                }
-                                onChange={() =>
-                                    (grapherState.addCountryMode =
-                                        EntitySelectionMode.MultipleEntities)
-                                }
-                            />
-                            User can add and remove data
-                        </label>
-                    </div>
-                    <div className="form-check">
-                        <label className="form-check-label">
-                            <input
-                                className="form-check-input"
-                                type="radio"
-                                name="add-country-mode"
-                                value={EntitySelectionMode.SingleEntity}
-                                checked={
-                                    grapherState.addCountryMode ===
-                                    EntitySelectionMode.SingleEntity
-                                }
-                                onChange={() =>
-                                    (grapherState.addCountryMode =
-                                        EntitySelectionMode.SingleEntity)
-                                }
-                            />
-                            User can change entity
-                        </label>
-                    </div>
-                    <div className="form-check">
-                        <label className="form-check-label">
-                            <input
-                                className="form-check-input"
-                                type="radio"
-                                name="add-country-mode"
-                                value={EntitySelectionMode.Disabled}
-                                checked={
-                                    grapherState.addCountryMode ===
-                                    EntitySelectionMode.Disabled
-                                }
-                                onChange={() =>
-                                    (grapherState.addCountryMode =
-                                        EntitySelectionMode.Disabled)
-                                }
-                            />
-                            User cannot change/add data
-                        </label>
-                    </div>
+                    <Radio.Group
+                        name="add-country-mode"
+                        value={grapherState.addCountryMode}
+                        onChange={action(
+                            (event) =>
+                                (grapherState.addCountryMode = event.target
+                                    .value as EntitySelectionMode)
+                        )}
+                    >
+                        <Space orientation="vertical" size={0}>
+                            <Radio value={EntitySelectionMode.MultipleEntities}>
+                                User can add and remove data
+                            </Radio>
+                            <Radio value={EntitySelectionMode.SingleEntity}>
+                                User can change entity
+                            </Radio>
+                            <Radio value={EntitySelectionMode.Disabled}>
+                                User cannot change/add data
+                            </Radio>
+                        </Space>
+                    </Radio.Group>
                 </Section>
                 <Section name="Entity type">
                     <FieldsRow>

--- a/adminSiteClient/EditorDataTab.tsx
+++ b/adminSiteClient/EditorDataTab.tsx
@@ -96,7 +96,7 @@ class EntityListItem extends React.Component<EntityListItemProps> {
 
         return (
             <div
-                className="list-group-item EditableListItem"
+                className="editable-list__item EditableListItem"
                 key={entityName}
                 {...rest}
             >
@@ -133,7 +133,7 @@ class SeriesListItem extends React.Component<SeriesListItemProps> {
         const { seriesName, isValid } = props
         const rest = _.omit(props, ["seriesName", "isValid", "onRemove"])
 
-        const className = cx("ListItem", "list-group-item", {
+        const className = cx("ListItem", "editable-list__item", {
             invalid: !isValid,
         })
         const annotation = !isValid ? "(not plotted)" : ""

--- a/adminSiteClient/EditorDebugTab.tsx
+++ b/adminSiteClient/EditorDebugTab.tsx
@@ -10,7 +10,7 @@ import {
     mergeGrapherConfigs,
 } from "@ourworldindata/utils"
 import YAML from "yaml"
-import { Button, Modal, notification, Space } from "antd"
+import { Button, Input, Modal, notification, Space } from "antd"
 import { AbstractChartEditor } from "./AbstractChartEditor.js"
 import {
     NarrativeChartEditor,
@@ -106,10 +106,9 @@ class EditorDebugTabForChart extends Component<{
         return (
             <div>
                 <Section name="Config">
-                    <textarea
+                    <Input.TextArea
                         rows={7}
                         readOnly
-                        className="form-control"
                         value={YAML.stringify(patchConfig)}
                     />
                     <Button
@@ -159,10 +158,9 @@ class EditorDebugTabForChart extends Component<{
                                         : "Parent config (not currently applied)"
                                 }
                             >
-                                <textarea
+                                <Input.TextArea
                                     rows={7}
                                     readOnly
-                                    className="form-control"
                                     value={YAML.stringify(parentConfig)}
                                 />
                             </Section>
@@ -171,10 +169,9 @@ class EditorDebugTabForChart extends Component<{
                 )}
 
                 <Section name="Full Config">
-                    <textarea
+                    <Input.TextArea
                         rows={7}
                         readOnly
-                        className="form-control"
                         value={YAML.stringify(fullConfig)}
                     />
                 </Section>
@@ -279,10 +276,9 @@ class EditorDebugTabForNarrativeChart extends Component<{
         return (
             <div>
                 <Section name="Config">
-                    <textarea
+                    <Input.TextArea
                         rows={7}
                         readOnly
-                        className="form-control"
                         value={YAML.stringify(patchConfig)}
                     />
                     <Space className="mt-2" wrap>
@@ -308,19 +304,17 @@ class EditorDebugTabForNarrativeChart extends Component<{
                 </Section>
                 {parentConfig && (
                     <Section name="Parent config">
-                        <textarea
+                        <Input.TextArea
                             rows={7}
                             readOnly
-                            className="form-control"
                             value={YAML.stringify(parentConfig)}
                         />
                     </Section>
                 )}
                 <Section name="Full Config">
-                    <textarea
+                    <Input.TextArea
                         rows={7}
                         readOnly
-                        className="form-control"
                         value={YAML.stringify(fullConfig)}
                     />
                 </Section>

--- a/adminSiteClient/EditorExportTab.scss
+++ b/adminSiteClient/EditorExportTab.scss
@@ -1,0 +1,9 @@
+// Styles for the chart editor's export tab, moved out of `admin.scss`.
+.EditorExportTab {
+    .DownloadButtons {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        align-items: flex-start;
+    }
+}

--- a/adminSiteClient/EditorFAQ.scss
+++ b/adminSiteClient/EditorFAQ.scss
@@ -1,0 +1,15 @@
+// Styles for the chart editor's FAQ dialog, moved out of `admin.scss`.
+.EditorFAQ {
+    .modal-body {
+        max-height: 80vh;
+        overflow-y: scroll;
+    }
+
+    h6 {
+        font-weight: bold;
+    }
+
+    h6:not(:first-child) {
+        margin-top: 20px;
+    }
+}

--- a/adminSiteClient/EditorHistoryTab.tsx
+++ b/adminSiteClient/EditorHistoryTab.tsx
@@ -85,7 +85,7 @@ class LogRenderer extends Component<LogRendererProps> {
 
         return (
             <li
-                className="list-group-item d-flex justify-content-between"
+                className="editable-list__item d-flex justify-content-between"
                 style={{ alignItems: "center" }}
             >
                 {hasCompareButton && (
@@ -126,7 +126,7 @@ export class EditorHistoryTab extends Component<{ editor: ChartEditor }> {
         return (
             <div>
                 {this.logs.map((log, i) => (
-                    <ul key={i} className="list-group">
+                    <ul key={i} className="editable-list">
                         <LogRenderer
                             log={log}
                             previousLog={this.logs[i + 1]} // Needed for comparison, might be undefined

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -346,7 +346,7 @@ export class EditorMapTab<Editor extends AbstractChartEditor> extends Component<
         const isReady = !!mapColumnSlug && grapherState.table.has(mapColumnSlug)
 
         return (
-            <div className="EditorMapTab tab-pane">
+            <div className="EditorMapTab">
                 <VariableSection
                     mapConfig={mapConfig}
                     filledDimensions={grapherState.filledDimensions}

--- a/adminSiteClient/EditorMapTab.tsx
+++ b/adminSiteClient/EditorMapTab.tsx
@@ -242,7 +242,7 @@ class InapplicableEntitiesSection extends Component<{
                     showSearch
                     allowClear
                 />
-                <small className="form-text text-muted">
+                <small className="form-field__help text-muted">
                     Entities the indicator's data can't apply to by
                     construction, e.g. Mexico for "Where do Mexican emigrants
                     live?". Excluded from the color scale and drawn in a

--- a/adminSiteClient/EditorReferencesTab.scss
+++ b/adminSiteClient/EditorReferencesTab.scss
@@ -1,0 +1,41 @@
+// Styles for the chart editor's "Refs" tab, moved out of `admin.scss` when the
+// tab's Bootstrap list-group and input-group markup was replaced.
+.EditorReferencesTab .redirect-prefix {
+    color: #aaa;
+    font-size: 13px;
+    font-weight: 400;
+    text-decoration: none;
+}
+
+.EditorReferencesTab .ReferencesDataInsights {
+    li {
+        display: flex;
+        gap: 1em;
+
+        a {
+            flex-grow: 1;
+        }
+
+        button {
+            min-width: 144px;
+        }
+    }
+}
+
+.AddRedirectForm__row {
+    margin-bottom: 0.5rem;
+}
+
+// A static label sitting flush against the antd `Input` next to it — what
+// Bootstrap's `.input-group-prepend` + `.input-group-text` used to render.
+.AddRedirectForm__addon {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+    padding: 4px 11px;
+    border: 1px solid #d9d9d9;
+    border-right: none;
+    border-radius: 6px 0 0 6px;
+    background: #fafafa;
+    white-space: nowrap;
+}

--- a/adminSiteClient/EditorReferencesTab.tsx
+++ b/adminSiteClient/EditorReferencesTab.tsx
@@ -27,7 +27,7 @@ import {
 import { ReuploadImageForDataInsightModal } from "./ReuploadImageForDataInsightModal.js"
 import { ImageUploadResponse } from "./imagesHelpers.js"
 import { DataInsightMinimalInformation } from "../adminShared/AdminTypes.js"
-import { Alert, Button, notification } from "antd"
+import { Alert, Button, Input, notification, Space } from "antd"
 import { getCanonicalUrl } from "@ourworldindata/components"
 
 const BASE_URL = BAKED_GRAPHER_URL.replace(/^https?:\/\//, "")
@@ -126,7 +126,7 @@ export class EditorReferencesTabForChart extends Component<{
                             )}
                         </div>
                     </div>
-                    <small className="form-text text-muted">
+                    <small className="form-field__help text-muted">
                         Chart view numbers include all views of this chart
                         (direct, embedded, and in articles). The numbers are
                         updated nightly.
@@ -159,11 +159,11 @@ export class EditorReferencesTabForChart extends Component<{
                     {this.redirects.length ? (
                         <Fragment>
                             <p>The following URLs redirect to this chart:</p>
-                            <ul className="list-group">
+                            <ul className="editable-list">
                                 {this.redirects.map((redirect) => (
                                     <li
                                         key={redirect.id}
-                                        className="list-group-item"
+                                        className="editable-list__item"
                                     >
                                         <span className="redirect-prefix">
                                             {BASE_URL}/
@@ -322,38 +322,28 @@ class AddRedirectForm<Editor extends AbstractChartEditor> extends Component<
                     void this.onSubmit()
                 }}
             >
-                <div className="input-group mb-2">
-                    <div className="input-group-prepend">
-                        <span className="input-group-text" id="basic-addon3">
-                            {BASE_URL}/
-                        </span>
-                    </div>
-                    <input
-                        type="text"
-                        className="form-control"
+                <Space.Compact className="AddRedirectForm__row" block>
+                    <span className="AddRedirectForm__addon">{BASE_URL}/</span>
+                    <Input
                         placeholder="URL"
                         value={this.slug}
                         onChange={(event) =>
                             this.onSlugChange(event.target.value)
                         }
                     />
-                </div>
-                <div className="input-group mb-2">
-                    <div className="input-group-prepend">
-                        <span className="input-group-text">
-                            Target query params (optional)
-                        </span>
-                    </div>
-                    <input
-                        type="text"
-                        className="form-control"
+                </Space.Compact>
+                <Space.Compact className="AddRedirectForm__row" block>
+                    <span className="AddRedirectForm__addon">
+                        Target query params (optional)
+                    </span>
+                    <Input
                         placeholder="e.g. 'tab=map'"
                         value={this.targetQueryParam}
                         onChange={(event) =>
                             this.onTargetQueryParamChange(event.target.value)
                         }
                     />
-                </div>
+                </Space.Compact>
                 <div className="text-right mb-3">
                     <Button
                         type="primary"
@@ -378,9 +368,9 @@ const ReferencesWordpressPosts = (props: {
     return (
         <>
             <p>Public wordpress pages that embed or reference this chart:</p>
-            <ul className="list-group">
+            <ul className="editable-list">
                 {props.references.postsWordpress.map((post) => (
-                    <li key={post.id} className="list-group-item">
+                    <li key={post.id} className="editable-list__item">
                         <a href={post.url} target="_blank" rel="noopener">
                             <strong>{post.title}</strong>
                         </a>{" "}
@@ -408,9 +398,9 @@ const ReferencesGdocPosts = (props: {
     return (
         <>
             <p>Published content that references this chart</p>
-            <ul className="list-group">
+            <ul className="editable-list">
                 {props.references.postsGdocs.map((post) => (
-                    <li key={post.id} className="list-group-item">
+                    <li key={post.id} className="editable-list__item">
                         <a
                             href={getCanonicalUrl(BAKED_BASE_URL, {
                                 slug: post.slug,
@@ -446,9 +436,9 @@ const ReferencesExplorers = (props: {
     return (
         <>
             <p>Explorers (incl. unpublished ones) that reference this chart:</p>
-            <ul className="list-group">
+            <ul className="editable-list">
                 {props.references.explorers.map((explorer) => (
-                    <li key={explorer} className="list-group-item">
+                    <li key={explorer} className="editable-list__item">
                         <a
                             href={`https://ourworldindata.org/explorers/${explorer}`}
                             target="_blank"
@@ -479,9 +469,9 @@ const ReferencesNarrativeCharts = (props: {
     return (
         <>
             <p>Narrative charts based on this chart</p>
-            <ul className="list-group">
+            <ul className="editable-list">
                 {props.references.narrativeCharts.map((narrativeChart) => (
-                    <li key={narrativeChart.id} className="list-group-item">
+                    <li key={narrativeChart.id} className="editable-list__item">
                         <a
                             href={`/admin/narrative-charts/${narrativeChart.id}/edit`}
                             target="_blank"
@@ -503,9 +493,9 @@ const ReferencesStaticViz = (props: {
     return (
         <>
             <p>Static visualizations created from this chart:</p>
-            <ul className="list-group">
+            <ul className="editable-list">
                 {props.references.staticViz.map((staticViz) => (
-                    <li key={staticViz.id} className="list-group-item">
+                    <li key={staticViz.id} className="editable-list__item">
                         <a
                             href={`/admin/static-viz/${staticViz.id}`}
                             target="_blank"
@@ -559,12 +549,12 @@ const ReferencesDataInsights = (props: {
                 <p>
                     Published and unpublished data insights based on this chart
                 </p>
-                <ul className="list-group">
+                <ul className="editable-list">
                     {props.references.dataInsights.map((dataInsight) => (
                         <Fragment key={dataInsight.gdocId}>
                             <li>
                                 <a
-                                    className="list-group-item"
+                                    className="editable-list__item"
                                     href={`/admin/gdocs/${dataInsight.gdocId}/preview`}
                                     target="_blank"
                                     rel="noopener"

--- a/adminSiteClient/EditorTextTab.tsx
+++ b/adminSiteClient/EditorTextTab.tsx
@@ -340,8 +340,8 @@ export class EditorTextTab<
                         helpText="Short comma-separated list of source names"
                         softCharacterLimit={60}
                     />
-                    <div className="form-group">
-                        <label>Origin url</label>
+                    <div className="form-field">
+                        <label className="form-field__label">Origin url</label>
                         <AutoComplete
                             style={{ width: "100%" }}
                             value={grapherState.originUrl ?? ""}
@@ -421,7 +421,7 @@ export class EditorTextTab<
                                 )
                             }}
                         />
-                        <small className="form-text text-muted">
+                        <small className="form-field__help text-muted">
                             The page containing this chart where more context
                             can be found. Choose a topic page from the dropdown
                             or type any relative or absolute URL.

--- a/adminSiteClient/Forms.scss
+++ b/adminSiteClient/Forms.scss
@@ -8,6 +8,11 @@
 // The rules below cover the parts that used to come from Bootstrap's
 // form/input-group/list-group/modal markup that `Forms.tsx` no longer emits.
 
+// Replaces Bootstrap's `.form-group`, which the wrapper still carries as well.
+.form-field {
+    margin-bottom: 1rem;
+}
+
 .form-field__label {
     display: block;
 }

--- a/adminSiteClient/Forms.scss
+++ b/adminSiteClient/Forms.scss
@@ -147,3 +147,99 @@
         }
     }
 }
+
+// Blocks below moved out of `admin.scss` when the chart editor was migrated;
+// they all style components that live in `Forms.tsx`.
+.EditableListItem {
+    @extend .draggable;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    > div {
+        display: flex;
+        align-items: center;
+    }
+
+    i {
+        font-size: 1.2rem;
+        color: #666;
+    }
+
+    > div:first-child > * {
+        margin-right: 12px;
+    }
+}
+
+.FieldsRow {
+    display: flex;
+    align-items: center;
+    margin: 0 0 1em;
+
+    > * {
+        padding-right: 1rem;
+        margin-bottom: 0 !important;
+        flex-grow: 1;
+        flex-basis: 0;
+    }
+}
+
+.WithResetButton {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    .form-field {
+        margin-bottom: 0;
+        width: 100%;
+    }
+
+    .ResetToDefaultButton {
+        height: auto;
+        padding: 0;
+        font-size: 0.8em;
+        color: inherit;
+
+        &:disabled {
+            font-style: italic;
+        }
+
+        &:not(:disabled) {
+            text-decoration: underline;
+        }
+
+        &:hover {
+            text-decoration: none;
+        }
+    }
+}
+
+.ColorBox {
+    width: 2em;
+    height: 2em;
+    cursor: pointer;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.colorpicker-tooltip {
+    .tippy-content {
+        padding: 0;
+    }
+}
+
+.LoadingBlocker {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 9999;
+    color: white;
+    align-items: center;
+    justify-content: center;
+}

--- a/adminSiteClient/Forms.scss
+++ b/adminSiteClient/Forms.scss
@@ -1,11 +1,12 @@
 // Styles for the shared admin form kit in `Forms.tsx`, which renders antd
 // primitives inside our own label / help-text / error chrome.
 //
-// The wrapper elements still carry Bootstrap's `form-group` and `list-group`
-// classes next to the ones below, because raw Bootstrap form and list markup
-// lives on in ~30 other admin files and is frequently interleaved with these
-// components. The rules here only cover the parts that used to come from
-// Bootstrap's form/input-group/modal markup that `Forms.tsx` no longer emits.
+// The field wrapper still carries Bootstrap's `form-group` class next to
+// `form-field`, because raw `form-group` markup lives on in the pages Phase 5
+// of the antd migration covers (ExplorerCreatePage, UsersIndexPage, GdocsAdd,
+// the gdocs settings forms) and is interleaved with these components there.
+// The rules below cover the parts that used to come from Bootstrap's
+// form/input-group/list-group/modal markup that `Forms.tsx` no longer emits.
 
 .form-field__label {
     display: block;
@@ -74,12 +75,36 @@
     height: auto;
 }
 
-// `EditableList` / `EditableListItem`. These deliberately mirror what
-// Bootstrap's list-group gives the hand-written `list-group-item` markup they
-// are mixed with; they exist as grep-able hooks for the phase that removes it.
+// `EditableList` / `EditableListItem`, plus the hand-written list markup in the
+// chart editor that used to carry Bootstrap's `list-group` classes. These rules
+// are what `bootstrap/scss/list-group` used to emit for them, minus the
+// variants (`-action`, `-flush`, contextual colours) nothing ever used.
 .editable-list {
+    display: flex;
+    flex-direction: column;
+    padding-left: 0;
     margin-top: 0;
     margin-bottom: 0.5em;
+}
+
+.editable-list__item {
+    position: relative;
+    display: block;
+    padding: 0.75rem 1.25rem;
+    margin-bottom: -1px;
+    background-color: #fff;
+    border: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.editable-list__item:first-child {
+    border-top-left-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+}
+
+.editable-list__item:last-child {
+    margin-bottom: 0;
+    border-bottom-right-radius: 0.25rem;
+    border-bottom-left-radius: 0.25rem;
 }
 
 // The `Modal` component renders whatever it is handed inside an antd modal

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -53,10 +53,11 @@ export class FieldsRow extends React.Component<{ children: React.ReactNode }> {
 
 /**
  * The wrapper every field renders. It keeps Bootstrap's `form-group` class
- * alongside our own `form-field` one: raw `form-group` markup still exists in
- * ~30 other admin files, and a good number of `admin.scss` rules key layout
- * off `.form-group` inside the chart editor. Dropping it belongs to the phase
- * that migrates those pages.
+ * alongside our own `form-field` one: the chart editor is off `form-group`
+ * now, but raw `form-group` markup still exists on the pages Phase 5 of the
+ * antd migration covers (ExplorerCreatePage, UsersIndexPage, GdocsAdd, the
+ * gdocs settings forms), and `admin.scss` still keys layout off it there.
+ * Dropping it belongs to the phase that migrates those pages.
  */
 function FormField(props: {
     className?: string

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -670,12 +670,6 @@ export class Toggle extends React.Component<ToggleProps> {
     }
 }
 
-/**
- * Keeps Bootstrap's `list-group` classes alongside our own: several call sites
- * mix `EditableListItem`s with hand-written `list-group-item` markup in the
- * same list, so the two have to keep looking the same until those pages move
- * over too.
- */
 export class EditableList extends React.Component<{
     className?: string
     children?: React.ReactNode
@@ -684,11 +678,7 @@ export class EditableList extends React.Component<{
         return this.props.children ? (
             <ul
                 {...this.props}
-                className={cx(
-                    "editable-list",
-                    "list-group",
-                    this.props.className
-                )}
+                className={cx("editable-list", this.props.className)}
             />
         ) : null
     }
@@ -703,11 +693,7 @@ export class EditableListItem extends React.Component<EditableListItemProps> {
         return (
             <li
                 {...this.props}
-                className={cx(
-                    "editable-list__item",
-                    "list-group-item",
-                    this.props.className
-                )}
+                className={cx("editable-list__item", this.props.className)}
             />
         )
     }

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -104,7 +104,7 @@ import { EditorColorScaleSection } from "./EditorColorScaleSection.js"
 import { Operation } from "../adminShared/SqlFilterSExpression.js"
 import { CATALOG_URL, DATA_API_URL } from "../settings/clientSettings.js"
 import { SortableList } from "./SortableList.js"
-import { Button } from "antd"
+import { Button, Tabs as AntdTabs } from "antd"
 
 type Disposer = () => void
 
@@ -1257,27 +1257,20 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
             return (
                 <div className="VariablesAnnotationPage">
                     <div className="sidebar">
-                        <div className="p-2">
-                            <ul className="nav nav-tabs">
-                                {ALL_TABS.map((tab) => (
-                                    <li key={tab} className="nav-item">
-                                        <a
-                                            className={
-                                                "nav-link" +
-                                                (tab === activeTab
-                                                    ? " active"
-                                                    : "")
-                                            }
-                                            onClick={action(
-                                                () => (this.activeTab = tab)
-                                            )}
-                                        >
-                                            {tab}
-                                        </a>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
+                        {/* Tab bar only: the panes stay where they are, as
+                            direct children of `.sidebar-content`, which sizes
+                            them (and the preview area below them) with flex. */}
+                        <AntdTabs
+                            className="VariablesAnnotationPage__tabs"
+                            activeKey={activeTab}
+                            onChange={action(
+                                (key: string) => (this.activeTab = key as Tabs)
+                            )}
+                            items={ALL_TABS.map((tab) => ({
+                                key: tab,
+                                label: tab,
+                            }))}
+                        />
                         <div className="sidebar-content">
                             {match(activeTab)
                                 .with(Tabs.EditorTab, () =>

--- a/adminSiteClient/VariableSelector.scss
+++ b/adminSiteClient/VariableSelector.scss
@@ -1,0 +1,73 @@
+// Styles for the indicator picker modal, moved out of `admin.scss`.
+.VariableSelector {
+    .modal-body > div {
+        display: flex !important;
+        justify-content: space-between;
+    }
+
+    .selectedData {
+        min-width: 25%;
+        padding-left: 1em;
+        max-height: 550px;
+        overflow-y: auto;
+    }
+
+    .searchResults h5 {
+        color: #666;
+        font-size: 1rem;
+        padding-bottom: 5px;
+        border-bottom: 1px solid #ccc;
+    }
+
+    .searchResults ul {
+        display: flex;
+        flex-wrap: wrap;
+    }
+
+    .searchResults b {
+        color: orange;
+    }
+
+    ul {
+        padding: 0;
+    }
+
+    li {
+        list-style-type: none;
+        flex: 1 0 15em;
+        min-height: 32px;
+    }
+
+    li > .toggle-field {
+        width: 100%;
+        margin-bottom: 0;
+    }
+
+    input[type="search"] {
+        width: 100%;
+        font-size: 0.9em;
+        padding: 0.4em;
+        margin-bottom: 0.4em;
+        border: 1px solid #ccc;
+    }
+
+    .muted-option {
+        opacity: 0.55;
+    }
+
+    .icon {
+        color: #999;
+        margin-right: 5px;
+    }
+
+    .badge {
+        background-color: #999;
+        border-radius: 2px;
+        text-transform: uppercase;
+        font-size: 10px;
+        font-weight: 700;
+        padding: 3px 4px;
+        color: white;
+        margin-left: 4px;
+    }
+}

--- a/adminSiteClient/VariableSelector.tsx
+++ b/adminSiteClient/VariableSelector.tsx
@@ -263,8 +263,10 @@ export class VariableSelector<
                                 onEscape={this.onDismiss}
                                 autofocus
                             />
-                            <div className="form-group">
-                                <label>Namespaces</label>
+                            <div className="form-field">
+                                <label className="form-field__label">
+                                    Namespaces
+                                </label>
                                 <Select<string[], NamespaceOption>
                                     options={namespaceOptions}
                                     value={this.chosenNamespaces.map(

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -76,8 +76,15 @@
 @import "./AdminLayout.scss";
 @import "./SaveButtons.scss";
 @import "./ChartEditorView.scss";
+@import "./EditorBasicTab.scss";
+@import "./DimensionCard.scss";
+@import "./VariableSelector.scss";
 @import "./EditorDataTab.scss";
+@import "./EditorCustomizeTab.scss";
+@import "./EditorColorScaleSection.scss";
+@import "./EditorExportTab.scss";
 @import "./EditorReferencesTab.scss";
+@import "./EditorFAQ.scss";
 @import "./EditableTags.scss";
 @import "./AdminSidebar.scss";
 @import "./GdocsIndexPage.scss";
@@ -149,21 +156,6 @@ button {
 
     section:not(:first-child) {
         margin-top: 40px;
-    }
-}
-
-.EditorFAQ {
-    .modal-body {
-        max-height: 80vh;
-        overflow-y: scroll;
-    }
-
-    h6 {
-        font-weight: bold;
-    }
-
-    h6:not(:first-child) {
-        margin-top: 20px;
     }
 }
 
@@ -247,284 +239,6 @@ button {
     }
 }
 
-.EditorBasicTab {
-    .DimensionCard {
-        header {
-            display: flex;
-            color: #666;
-            align-items: center;
-            text-align: center;
-            gap: 1em;
-            justify-content: space-between;
-
-            > div {
-                display: flex;
-                align-items: center;
-                gap: 0.5em;
-            }
-        }
-
-        > div {
-            margin: 1em 0;
-        }
-
-        .dimensionLink {
-            color: inherit;
-            text-decoration: underline;
-            text-decoration-color: rgba(0, 0, 0, 0.2);
-
-            &:hover {
-                text-decoration-color: inherit;
-            }
-        }
-    }
-
-    .dimensionSlot {
-        cursor: pointer;
-        min-height: 50px;
-        border: 1px dashed #bbb;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: #666;
-    }
-
-    .VariableSlots {
-        display: flex;
-        flex-direction: column;
-        gap: 1em;
-    }
-
-    .DimensionSlotHeader {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-    }
-
-    .chart-type-group {
-        margin-bottom: 12px;
-
-        .chart-type-group__label {
-            display: block;
-            font-size: 0.75rem;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-            margin-bottom: 4px;
-        }
-
-        .chart-type-group__description {
-            display: block;
-            font-size: 0.75rem;
-            font-style: italic;
-            margin-bottom: 7px;
-        }
-
-        .chart-type-group__grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 4px;
-
-            .ant-tag-checkable {
-                display: flex;
-                align-items: center;
-                gap: 4px;
-                margin: 0;
-                padding: 5px 10px;
-                border: 1px solid #d9d9d9;
-                background: white;
-
-                &:hover {
-                    border-color: #396d8f;
-                    color: inherit;
-                }
-
-                &.ant-tag-checkable-checked {
-                    background: #e6f0f8;
-                    border-color: #396d8f;
-                    color: #2a4d65;
-                }
-            }
-        }
-    }
-}
-
-.EditorExportTab {
-    .DownloadButtons {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        align-items: flex-start;
-    }
-}
-
-.ColorableItem {
-    display: flex;
-    align-items: center;
-
-    > div {
-        margin-right: 0.5em;
-    }
-}
-
-.VariableSelector {
-    .modal-body > div {
-        display: flex !important;
-        justify-content: space-between;
-    }
-
-    .selectedData {
-        min-width: 25%;
-        padding-left: 1em;
-        max-height: 550px;
-        overflow-y: auto;
-    }
-
-    .searchResults h5 {
-        color: #666;
-        font-size: 1rem;
-        padding-bottom: 5px;
-        border-bottom: 1px solid #ccc;
-    }
-
-    .searchResults ul {
-        display: flex;
-        flex-wrap: wrap;
-    }
-
-    .searchResults b {
-        color: orange;
-    }
-
-    ul {
-        padding: 0;
-    }
-
-    li {
-        list-style-type: none;
-        flex: 1 0 15em;
-        min-height: 32px;
-    }
-
-    li > .toggle-field {
-        width: 100%;
-        margin-bottom: 0;
-    }
-
-    input[type="search"] {
-        width: 100%;
-        font-size: 0.9em;
-        padding: 0.4em;
-        margin-bottom: 0.4em;
-        border: 1px solid #ccc;
-    }
-
-    .muted-option {
-        opacity: 0.55;
-    }
-
-    .icon {
-        color: #999;
-        margin-right: 5px;
-    }
-
-    .badge {
-        background-color: #999;
-        border-radius: 2px;
-        text-transform: uppercase;
-        font-size: 10px;
-        font-weight: 700;
-        padding: 3px 4px;
-        color: white;
-        margin-left: 4px;
-    }
-}
-
-.ListItem {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    > div {
-        display: flex;
-        align-items: center;
-    }
-
-    &.invalid {
-        background: #fce9e6;
-    }
-}
-
-.EditableListItem {
-    @extend .draggable;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    > div {
-        display: flex;
-        align-items: center;
-    }
-
-    i {
-        font-size: 1.2rem;
-        color: #666;
-    }
-
-    > div:first-child > * {
-        margin-right: 12px;
-    }
-}
-
-.ColorSchemeEditor {
-    padding-left: 0;
-    li {
-        display: flex;
-        align-items: center;
-
-        i {
-            font-size: 1.2rem;
-            color: #666;
-        }
-
-        > * {
-            margin-right: 8px;
-
-            &:last-child {
-                margin-right: 0;
-            }
-        }
-
-        .range {
-            display: flex;
-            flex: 1 0;
-            align-items: center;
-
-            span {
-                font-size: 0.85em;
-                margin: 0 3px;
-            }
-        }
-
-        .form-field {
-            flex: 1 1;
-            margin-bottom: 0;
-        }
-    }
-}
-
-.BinLabelView .FieldsRow {
-    margin-bottom: 0;
-}
-
-.EditorScatterTab,
-.EditorMarimekkoTab,
-.EditorDataTab {
-    .form-field__label {
-        margin-bottom: 0.3rem;
-    }
-}
-
 /* Reusable utility classes */
 
 .draggable {
@@ -544,79 +258,6 @@ button {
 .clickable {
     cursor: pointer;
     user-select: none;
-}
-
-.FieldsRow {
-    display: flex;
-    align-items: center;
-    margin: 0 0 1em;
-
-    > * {
-        padding-right: 1rem;
-        margin-bottom: 0 !important;
-        flex-grow: 1;
-        flex-basis: 0;
-    }
-}
-
-.WithResetButton {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-
-    .form-field {
-        margin-bottom: 0;
-        width: 100%;
-    }
-
-    .ResetToDefaultButton {
-        height: auto;
-        padding: 0;
-        font-size: 0.8em;
-        color: inherit;
-
-        &:disabled {
-            font-style: italic;
-        }
-
-        &:not(:disabled) {
-            text-decoration: underline;
-        }
-
-        &:hover {
-            text-decoration: none;
-        }
-    }
-}
-
-.ColorBox {
-    width: 2em;
-    height: 2em;
-    cursor: pointer;
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.colorpicker-tooltip {
-    .tippy-content {
-        padding: 0;
-    }
-}
-
-.LoadingBlocker {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 9999;
-    color: white;
-    align-items: center;
-    justify-content: center;
 }
 
 main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
@@ -1455,12 +1096,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     }
 }
 
-// Make the x/y dropdown in the comparison line editor narrow
-.comparisonLine .form-field:first-of-type {
-    flex-grow: 0;
-    flex-basis: 65px;
-}
-
 .multi-dim-preview {
     display: flex;
     align-items: center;
@@ -1552,22 +1187,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
 
 .table-preview-col--centered {
     text-align: center;
-}
-
-.dumbbell-trend-colors {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-
-    .dumbbell-trend-colors__invert {
-        margin-left: auto;
-    }
-
-    .dumbbell-trend-colors__invert-icon {
-        position: relative;
-        top: 1px;
-        margin-right: 6px;
-    }
 }
 
 .SvgTesterIndexPage__intro {

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -17,23 +17,17 @@
 // Layout:
 @import "bootstrap/scss/grid";
 @import "bootstrap/scss/tables";
-// Form controls. `Forms.tsx` is on antd now, but raw `form-group` /
-// `form-control` / `form-check` / `form-text` markup is still hand-written in
-// the editor tabs, ExplorerCreatePage, UsersIndexPage, GdocsAdd and others,
-// and `admin.scss` also `@extend`s `.form-control`:
+// Form controls. `Forms.tsx` is on antd now, and so is the chart editor, but
+// raw `form-control` / `form-check` / `form-group` markup is still hand-written
+// on the pages Phase 5 covers — ExplorerCreatePage, UsersIndexPage, GdocsAdd,
+// VariableEditPage, CalloutFunctionsPage — and `admin.scss` also `@extend`s
+// `.form-control`:
 @import "bootstrap/scss/forms";
-// still used by EditorReferencesTab (`input-group-prepend`/`input-group-text`):
-@import "bootstrap/scss/input-group";
-// Chrome and navigation. `nav` is still used by the `nav nav-tabs` chrome of
-// ChartEditorView, GrapherConfigGridEditor and DatasetEditPage:
-@import "bootstrap/scss/nav";
+// Chrome and navigation:
 @import "bootstrap/scss/breadcrumb";
 @import "bootstrap/scss/pagination";
 // Components:
 @import "bootstrap/scss/badge";
-// still used by EditorReferencesTab, EditorHistoryTab, EditorDataTab and
-// DimensionCard, which interleave `list-group-item`s with `EditableListItem`s:
-@import "bootstrap/scss/list-group";
 // Helpers:
 @import "bootstrap/scss/utilities";
 @import "bootstrap/scss/print";
@@ -45,8 +39,11 @@
 //   modal (`Forms.tsx`'s `Modal` is antd's; the `.modal-header`/`.modal-body`/
 //   `.modal-footer` markup its consumers pass in is styled in `Forms.scss`),
 //   navbar (the admin chrome is an antd `Layout` — see `AdminLayout.tsx`),
+//   nav (every tab strip is an antd `Tabs`),
 //   buttons + button-group (every button in the admin is an antd `Button`),
-//   alert (every alert in the admin is an antd `Alert`).
+//   alert (every alert in the admin is an antd `Alert`),
+//   input-group (antd `Space.Compact` / `Input`'s `addonBefore` instead),
+//   list-group (`.editable-list` in `Forms.scss` instead).
 
 // Our own copy of the parts of Bootstrap's reboot the admin depends on, so that
 // removing `bootstrap/scss/reboot` above stays a small, deliberate step rather
@@ -80,6 +77,7 @@
 @import "./SaveButtons.scss";
 @import "./ChartEditorView.scss";
 @import "./EditorDataTab.scss";
+@import "./EditorReferencesTab.scss";
 @import "./EditableTags.scss";
 @import "./AdminSidebar.scss";
 @import "./GdocsIndexPage.scss";
@@ -246,11 +244,6 @@ button {
     > .ant-tabs-content-holder {
         display: none;
     }
-}
-
-.list-group {
-    margin-top: 0;
-    margin-bottom: 0.5em;
 }
 
 .EditorBasicTab {
@@ -900,30 +893,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     }
 }
 
-.redirect-prefix {
-    color: #aaa;
-    font-size: 13px;
-    font-weight: 400;
-    text-decoration: none;
-}
-
-.add-redirect-form {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-
-    span,
-    button {
-        flex: 0;
-    }
-
-    input[type="text"] {
-        flex: 1;
-        font-weight: 700;
-        color: #007bff;
-    }
-}
-
 .TagEditPage {
     .form-check-label {
         &:has(input:disabled) {
@@ -1360,21 +1329,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
 
     img.border {
         border: 1px solid rgb(240, 240, 240) !important;
-    }
-}
-
-.EditorReferencesTab .ReferencesDataInsights {
-    li {
-        display: flex;
-        gap: 1em;
-
-        a {
-            flex-grow: 1;
-        }
-
-        button {
-            min-width: 144px;
-        }
     }
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -233,68 +233,18 @@ button {
     }
 }
 
-.ChartEditorPage {
-    display: flex;
-    flex-grow: 1;
+// The bulk editor's sidebar uses an antd `Tabs` as a tab bar only — its panes
+// are rendered as siblings, below, so that `.sidebar-content`'s flex sizing
+// still reaches them. Hide the empty content area antd renders anyway.
+.VariablesAnnotationPage__tabs {
+    padding: 0.5rem 0.5rem 0;
 
-    .form-group > label {
+    > .ant-tabs-nav {
         margin-bottom: 0;
     }
 
-    .nav-tabs :not(.active).nav-link {
-        background: #f9f9f9;
-    }
-
-    .nav-tabs .nav-link {
-        color: inherit;
-        padding-left: 0.75rem;
-        padding-right: 0.75rem;
-    }
-
-    > .chart-editor-settings {
-        min-width: 550px;
-        width: 550px;
-        min-height: 100%;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-    }
-
-    .innerForm {
-        overflow-y: scroll;
-        flex-grow: 1;
-    }
-
-    > .chart-editor-view {
-        display: flex;
-        flex-direction: column;
-        flex-grow: 1;
-        align-items: center;
-        justify-content: center;
-        position: relative;
-
-        a.preview {
-            position: absolute;
-            top: 8px;
-            right: 16px;
-        }
-    }
-
-    section {
-        padding: 1.2em;
-        border-radius: 0.4em;
-        margin-bottom: 1.2em;
-        background-color: #f9f9f9;
-
-        > h5 {
-            padding-bottom: 0.5rem;
-            border-bottom: 1px solid #ccc;
-        }
-    }
-
-    figure[data-grapher-src],
-    figure.grapher-component {
-        line-height: 0; // remove extra space on the bottom
+    > .ant-tabs-content-holder {
+        display: none;
     }
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -121,6 +121,7 @@ button {
 
     button,
     a,
+    .form-field__label,
     .form-group > label,
     .form-check > label {
         @extend .clickable;
@@ -505,7 +506,7 @@ button {
             }
         }
 
-        .form-group {
+        .form-field {
             flex: 1 1;
             margin-bottom: 0;
         }
@@ -519,7 +520,7 @@ button {
 .EditorScatterTab,
 .EditorMarimekkoTab,
 .EditorDataTab {
-    .form-group > label {
+    .form-field__label {
         margin-bottom: 0.3rem;
     }
 }
@@ -563,7 +564,7 @@ button {
     flex-direction: column;
     align-items: flex-start;
 
-    .form-group {
+    .form-field {
         margin-bottom: 0;
         width: 100%;
     }
@@ -1455,7 +1456,7 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
 }
 
 // Make the x/y dropdown in the comparison line editor narrow
-.comparisonLine .form-group:first-of-type {
+.comparisonLine .form-field:first-of-type {
     flex-grow: 0;
     flex-basis: 65px;
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

**Stacked on #7048** (← #7047 ← #7046 ← #7044). Phase 4 of the admin's Bootstrap→antd migration, and the riskiest one: the chart editor. The `nav nav-tabs` strips (chart editor, dataset page, bulk editor) are now antd `Tabs`, the editor tabs' raw Bootstrap form/list/input-group markup is gone, and the chart editor's styles moved out of `admin.scss` into per-component stylesheets (`admin.scss`: 1697 → 1221 lines). The `nav`, `input-group` and `list-group` Bootstrap modules are deleted.

Review focus — behavior, not looks:
- Tabs use `destroyOnHidden` to exactly match the old render-only-the-active-tab behavior; every field writes through to `grapherState`, so edits survive tab round-trips (verified: edited title survives switching away and back, live preview updates, "Update chart" enables, `?tab=` URL sync untouched since it's a MobX `reaction` on `editor.tab`).
- With 8–11 tabs in a 550px column, antd folds overflow into a "more" dropdown; `tabBarGutter={14}` keeps most in the bar. Tabs reached through the dropdown verified too.

<details><summary>Details</summary>

**Commits:** tab strips → antd Tabs (`70c9389667`); list-group/input-group markup (`433333a691`); raw form markup out of editor tabs (`ac7481929e`); scss extraction (`4b08f766a1`); tab bar gutter (`4740a0602b`).

**Tab chrome:** `ChartEditorView` moved labels and bodies into the `items` API (`renderTabLabel`/`renderTabContent` + `@action.bound onTabChange`); `DatasetEditPage` same; `GrapherConfigGridEditor` got the tab bar only — its panes stay direct children of `.sidebar-content` whose flex rules would break if wrapped (the empty content holder is hidden via css).

**Markup conversions:** `form-group`→`form-field`, `form-text`→`form-field__help` across EditorColorScaleSection/Customize/Text/Basic/Map tabs, VariableSelector, ChartEditorView; EditorReferencesTab's `input-group-prepend` → `Space.Compact` + `Input` (avoiding the deprecated `addonBefore`); `list-group` markup → the `editable-list` classes in References/History/Data tabs and DimensionCard; EditorDataTab's `form-check` radios → `Radio.Group`; EditorDebugTab's nine `textarea.form-control` → `Input.TextArea`.

**Dual-class emission (from #7046):** `list-group`/`list-group-item` dropped from Forms.tsx (nothing keys off them anymore). `form-group` still emitted — Phase 5 pages (GdocsSettingsForms, GdocsAdd, UsersIndexPage, TagEditPage, VariableEditPage, ExplorerCreatePage, CalloutFunctionsPage, DatasetEditPage) carry raw markup and scss that keys off it; commented in Forms.tsx/Forms.scss.

**SCSS extraction (standing rule):** new EditorBasicTab/DimensionCard/VariableSelector/EditorCustomizeTab/EditorColorScaleSection/EditorExportTab/EditorFAQ/EditorReferencesTab `.scss`; `.ChartEditorPage` → ChartEditorView.scss; Forms component blocks → Forms.scss; dead `.ColorableItem`/`.add-redirect-form` deleted. Verified a no-op by compiling admin.scss before/after (identical rule set minus the dead class) plus byte-identical screenshots of four tabs.

**Modules:** deleted `nav`, `input-group`, `list-group` (grep-verified zero references). Kept `forms` (Phase 5 pages + an `@extend .form-control`), `grid`, `tables`, `type`, `code`, `badge`, `breadcrumb`, `pagination`, `utilities`, `print`, `reboot` — annotations updated.

**Verification:** typecheck/lint/format clean; vitest 2336 passed (one unrelated flaky R2 e2e suite, green on rerun). Headless QA: all tabs cycled and screenshotted on a Map+Line chart, a scatter, a Marimekko, a narrative chart and an indicator editor; DatasetEditPage and bulk-editor tab strips clicked through; EditorFAQ modal. Console errors byte-identical to the pre-change baseline (stash + rerun of the same script). Behavior: debounced title→preview updates, trim-on-blur on subtitle, map tab `selectDisplayValue` fallbacks, and "Update chart" issuing the PUT with the edited payload (request aborted; DB untouched).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
