### PR TITLE
Admin: move the CRUD and index pages off Bootstrap

### DIFF
--- a/adminSiteClient/AdminTable.scss
+++ b/adminSiteClient/AdminTable.scss
@@ -32,3 +32,21 @@
 .admin-table tr.admin-table__row--danger > th {
     background-color: #f5c6cb;
 }
+
+// The thumbnail column that `ChartRow` and `DatasetEditPage`'s explorer /
+// multi-dim tables share. It is used from both an `.admin-table` and an antd
+// `<Table>` column's `className`, so it stays unscoped.
+.table-preview-col {
+    min-width: 140px;
+    width: 12.5%;
+}
+
+.table-preview-col--centered {
+    text-align: center;
+}
+
+.chartPreview {
+    width: 100%;
+    height: auto;
+    max-width: 140px;
+}

--- a/adminSiteClient/AdminTable.scss
+++ b/adminSiteClient/AdminTable.scss
@@ -1,0 +1,34 @@
+// The plain bordered table the admin's list views use, replacing Bootstrap's
+// `.table.table-bordered`. Index pages whose rows are ordinary records use an
+// antd `<Table>` instead; this class is for the lists whose rows are their own
+// MobX `@observer` components (`ChartList`, `DatasetList`, `VariableList`,
+// `ExplorersListPage`, `ExplorerTagsPage`), where antd's `columns`/`dataSource`
+// API would mean rewriting the row components for no gain.
+//
+// `border-collapse: collapse` comes from the reboot.
+
+.admin-table {
+    width: 100%;
+    margin-bottom: 1rem;
+    border: 1px solid #dee2e6;
+}
+
+.admin-table th,
+.admin-table td {
+    padding: 0.75rem;
+    vertical-align: top;
+    border: 1px solid #dee2e6;
+}
+
+.admin-table thead th,
+.admin-table thead td {
+    vertical-align: bottom;
+    border-bottom-width: 2px;
+}
+
+// Flags a row whose data no longer resolves — e.g. an explorer slug in
+// `ExplorerTagsPage` that matches no explorer in the database.
+.admin-table tr.admin-table__row--danger > td,
+.admin-table tr.admin-table__row--danger > th {
+    background-color: #f5c6cb;
+}

--- a/adminSiteClient/CalloutFunctionsPage.scss
+++ b/adminSiteClient/CalloutFunctionsPage.scss
@@ -1,0 +1,58 @@
+// The "Callout function strings" lookup page (`CalloutFunctionsPage.tsx`).
+
+.CalloutFunctionsPage {
+    padding: 24px;
+}
+
+.CalloutFunctionsPage__form {
+    margin-top: 16px;
+}
+
+.CalloutFunctionsPage__input-group {
+    display: flex;
+    gap: 8px;
+
+    input {
+        flex: 1;
+    }
+}
+
+.CalloutFunctionsPage__results {
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    padding: 16px;
+}
+
+.CalloutFunctionsPage__function-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.CalloutFunctionsPage__column-functions {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    padding: 8px 12px;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 4px;
+    margin-bottom: 8px;
+
+    ul {
+        width: 100%;
+        margin-top: 8px;
+
+        li {
+            margin-bottom: 4px;
+            list-style: none;
+        }
+    }
+
+    code {
+        flex: 1;
+        font-size: 14px;
+        color: #1f2937;
+    }
+}

--- a/adminSiteClient/CalloutFunctionsPage.tsx
+++ b/adminSiteClient/CalloutFunctionsPage.tsx
@@ -2,7 +2,7 @@ import { useContext, useState, useEffect, useCallback } from "react"
 import { useLocation, useHistory } from "react-router-dom"
 import { AdminAppContext } from "./AdminAppContext.js"
 import { AdminLayout } from "./AdminLayout.js"
-import { Alert, Button, Spin } from "antd"
+import { Alert, Button, Input, Spin } from "antd"
 
 type CalloutFunctionsResponse = {
     url: string
@@ -78,12 +78,11 @@ export const CalloutFunctionsPage = () => {
                     className="CalloutFunctionsPage__form"
                 >
                     <div className="CalloutFunctionsPage__input-group">
-                        <input
+                        <Input
                             type="text"
                             value={chartUrl}
                             onChange={(e) => setChartUrl(e.target.value)}
                             placeholder="https://ourworldindata.org/grapher/life-expectancy"
-                            className="form-control"
                         />
                         <Button
                             type="primary"

--- a/adminSiteClient/ChartList.scss
+++ b/adminSiteClient/ChartList.scss
@@ -1,0 +1,26 @@
+// The searchable chart list (`ChartList.tsx`) and its rows (`ChartRow.tsx`),
+// embedded on the chart index, dataset, indicator and tag pages. The table
+// itself is styled by `AdminTable.scss`.
+
+.ChartList {
+    .topRow {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 1em;
+
+        .form-field {
+            margin: 0;
+        }
+
+        input {
+            width: 500px;
+        }
+    }
+}
+
+.internalNotes {
+    font-size: 13px;
+    color: #666;
+    margin-top: 6px;
+}

--- a/adminSiteClient/ChartList.tsx
+++ b/adminSiteClient/ChartList.tsx
@@ -301,7 +301,7 @@ export class ChartList extends React.Component<ChartListProps> {
                         autofocus={this.props.autofocusSearchInput}
                     />
                 </div>
-                <table className="table table-bordered">
+                <table className="admin-table">
                     <thead>
                         <tr>
                             <th></th>

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -39,7 +39,15 @@ import {
     faMagnifyingGlass,
     faChartColumn,
 } from "@fortawesome/free-solid-svg-icons"
-import { Button, Divider, Space, Tabs, Typography } from "antd"
+import {
+    Button,
+    Divider,
+    Space,
+    Table,
+    TableColumnsType,
+    Tabs,
+    Typography,
+} from "antd"
 
 interface ExplorerListItem {
     slug: string
@@ -150,77 +158,92 @@ class ExplorerList extends Component<ExplorerListProps> {
             return <p>No explorers use variables from this dataset.</p>
         }
 
+        const columns: TableColumnsType<ExplorerListItem> = [
+            {
+                title: "Preview",
+                key: "preview",
+                className: "table-preview-col",
+                align: "center",
+                render: (_, explorer) =>
+                    explorer.isPublished ? (
+                        <a
+                            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${explorer.slug}`}
+                        >
+                            <img
+                                src={`${EXPLORER_DYNAMIC_THUMBNAIL_URL}/${explorer.slug}.png`}
+                                width={850}
+                                height={600}
+                                className="chartPreview"
+                            />
+                        </a>
+                    ) : null,
+            },
+            {
+                title: "Slug",
+                dataIndex: "slug",
+                sorter: (a, b) => a.slug.localeCompare(b.slug),
+                render: (slug: string) => (
+                    <Link native to={`/${EXPLORERS_ROUTE_FOLDER}/${slug}`}>
+                        {slug}
+                    </Link>
+                ),
+            },
+            {
+                title: "Title",
+                dataIndex: "title",
+                render: (title: string | null) => title || <em>No title</em>,
+            },
+            {
+                title: "Status",
+                key: "status",
+                render: (_, explorer) =>
+                    explorer.isPublished ? (
+                        <a
+                            href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${explorer.slug}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Published
+                        </a>
+                    ) : (
+                        <span className="text-secondary">Unpublished</span>
+                    ),
+            },
+            {
+                title: "Views per day",
+                dataIndex: "pageviewsPerDay",
+                sorter: (a, b) =>
+                    (a.pageviewsPerDay ?? 0) - (b.pageviewsPerDay ?? 0),
+                render: (pageviewsPerDay: number | undefined) =>
+                    pageviewsPerDay?.toLocaleString() ?? "0",
+            },
+            {
+                title: "Last updated",
+                key: "lastEditedAt",
+                sorter: (a, b) => a.lastEditedAt.localeCompare(b.lastEditedAt),
+                render: (_, explorer) => (
+                    <Timeago
+                        time={explorer.lastEditedAt}
+                        by={explorer.lastEditedByUserName}
+                    />
+                ),
+            },
+            {
+                title: "Created",
+                dataIndex: "createdAt",
+                sorter: (a, b) => a.createdAt.localeCompare(b.createdAt),
+                render: (createdAt: string) => <Timeago time={createdAt} />,
+            },
+        ]
+
         return (
-            <table className="table table-bordered">
-                <thead>
-                    <tr>
-                        <th className="table-preview-col">Preview</th>
-                        <th>Slug</th>
-                        <th>Title</th>
-                        <th>Status</th>
-                        <th>Views per day</th>
-                        <th>Last updated</th>
-                        <th>Created</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {explorers.map((explorer) => (
-                        <tr key={explorer.slug}>
-                            <td className="table-preview-col table-preview-col--centered">
-                                {explorer.isPublished ? (
-                                    <a
-                                        href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${explorer.slug}`}
-                                    >
-                                        <img
-                                            src={`${EXPLORER_DYNAMIC_THUMBNAIL_URL}/${explorer.slug}.png`}
-                                            width={850}
-                                            height={600}
-                                            className="chartPreview"
-                                        />
-                                    </a>
-                                ) : null}
-                            </td>
-                            <td>
-                                <Link
-                                    native
-                                    to={`/${EXPLORERS_ROUTE_FOLDER}/${explorer.slug}`}
-                                >
-                                    {explorer.slug}
-                                </Link>
-                            </td>
-                            <td>{explorer.title || <em>No title</em>}</td>
-                            <td>
-                                {explorer.isPublished ? (
-                                    <a
-                                        href={`${BAKED_BASE_URL}/${EXPLORERS_ROUTE_FOLDER}/${explorer.slug}`}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                    >
-                                        Published
-                                    </a>
-                                ) : (
-                                    <span className="text-secondary">
-                                        Unpublished
-                                    </span>
-                                )}
-                            </td>
-                            <td>
-                                {explorer.pageviewsPerDay?.toLocaleString() ??
-                                    "0"}
-                            </td>
-                            <td>
-                                <Timeago
-                                    time={explorer.lastEditedAt}
-                                    by={explorer.lastEditedByUserName}
-                                />
-                            </td>
-                            <td>
-                                <Timeago time={explorer.createdAt} />
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
+            <Table
+                size="small"
+                rowKey={(explorer) => explorer.slug}
+                dataSource={explorers}
+                pagination={false}
+                columns={columns}
+            />
         )
     }
 }
@@ -260,104 +283,108 @@ class MultiDimList extends Component<MultiDimListProps> {
             )
         }
 
+        const columns: TableColumnsType<MultiDimListItem> = [
+            {
+                title: "Preview",
+                key: "preview",
+                className: "table-preview-col",
+                align: "center",
+                render: (_, mdim) =>
+                    mdim.published && mdim.slug ? (
+                        <a href={`${BAKED_GRAPHER_URL}/${mdim.slug}`}>
+                            <img
+                                src={`${GRAPHER_DYNAMIC_THUMBNAIL_URL}/${mdim.slug}.png`}
+                                height={600}
+                                width={850}
+                                className="chartPreview"
+                            />
+                        </a>
+                    ) : null,
+            },
+            {
+                title: "Slug",
+                key: "slug",
+                sorter: (a, b) => (a.slug ?? "").localeCompare(b.slug ?? ""),
+                render: (_, mdim) => {
+                    if (!mdim.slug) return <em>No slug</em>
+                    const githubPath = getGitHubPathFromCatalogPath(
+                        mdim.catalogPath
+                    )
+                    if (!githubPath) return mdim.slug
+                    return (
+                        <a
+                            href={`https://github.com/owid/etl/tree/master/etl/steps/export/multidim/${githubPath}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            {mdim.slug}
+                        </a>
+                    )
+                },
+            },
+            {
+                title: "Title",
+                key: "title",
+                render: (_, mdim) =>
+                    mdim.title ? (
+                        <>
+                            {mdim.title}
+                            {mdim.titleVariant && <>, {mdim.titleVariant}</>}
+                        </>
+                    ) : (
+                        <em>No title</em>
+                    ),
+            },
+            {
+                title: "Status",
+                key: "status",
+                render: (_, mdim) => {
+                    if (!mdim.published)
+                        return (
+                            <span className="text-secondary">Unpublished</span>
+                        )
+                    if (!mdim.slug) return "Published"
+                    return (
+                        <a
+                            href={`${BAKED_GRAPHER_URL}/${mdim.slug}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                        >
+                            Published
+                        </a>
+                    )
+                },
+            },
+            {
+                title: "Grapher views/day",
+                dataIndex: "grapherViewsPerDay",
+                sorter: (a, b) =>
+                    (a.grapherViewsPerDay ?? 0) - (b.grapherViewsPerDay ?? 0),
+                render: (grapherViewsPerDay: number | undefined) =>
+                    grapherViewsPerDay?.toLocaleString() ?? "0",
+            },
+            {
+                title: "Last updated",
+                dataIndex: "updatedAt",
+                sorter: (a, b) => a.updatedAt.localeCompare(b.updatedAt),
+                render: (updatedAt: string) => <Timeago time={updatedAt} />,
+            },
+            {
+                title: "Created",
+                dataIndex: "createdAt",
+                sorter: (a, b) => a.createdAt.localeCompare(b.createdAt),
+                render: (createdAt: string) => <Timeago time={createdAt} />,
+            },
+        ]
+
         return (
-            <table className="table table-bordered">
-                <thead>
-                    <tr>
-                        <th className="table-preview-col">Preview</th>
-                        <th>Slug</th>
-                        <th>Title</th>
-                        <th>Status</th>
-                        <th>Grapher views/day</th>
-                        <th>Last updated</th>
-                        <th>Created</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {multiDims.map((mdim) => (
-                        <tr key={mdim.id}>
-                            <td className="table-preview-col table-preview-col--centered">
-                                {mdim.published && mdim.slug ? (
-                                    <a
-                                        href={`${BAKED_GRAPHER_URL}/${mdim.slug}`}
-                                    >
-                                        <img
-                                            src={`${GRAPHER_DYNAMIC_THUMBNAIL_URL}/${mdim.slug}.png`}
-                                            height={600}
-                                            width={850}
-                                            className="chartPreview"
-                                        />
-                                    </a>
-                                ) : null}
-                            </td>
-                            <td>
-                                {mdim.slug ? (
-                                    (() => {
-                                        const githubPath =
-                                            getGitHubPathFromCatalogPath(
-                                                mdim.catalogPath
-                                            )
-                                        return githubPath ? (
-                                            <a
-                                                href={`https://github.com/owid/etl/tree/master/etl/steps/export/multidim/${githubPath}`}
-                                                target="_blank"
-                                                rel="noopener noreferrer"
-                                            >
-                                                {mdim.slug}
-                                            </a>
-                                        ) : (
-                                            mdim.slug
-                                        )
-                                    })()
-                                ) : (
-                                    <em>No slug</em>
-                                )}
-                            </td>
-                            <td>
-                                {mdim.title ? (
-                                    <>
-                                        {mdim.title}
-                                        {mdim.titleVariant && (
-                                            <>, {mdim.titleVariant}</>
-                                        )}
-                                    </>
-                                ) : (
-                                    <em>No title</em>
-                                )}
-                            </td>
-                            <td>
-                                {mdim.published ? (
-                                    mdim.slug ? (
-                                        <a
-                                            href={`${BAKED_GRAPHER_URL}/${mdim.slug}`}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                        >
-                                            Published
-                                        </a>
-                                    ) : (
-                                        "Published"
-                                    )
-                                ) : (
-                                    <span className="text-secondary">
-                                        Unpublished
-                                    </span>
-                                )}
-                            </td>
-                            <td>
-                                {mdim.grapherViewsPerDay?.toLocaleString() ??
-                                    "0"}
-                            </td>
-                            <td>
-                                <Timeago time={mdim.updatedAt} />
-                            </td>
-                            <td>
-                                <Timeago time={mdim.createdAt} />
-                            </td>
-                        </tr>
-                    ))}
-                </tbody>
-            </table>
+            <Table
+                size="small"
+                rowKey={(mdim) => mdim.id}
+                dataSource={multiDims}
+                pagination={false}
+                columns={columns}
+            />
         )
     }
 }

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -382,8 +382,8 @@ class DatasetTagEditor extends Component<DatasetTagEditorProps> {
         const { newDataset, availableTags } = this.props
 
         return (
-            <div className="form-group">
-                <label>Tags</label>
+            <div className="form-field">
+                <label className="form-field__label">Tags</label>
                 <EditableTags
                     tags={newDataset.tags}
                     suggestions={availableTags}

--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -41,7 +41,9 @@ import {
 } from "@fortawesome/free-solid-svg-icons"
 import {
     Button,
+    Col,
     Divider,
+    Row,
     Space,
     Table,
     TableColumnsType,
@@ -627,8 +629,8 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                                 Metadata is non-editable and can be only changed
                                 in ETL.
                             </p>
-                            <div className="row">
-                                <div className="col">
+                            <Row gutter={30}>
+                                <Col flex="1 1 0">
                                     <BindString
                                         field="name"
                                         store={newDataset}
@@ -666,8 +668,8 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                                             disabled
                                         />
                                     </FieldsRow>
-                                </div>
-                                <div className="col">
+                                </Col>
+                                <Col flex="1 1 0">
                                     <BindString
                                         label="Number of days between OWID updates"
                                         field="updatePeriodDays"
@@ -683,8 +685,8 @@ class DatasetEditor extends Component<DatasetEditorProps> {
                                         textarea
                                         disabled
                                     />
-                                </div>
-                            </div>
+                                </Col>
+                            </Row>
                             <Button
                                 color="green"
                                 variant="solid"

--- a/adminSiteClient/DatasetList.tsx
+++ b/adminSiteClient/DatasetList.tsx
@@ -143,7 +143,7 @@ export class DatasetList extends React.Component<DatasetListProps> {
         const { props, availableTags } = this
         const tagGraphRolesById = getTagGraphRolesById(availableTags ?? [])
         return (
-            <table className="table table-bordered">
+            <table className="admin-table">
                 <thead>
                     <tr>
                         <th>Dataset</th>

--- a/adminSiteClient/ExplorerCreatePage.tsx
+++ b/adminSiteClient/ExplorerCreatePage.tsx
@@ -28,7 +28,7 @@ import {
 } from "./ExplorerCommands.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
 import { ENV } from "../settings/clientSettings.js"
-import { Button } from "antd"
+import { Button, Checkbox } from "antd"
 
 const RESERVED_NAMES = [DefaultNewExplorerSlug, "index", "new", "create"] // don't allow authors to save explorers with these names, otherwise might create some annoying situations.
 
@@ -287,18 +287,12 @@ export class ExplorerCreatePage extends Component<ExplorerCreatePageProps> {
             : "" // todo: provide an explanation of how many cells are modified.
 
         const showPreviewCheckbox = (
-            <div className="form-check">
-                <input
-                    type="checkbox"
-                    className="form-check-input"
-                    id="showPreview"
-                    checked={this.showPreview}
-                    onChange={() => this.onShowPreviewChanged()}
-                ></input>
-                <label className="form-check-label" htmlFor="showPreview">
-                    Show Preview
-                </label>
-            </div>
+            <Checkbox
+                checked={this.showPreview}
+                onChange={() => this.onShowPreviewChanged()}
+            >
+                Show Preview
+            </Checkbox>
         )
 
         return (

--- a/adminSiteClient/ExplorerTagsPage.tsx
+++ b/adminSiteClient/ExplorerTagsPage.tsx
@@ -16,7 +16,7 @@ import {
     MinimalTagWithMetadata,
 } from "./TagGraphMetadata.js"
 import cx from "clsx"
-import { Button } from "antd"
+import { Button, Select } from "antd"
 
 type ExplorerWithTags = {
     slug: string
@@ -72,7 +72,7 @@ export class ExplorerTagsPage extends Component {
                         new slug.
                     </p>
 
-                    <table className="table table-bordered">
+                    <table className="admin-table">
                         <thead>
                             <tr>
                                 <th style={{ width: "45%" }}>Explorer</th>
@@ -91,7 +91,8 @@ export class ExplorerTagsPage extends Component {
                                     <tr
                                         key={explorer.slug}
                                         className={cx({
-                                            "table-danger": !isSlugValid,
+                                            "admin-table__row--danger":
+                                                !isSlugValid,
                                         })}
                                     >
                                         <td>
@@ -142,27 +143,24 @@ export class ExplorerTagsPage extends Component {
                             {/* New Explorer Row */}
                             <tr>
                                 <td>
-                                    <select
-                                        value={this.newExplorerSlug}
-                                        onChange={(e) => {
-                                            this.newExplorerSlug =
-                                                e.target.value
+                                    <Select
+                                        style={{ width: "100%" }}
+                                        value={
+                                            this.newExplorerSlug || undefined
+                                        }
+                                        placeholder="Select an explorer"
+                                        onChange={action((slug: string) => {
+                                            this.newExplorerSlug = slug
+                                        })}
+                                        showSearch={{
+                                            optionFilterProp: "value",
                                         }}
-                                    >
-                                        <option value="">
-                                            Select an explorer
-                                        </option>
-                                        {this.filteredExplorers.map(
-                                            (explorer) => (
-                                                <option
-                                                    key={explorer.slug}
-                                                    value={explorer.slug}
-                                                >
-                                                    {explorer.slug}
-                                                </option>
-                                            )
+                                        options={this.filteredExplorers.map(
+                                            (explorer) => ({
+                                                value: explorer.slug,
+                                            })
                                         )}
-                                    </select>
+                                    />
                                 </td>
                                 <td>
                                     <EditableTags

--- a/adminSiteClient/ExplorersListPage.tsx
+++ b/adminSiteClient/ExplorersListPage.tsx
@@ -25,7 +25,7 @@ import {
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { AdminManager } from "./AdminManager.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
-import { Button, Checkbox } from "antd"
+import { Button, Checkbox, Tag } from "antd"
 
 interface ExplorerRowProps {
     explorer: ExplorerProgram
@@ -35,15 +35,15 @@ interface ExplorerRowProps {
 
 function explorerTypeBadge(mode: ExplorerChartCreationMode): {
     label: string
-    className: string
+    color?: string
 } {
     switch (mode) {
         case ExplorerChartCreationMode.FromVariableIds:
-            return { label: "Indicator", className: "badge badge-success" }
+            return { label: "Indicator", color: "success" }
         case ExplorerChartCreationMode.FromGrapherId:
-            return { label: "Grapher", className: "badge badge-secondary" }
+            return { label: "Grapher" }
         case ExplorerChartCreationMode.FromExplorerTableColumnSlugs:
-            return { label: "CSV", className: "badge badge-secondary" }
+            return { label: "CSV" }
     }
 }
 
@@ -107,10 +107,10 @@ class ExplorerRow extends Component<ExplorerRowProps> {
                 </td>
                 <td>
                     {(() => {
-                        const { label, className } = explorerTypeBadge(
+                        const { label, color } = explorerTypeBadge(
                             explorer.chartCreationMode
                         )
-                        return <span className={className}>{label}</span>
+                        return <Tag color={color}>{label}</Tag>
                     })()}
                 </td>
                 <td>

--- a/adminSiteClient/ExplorersListPage.tsx
+++ b/adminSiteClient/ExplorersListPage.tsx
@@ -25,7 +25,7 @@ import {
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { AdminManager } from "./AdminManager.js"
 import { AdminAppContext, AdminAppContextType } from "./AdminAppContext.js"
-import { Button } from "antd"
+import { Button, Checkbox } from "antd"
 
 interface ExplorerRowProps {
     explorer: ExplorerProgram
@@ -178,7 +178,7 @@ class ExplorerList extends Component<ExplorerListProps> {
             userSelect: "none" as const,
         }
         return (
-            <table className="table table-bordered">
+            <table className="admin-table">
                 <thead>
                     <tr>
                         <th>Slug</th>
@@ -307,21 +307,12 @@ export class ExplorersIndexPage extends Component<{
                         explorers
                     </div>
                     <div>
-                        <label
-                            style={{
-                                marginBottom: 0,
-                                cursor: "pointer",
-                                userSelect: "none",
-                            }}
+                        <Checkbox
+                            checked={this.showOnlyPublished}
+                            onChange={this.onToggleShowOnlyPublished}
                         >
-                            <input
-                                type="checkbox"
-                                checked={this.showOnlyPublished}
-                                onChange={this.onToggleShowOnlyPublished}
-                                style={{ marginRight: 6 }}
-                            />
                             Show only published
-                        </label>
+                        </Checkbox>
                     </div>
                     {/* <div style={{ textAlign: "right" }}>
                         <Button

--- a/adminSiteClient/Forms.scss
+++ b/adminSiteClient/Forms.scss
@@ -1,14 +1,13 @@
 // Styles for the shared admin form kit in `Forms.tsx`, which renders antd
 // primitives inside our own label / help-text / error chrome.
 //
-// The field wrapper still carries Bootstrap's `form-group` class next to
-// `form-field`, because raw `form-group` markup lives on in the pages Phase 5
-// of the antd migration covers (ExplorerCreatePage, UsersIndexPage, GdocsAdd,
-// the gdocs settings forms) and is interleaved with these components there.
 // The rules below cover the parts that used to come from Bootstrap's
 // form/input-group/list-group/modal markup that `Forms.tsx` no longer emits.
+// A few pages outside `Forms.tsx` hand-write `form-field` /
+// `form-field__label` / `form-field__help` around a control of their own; they
+// get the same chrome that way.
 
-// Replaces Bootstrap's `.form-group`, which the wrapper still carries as well.
+// Replaces Bootstrap's `.form-group`.
 .form-field {
     margin-bottom: 1rem;
 }

--- a/adminSiteClient/Forms.tsx
+++ b/adminSiteClient/Forms.tsx
@@ -51,14 +51,7 @@ export class FieldsRow extends React.Component<{ children: React.ReactNode }> {
     }
 }
 
-/**
- * The wrapper every field renders. It keeps Bootstrap's `form-group` class
- * alongside our own `form-field` one: the chart editor is off `form-group`
- * now, but raw `form-group` markup still exists on the pages Phase 5 of the
- * antd migration covers (ExplorerCreatePage, UsersIndexPage, GdocsAdd, the
- * gdocs settings forms), and `admin.scss` still keys layout off it there.
- * Dropping it belongs to the phase that migrates those pages.
- */
+/** The wrapper every field renders. See `Forms.scss` for its chrome. */
 function FormField(props: {
     className?: string
     innerRef?: React.Ref<HTMLDivElement>
@@ -71,10 +64,7 @@ function FormField(props: {
     children: React.ReactNode
 }): React.ReactElement {
     return (
-        <div
-            className={cx("form-field", "form-group", props.className)}
-            ref={props.innerRef}
-        >
+        <div className={cx("form-field", props.className)} ref={props.innerRef}>
             {props.label !== undefined && props.label !== "" && (
                 <label className="form-field__label">
                     {props.label}

--- a/adminSiteClient/GdocsAdd.scss
+++ b/adminSiteClient/GdocsAdd.scss
@@ -1,0 +1,28 @@
+// The "Add a document" modal (`GdocsAdd.tsx`). Validation is native HTML5
+// validation on the URL field's `pattern`, surfaced through the `:invalid`
+// sibling selector below rather than through any component state.
+
+.GdocsAddForm__instructions {
+    margin-left: 8px;
+    margin-bottom: 8px;
+}
+
+.GdocsAddForm__validation-notice {
+    display: none;
+}
+
+.GdocsAddForm input:invalid + .GdocsAddForm__validation-notice {
+    display: block;
+    margin-top: 4px;
+    color: red;
+    padding-left: 5px;
+
+    pre {
+        color: red;
+    }
+}
+
+// A blank input counts as invalid, but there is nothing to complain about yet.
+.GdocsAddForm input:placeholder-shown + .GdocsAddForm__validation-notice {
+    display: none;
+}

--- a/adminSiteClient/GdocsAdd.tsx
+++ b/adminSiteClient/GdocsAdd.tsx
@@ -7,7 +7,7 @@ import {
     GDOCS_ANNOUNCEMENT_DUPLICATION_TEMPLATE_ID,
 } from "../settings/clientSettings.js"
 import { useGdocsStore } from "./GdocsStoreContext.js"
-import { Button } from "antd"
+import { Button, Input } from "antd"
 
 export const GdocsAdd = ({ onAdd }: { onAdd: (id: string) => void }) => {
     const [documentUrl, setDocumentUrl] = React.useState("")
@@ -73,17 +73,16 @@ export const GdocsAdd = ({ onAdd }: { onAdd: (id: string) => void }) => {
                     </ul>
                     Paste the URL of your new document in the field below 👇
                 </div>
-                <div className="form-group">
-                    <input
+                <div className="form-field">
+                    <Input
                         type="text"
-                        className="form-control"
                         onChange={(e) => setDocumentUrl(e.target.value)}
                         value={documentUrl}
                         required
                         placeholder={GDOCS_URL_PLACEHOLDER}
                         pattern={gdocUrlRegex.source}
                     />
-                    <span className="validation-notice">
+                    <span className="GdocsAddForm__validation-notice">
                         Invalid URL - it should look like this:{" "}
                         <pre>{GDOCS_URL_PLACEHOLDER}</pre>
                     </span>

--- a/adminSiteClient/GdocsManualBreadcrumbsInput.tsx
+++ b/adminSiteClient/GdocsManualBreadcrumbsInput.tsx
@@ -94,7 +94,7 @@ export const GdocsManualBreadcrumbsInput = ({
     }
 
     return (
-        <div className="form-group">
+        <div className="form-field">
             <div className="d-flex justify-content-between">Breadcrumbs</div>
             {!!gdoc.breadcrumbs?.length && !gdoc.manualBreadcrumbs?.length ? (
                 <div>

--- a/adminSiteClient/GdocsSettingsContentField.scss
+++ b/adminSiteClient/GdocsSettingsContentField.scss
@@ -1,0 +1,13 @@
+// The featured-image preview `GdocsSettingsContentField.tsx` renders under the
+// `featured-image` field of the gdocs settings drawer.
+
+.GdocsSettingsContentField__imagePreview {
+    margin-top: 12px;
+}
+
+.GdocsSettingsContentField__imagePreviewImage {
+    display: block;
+    width: 100%;
+    border: 1px solid #d9d9d9;
+    border-radius: 4px;
+}

--- a/adminSiteClient/GdocsSettingsContentField.tsx
+++ b/adminSiteClient/GdocsSettingsContentField.tsx
@@ -54,8 +54,8 @@ export const GdocsSettingsContentField = ({
     const featuredImageSrc = getFeaturedImageSrc(gdoc, property, value)
 
     return (
-        <div className="form-group">
-            <label htmlFor={property}>
+        <div className="form-field">
+            <label className="form-field__label" htmlFor={property}>
                 <span className="text-capitalize">{property}</span>
             </label>
             <div className="edit-in-gdocs">

--- a/adminSiteClient/GdocsSettingsForms.scss
+++ b/adminSiteClient/GdocsSettingsForms.scss
@@ -1,0 +1,79 @@
+// Styles for the gdocs settings drawer (`GdocsSettingsForms.tsx`). The status
+// colours are shared with `GdocsEditPage.tsx`, which renders the same drawer.
+
+.GdocsEditPage,
+.GdocsSettingsForm {
+    .success {
+        color: #52c41a;
+    }
+
+    .warning {
+        color: #faad14;
+    }
+
+    .error {
+        color: #ff4d4f;
+    }
+
+    .muted {
+        color: rgba(0, 0, 0, 0.25);
+    }
+
+    h3.form-section-heading {
+        color: #757575;
+    }
+}
+
+// One titled block of settings. Replaces Bootstrap's `.form-group`, which this
+// markup used as a generic spacing wrapper rather than as a form field.
+.GdocsSettingsForm__section {
+    margin-bottom: 1rem;
+}
+
+.GdocsSettingsForm__section:not(:first-child) h3.form-section-heading {
+    margin-top: 32px;
+}
+
+// Replaces Bootstrap's `.form-text` on the notes under the entity picker.
+.GdocsSettingsForm__help {
+    display: block;
+    margin-top: 0.25rem;
+}
+
+.GdocsSettingsForm__preview-entity {
+    background: #f9f9f9;
+    padding: 10px;
+    border-radius: 5px;
+    margin-bottom: 20px;
+}
+
+.GdocsSettingsForm__alert {
+    margin-bottom: 8px;
+}
+
+.GdocsSettingsForm {
+    .edit-in-gdocs {
+        position: relative;
+
+        a {
+            background-color: rgb(24, 144, 255, 0.8);
+            position: absolute;
+            top: 0;
+            right: 0;
+            bottom: 0;
+            left: 0;
+            z-index: 10;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            text-decoration: none;
+            transition: all 0.2s;
+            opacity: 0;
+        }
+
+        &:hover a {
+            opacity: 1;
+        }
+    }
+}

--- a/adminSiteClient/GdocsSettingsForms.tsx
+++ b/adminSiteClient/GdocsSettingsForms.tsx
@@ -60,7 +60,7 @@ const GdocCommonSettings = <T extends OwidGdoc>({
     subdirectory?: string
 }) => {
     return (
-        <div className="form-group">
+        <div className="GdocsSettingsForm__section">
             <h3 className="form-section-heading">Common settings</h3>
             <GdocsSettingsContentField
                 property="title"
@@ -114,7 +114,7 @@ export const GdocPostSettings = ({
                 setCurrentGdoc={setCurrentGdoc}
                 errors={errors}
             />
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Post settings</h3>
                 <GdocsSettingsContentField
                     property="excerpt"
@@ -195,7 +195,7 @@ export const GdocInsightSettings = ({
                 errors={errors}
                 subdirectory="data-insights/"
             />
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Data insight settings</h3>
                 <GdocsPublicationContext
                     gdoc={gdoc}
@@ -247,7 +247,7 @@ export const GdocAnnouncementSettings = ({
                 gdoc={gdoc}
                 setCurrentGdoc={setCurrentGdoc}
             />
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Announcement settings</h3>
                 <GdocsSettingsContentField
                     property="kicker"
@@ -270,7 +270,7 @@ export const GdocHomepageSettings = ({
     return (
         <div className="GdocsSettingsForm">
             <GdocCommonErrors errors={errors} errorsToFilter={[]} />
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Homepage settings</h3>
                 <p>The homepage has no custom authors, slug, title, etc.</p>
                 <p>Just hit publish when you'd like to update the page!</p>
@@ -292,7 +292,7 @@ export const GdocAuthorSettings = ({
     return (
         <div className="GdocsSettingsForm">
             <GdocCommonErrors errors={errors} errorsToFilter={[]} />
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Common settings</h3>
                 <GdocsSettingsContentField
                     property="title"
@@ -306,7 +306,7 @@ export const GdocAuthorSettings = ({
                     subdirectory="team/"
                 />
             </div>
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Author settings</h3>
                 <GdocsSettingsContentField
                     property="role"
@@ -331,7 +331,7 @@ export const GdocAboutPageSettings = ({
     return (
         <div className="GdocsSettingsForm">
             <GdocCommonErrors errors={errors} errorsToFilter={[]} />
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Common settings</h3>
                 <GdocsSettingsContentField
                     property="title"
@@ -344,7 +344,7 @@ export const GdocAboutPageSettings = ({
                     errors={errors}
                 />
             </div>
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">About page settings</h3>
                 <GdocsSettingsContentField
                     property="hide-nav"
@@ -378,16 +378,8 @@ export const GdocProfileSettings = ({
 }) => {
     return (
         <form className="GdocsSettingsForm">
-            <div
-                className="form-group"
-                style={{
-                    background: "#f9f9f9",
-                    padding: "10px",
-                    borderRadius: "5px",
-                    marginBottom: "20px",
-                }}
-            >
-                <label>
+            <div className="GdocsSettingsForm__section GdocsSettingsForm__preview-entity">
+                <label className="form-field__label">
                     <strong>Preview entity</strong>
                 </label>
                 <Select
@@ -398,12 +390,12 @@ export const GdocProfileSettings = ({
                     onChange={setSelectedEntity}
                     options={entitiesInScope}
                 />
-                <p className="form-text text-muted">
+                <p className="GdocsSettingsForm__help text-muted">
                     Select which country to preview this profile template for.
                     This only affects the preview and does not change the
                     template itself.
                 </p>
-                <p className="form-text text-muted">
+                <p className="GdocsSettingsForm__help text-muted">
                     <a
                         href={`/admin/gdocs/${gdoc.id}/coverage?contentSource=gdocs`}
                         target="_blank"
@@ -423,7 +415,7 @@ export const GdocProfileSettings = ({
                 errors={errors}
                 subdirectory="profile/"
             />
-            <div className="form-group">
+            <div className="GdocsSettingsForm__section">
                 <h3 className="form-section-heading">Profile settings</h3>
                 <GdocsSettingsContentField
                     property="scope"

--- a/adminSiteClient/GrapherConfigGridEditor.scss
+++ b/adminSiteClient/GrapherConfigGridEditor.scss
@@ -1,0 +1,94 @@
+// The bulk grapher-config editor (`GrapherConfigGridEditor.tsx`): a Handsontable
+// grid with a sidebar of editing tabs, rendered by the "Bulk chart editor" page
+// under the `.VariablesAnnotationPage` class.
+
+.VariablesAnnotationPage {
+    display: flex;
+    flex-grow: 1;
+
+    > .sidebar {
+        min-width: 500px;
+        width: 500px;
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+
+        > .sidebar-content {
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            align-items: stretch;
+            overflow-y: auto;
+            height: 100%;
+
+            > .preview {
+                flex: 0 0 auto;
+                border-top: 1px solid lightgray;
+                padding-top: 5px;
+            }
+
+            > section {
+                flex: 1 0 200px;
+            }
+        }
+    }
+
+    > .editor-view {
+        width: 100%;
+    }
+
+    .column-list-item {
+        padding: 3px;
+        border: lightgray 1px solid;
+        border-radius: 4px;
+
+        button {
+            margin-right: 0.5rem;
+        }
+    }
+
+    .column-list-item + .column-list-item {
+        margin-top: 4px;
+    }
+
+    .column-section {
+        overflow-y: auto;
+    }
+
+    .queryBuilder {
+        margin: 8px 0;
+    }
+
+    .rich-editor-confirm-buttons {
+        margin-top: 0.5rem;
+
+        button {
+            margin-right: 0.5rem;
+        }
+    }
+}
+
+// The gutter each sidebar tab's contents sit in. Replaces Bootstrap's
+// `.container`, which only ever contributed its horizontal padding here — the
+// sidebar is far narrower than the smallest `.container` max-width.
+.VariablesAnnotationPage__panel {
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+}
+
+// The bulk editor's sidebar uses an antd `Tabs` as a tab bar only — its panes
+// are rendered as siblings, below, so that `.sidebar-content`'s flex sizing
+// still reaches them. Hide the empty content area antd renders anyway.
+.VariablesAnnotationPage__tabs {
+    padding: 0.5rem 0.5rem 0;
+
+    > .ant-tabs-nav {
+        margin-bottom: 0;
+    }
+
+    > .ant-tabs-content-holder {
+        display: none;
+    }
+}

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -104,7 +104,7 @@ import { EditorColorScaleSection } from "./EditorColorScaleSection.js"
 import { Operation } from "../adminShared/SqlFilterSExpression.js"
 import { CATALOG_URL, DATA_API_URL } from "../settings/clientSettings.js"
 import { SortableList } from "./SortableList.js"
-import { Button, Tabs as AntdTabs } from "antd"
+import { Button, Pagination, Tabs as AntdTabs } from "antd"
 
 type Disposer = () => void
 
@@ -1303,9 +1303,11 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
         const { editControl, hasUncommitedRichEditorChanges } = this
         return (
             <section>
-                <div className="container">{editControl}</div>
+                <div className="VariablesAnnotationPage__panel">
+                    {editControl}
+                </div>
                 {hasUncommitedRichEditorChanges ? (
-                    <div className="container rich-editor-confirm-buttons">
+                    <div className="VariablesAnnotationPage__panel rich-editor-confirm-buttons">
                         <Button
                             type="primary"
                             onClick={() => this.commitRichEditorChanges()}
@@ -1328,62 +1330,26 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
     }
 
     @action.bound
-    pageToPreviousPage(): void {
-        if (
-            (this.numTotalRows ?? 0) > PAGEING_SIZE &&
-            this.desiredPagingOffset >= PAGEING_SIZE
-        )
-            this.desiredPagingOffset -= PAGEING_SIZE
-    }
-
-    @action.bound
-    pageToNextPage(): void {
-        if (
-            (this.numTotalRows ?? 0) > PAGEING_SIZE &&
-            this.desiredPagingOffset + PAGEING_SIZE < (this.numTotalRows ?? 0)
-        ) {
-            this.desiredPagingOffset += PAGEING_SIZE
-        }
+    pageTo(page: number): void {
+        this.desiredPagingOffset = (page - 1) * PAGEING_SIZE
     }
 
     renderPagination(): React.ReactElement {
         const { numTotalRows, currentPagingOffset } = this
-        const currentStartLabel = currentPagingOffset + 1
-        const currentEndLabel = Math.min(
-            currentPagingOffset + PAGEING_SIZE,
-            numTotalRows ?? 0
-        )
 
         return (
             <nav aria-label="Indicator annotation pagination controls">
-                <ul className="pagination">
-                    <li className="page-item">
-                        <a
-                            className="page-link"
-                            href="#"
-                            aria-label="Previous"
-                            onClick={this.pageToPreviousPage}
-                        >
-                            <span aria-hidden="true">&laquo;</span>
-                        </a>
-                    </li>
-                    <li className="page-item">
-                        <a className="page-link">
-                            {currentStartLabel} to {currentEndLabel} of{" "}
-                            {numTotalRows}
-                        </a>
-                    </li>
-                    <li className="page-item">
-                        <a
-                            className="page-link"
-                            href="#"
-                            aria-label="Next"
-                            onClick={this.pageToNextPage}
-                        >
-                            <span aria-hidden="true">&raquo;</span>
-                        </a>
-                    </li>
-                </ul>
+                <Pagination
+                    simple
+                    current={Math.floor(currentPagingOffset / PAGEING_SIZE) + 1}
+                    pageSize={PAGEING_SIZE}
+                    total={numTotalRows ?? 0}
+                    onChange={this.pageTo}
+                    showSizeChanger={false}
+                    showTotal={(total, [from, to]) =>
+                        `${from} to ${to} of ${total}`
+                    }
+                />
             </nav>
         )
     }
@@ -1392,7 +1358,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
         const { filterPanelFields, filterState } = this
         return (
             <section>
-                <div className="container">
+                <div className="VariablesAnnotationPage__panel">
                     <h3>Row filters</h3>
                     {this.renderPagination()}
                     <label>Query builder</label>
@@ -1542,7 +1508,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
 
         return (
             <section className="column-section">
-                <div className="container">
+                <div className="VariablesAnnotationPage__panel">
                     <h3>Columns</h3>
                     <SelectField
                         label="Column set"

--- a/adminSiteClient/GrapherConfigGridEditor.tsx
+++ b/adminSiteClient/GrapherConfigGridEditor.tsx
@@ -1411,7 +1411,7 @@ export class GrapherConfigGridEditor extends React.Component<GrapherConfigGridEd
                             />
                         </QueryBuilderAntD>
                     )}
-                    <small className="form-text text-muted">
+                    <small className="form-field__help text-muted">
                         Note that default values like empty string, "LineChart"
                         for type or the default checkbox state are often stored
                         as null. To find these you have to use the "is null"

--- a/adminSiteClient/RedirectsIndexPage.tsx
+++ b/adminSiteClient/RedirectsIndexPage.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useContext, useEffect, useState } from "react"
+import { useCallback, useContext, useEffect, useMemo, useState } from "react"
 import { AdminLayout } from "./AdminLayout.js"
 import { FieldsRow } from "./Forms.js"
 import { Link } from "./Link.js"
 import { AdminAppContext } from "./AdminAppContext.js"
-import { Button } from "antd"
+import { Button, Table, TableColumnsType } from "antd"
 
 interface RedirectListItem {
     id: number
@@ -11,36 +11,6 @@ interface RedirectListItem {
     chartId: number
     chartSlug: string
     targetQueryParam: string | null
-}
-
-interface RedirectRowProps {
-    redirect: RedirectListItem
-    onDelete: (redirect: RedirectListItem) => void
-}
-
-function RedirectRow({ redirect, onDelete }: RedirectRowProps) {
-    return (
-        <tr>
-            <td>{redirect.slug}</td>
-            <td>
-                <Link to={`/charts/${redirect.chartId}/edit`}>
-                    {redirect.chartSlug}
-                    {redirect.targetQueryParam
-                        ? `?${redirect.targetQueryParam}`
-                        : ""}
-                </Link>
-            </td>
-            <td>
-                <Button
-                    color="danger"
-                    variant="solid"
-                    onClick={() => onDelete(redirect)}
-                >
-                    Delete
-                </Button>
-            </td>
-        </tr>
-    )
 }
 
 export function RedirectsIndexPage() {
@@ -79,6 +49,42 @@ export function RedirectsIndexPage() {
         void getData()
     }, [admin])
 
+    const columns: TableColumnsType<RedirectListItem> = useMemo(
+        () => [
+            {
+                title: "Slug",
+                dataIndex: "slug",
+                sorter: (a, b) => a.slug.localeCompare(b.slug),
+            },
+            {
+                title: "Redirects To",
+                key: "target",
+                render: (_, redirect) => (
+                    <Link to={`/charts/${redirect.chartId}/edit`}>
+                        {redirect.chartSlug}
+                        {redirect.targetQueryParam
+                            ? `?${redirect.targetQueryParam}`
+                            : ""}
+                    </Link>
+                ),
+            },
+            {
+                title: "",
+                key: "delete",
+                render: (_, redirect) => (
+                    <Button
+                        color="danger"
+                        variant="solid"
+                        onClick={() => onDelete(redirect)}
+                    >
+                        Delete
+                    </Button>
+                ),
+            },
+        ],
+        [onDelete]
+    )
+
     return (
         <AdminLayout title="Chart Redirects">
             <main className="RedirectsIndexPage">
@@ -89,22 +95,13 @@ export function RedirectsIndexPage() {
                     Redirects are automatically created when the slug of a
                     published chart is changed.
                 </p>
-                <table className="table table-bordered">
-                    <tbody>
-                        <tr>
-                            <th>Slug</th>
-                            <th>Redirects To</th>
-                            <th></th>
-                        </tr>
-                        {redirects.map((redirect) => (
-                            <RedirectRow
-                                key={redirect.id}
-                                redirect={redirect}
-                                onDelete={onDelete}
-                            />
-                        ))}
-                    </tbody>
-                </table>
+                <Table
+                    size="small"
+                    rowKey={(redirect) => redirect.id}
+                    dataSource={redirects}
+                    pagination={false}
+                    columns={columns}
+                />
             </main>
         </AdminLayout>
     )

--- a/adminSiteClient/SourceList.tsx
+++ b/adminSiteClient/SourceList.tsx
@@ -1,5 +1,5 @@
 import { OwidSource } from "@ourworldindata/utils"
-import { Alert } from "antd"
+import { Alert, Col, Row } from "antd"
 import { BindString } from "./Forms.js"
 
 const MAX_SOURCES = 10
@@ -20,8 +20,8 @@ export function SourceList({ sources }: { sources: OwidSource[] }) {
             )}
             {limitedSources.map((source, index) => (
                 <div key={index}>
-                    <div className="row">
-                        <div className="col">
+                    <Row gutter={30}>
+                        <Col flex="1 1 0">
                             <BindString
                                 field="name"
                                 store={source}
@@ -62,9 +62,9 @@ export function SourceList({ sources }: { sources: OwidSource[] }) {
                                 disabled
                                 // helpText="Date when this data was obtained by us. Date format should always be YYYY-MM-DD."
                             />
-                        </div>
+                        </Col>
 
-                        <div className="col">
+                        <Col flex="1 1 0">
                             <BindString
                                 field="additionalInfo"
                                 store={source}
@@ -75,8 +75,8 @@ export function SourceList({ sources }: { sources: OwidSource[] }) {
                                 // helpText="Describe the dataset and the methodology used in its construction. This can be as long and detailed as you like."
                                 rows={15}
                             />
-                        </div>
-                    </div>
+                        </Col>
+                    </Row>
                     <hr />
                 </div>
             ))}

--- a/adminSiteClient/TagEditPage.tsx
+++ b/adminSiteClient/TagEditPage.tsx
@@ -156,8 +156,8 @@ class TagEditor extends Component<{
                             label="Name"
                             helpText="Tag names must be unique and should be able to be understood without context"
                         />
-                        <div className="form-group">
-                            <label>Slug</label>
+                        <div className="form-field">
+                            <label className="form-field__label">Slug</label>
                             <AutoComplete
                                 style={{ width: "100%" }}
                                 value={newtag.slug ?? ""}
@@ -184,7 +184,7 @@ class TagEditor extends Component<{
                                 }}
                                 allowClear
                             />
-                            <small className="form-text text-muted">
+                            <small className="form-field__help text-muted">
                                 The slug for this tag's topic page, e.g.
                                 trade-and-globalization.
                             </small>

--- a/adminSiteClient/UsersIndexPage.tsx
+++ b/adminSiteClient/UsersIndexPage.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { observer } from "mobx-react"
-import { observable, action, runInAction, makeObservable } from "mobx"
+import { observable, action, computed, runInAction, makeObservable } from "mobx"
 
-import { Alert, Button, Input } from "antd"
+import { Alert, Button, Input, Table, TableColumnsType } from "antd"
 import { Modal, Timeago } from "./Forms.js"
 import { LinkButton } from "./Link.js"
 import { AdminLayout } from "./AdminLayout.js"
@@ -11,6 +11,10 @@ import { UserIndexMeta } from "./UserMeta.js"
 
 interface UserIndexMetaWithLastSeen extends UserIndexMeta {
     lastSeen: Date
+}
+
+function compareTimes(a: Date | undefined, b: Date | undefined): number {
+    return new Date(a ?? 0).getTime() - new Date(b ?? 0).getTime()
 }
 
 @observer
@@ -140,6 +144,64 @@ export class UsersIndexPage extends React.Component {
         }
     }
 
+    @computed get columns(): TableColumnsType<UserIndexMetaWithLastSeen> {
+        const { isSuperuser } = this.context.admin
+        const columns: TableColumnsType<UserIndexMetaWithLastSeen> = [
+            {
+                title: "Name",
+                dataIndex: "fullName",
+                sorter: (a, b) => a.fullName.localeCompare(b.fullName),
+            },
+            {
+                title: "Last Seen",
+                dataIndex: "lastSeen",
+                sorter: (a, b) => compareTimes(a.lastSeen, b.lastSeen),
+                render: (lastSeen: Date) => <Timeago time={lastSeen} />,
+            },
+            {
+                title: "Joined",
+                dataIndex: "createdAt",
+                sorter: (a, b) => compareTimes(a.createdAt, b.createdAt),
+                render: (createdAt: Date) => <Timeago time={createdAt} />,
+            },
+        ]
+
+        if (isSuperuser) {
+            columns.push(
+                {
+                    title: "Status",
+                    dataIndex: "isActive",
+                    render: (isActive: boolean) =>
+                        isActive ? "active" : "disabled",
+                },
+                {
+                    title: "",
+                    key: "edit",
+                    render: (_, user) => (
+                        <LinkButton type="primary" to={`/users/${user.id}`}>
+                            Edit
+                        </LinkButton>
+                    ),
+                },
+                {
+                    title: "",
+                    key: "delete",
+                    render: (_, user) => (
+                        <Button
+                            color="danger"
+                            variant="solid"
+                            onClick={() => this.onDelete(user)}
+                        >
+                            Delete
+                        </Button>
+                    ),
+                }
+            )
+        }
+
+        return columns
+    }
+
     override render() {
         const { users } = this
         const { isSuperuser } = this.context.admin
@@ -164,59 +226,13 @@ export class UsersIndexPage extends React.Component {
                             </Button>
                         )}
                     </div>
-                    <table className="table table-bordered">
-                        <tbody>
-                            <tr>
-                                <th>Name</th>
-                                <th>Last Seen</th>
-                                <th>Joined</th>
-                                {isSuperuser && <th>Status</th>}
-                                {isSuperuser && <th></th>}
-                                {isSuperuser && <th></th>}
-                            </tr>
-                            {users.map((user) => (
-                                <tr key={user.id}>
-                                    <td>{user.fullName}</td>
-                                    <td>
-                                        <Timeago time={user.lastSeen} />
-                                    </td>
-                                    <td>
-                                        <Timeago time={user.createdAt} />
-                                    </td>
-                                    {isSuperuser && (
-                                        <td>
-                                            {user.isActive
-                                                ? "active"
-                                                : "disabled"}
-                                        </td>
-                                    )}
-                                    {isSuperuser && (
-                                        <td>
-                                            <LinkButton
-                                                type="primary"
-                                                to={`/users/${user.id}`}
-                                            >
-                                                Edit
-                                            </LinkButton>
-                                        </td>
-                                    )}
-                                    {isSuperuser && (
-                                        <td>
-                                            <Button
-                                                color="danger"
-                                                variant="solid"
-                                                onClick={() =>
-                                                    this.onDelete(user)
-                                                }
-                                            >
-                                                Delete
-                                            </Button>
-                                        </td>
-                                    )}
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
+                    <Table
+                        size="small"
+                        rowKey={(user) => user.id}
+                        dataSource={users}
+                        pagination={false}
+                        columns={this.columns}
+                    />
                 </main>
             </AdminLayout>
         )

--- a/adminSiteClient/UsersIndexPage.tsx
+++ b/adminSiteClient/UsersIndexPage.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { observer } from "mobx-react"
 import { observable, action, runInAction, makeObservable } from "mobx"
 
-import { Alert, Button } from "antd"
+import { Alert, Button, Input } from "antd"
 import { Modal, Timeago } from "./Forms.js"
 import { LinkButton } from "./Link.js"
 import { AdminLayout } from "./AdminLayout.js"
@@ -60,25 +60,29 @@ class InviteModal extends React.Component<{ onClose: () => void }> {
                         <h5 className="modal-title">Add a user</h5>
                     </div>
                     <div className="modal-body">
-                        <div className="form-group">
-                            <label>Full name</label>
-                            <input
+                        <div className="form-field">
+                            <label className="form-field__label">
+                                Full name
+                            </label>
+                            <Input
                                 type="text"
-                                className="form-control"
-                                onChange={(e) =>
-                                    (this.fullName = e.currentTarget.value)
-                                }
+                                value={this.fullName}
+                                onChange={action(
+                                    (e: React.ChangeEvent<HTMLInputElement>) =>
+                                        (this.fullName = e.currentTarget.value)
+                                )}
                                 required
                             />
                         </div>
-                        <div className="form-group">
-                            <label>Email</label>
-                            <input
+                        <div className="form-field">
+                            <label className="form-field__label">Email</label>
+                            <Input
                                 type="email"
-                                className="form-control"
-                                onChange={(e) =>
-                                    (this.email = e.currentTarget.value)
-                                }
+                                value={this.email}
+                                onChange={action(
+                                    (e: React.ChangeEvent<HTMLInputElement>) =>
+                                        (this.email = e.currentTarget.value)
+                                )}
                                 required
                             />
                         </div>

--- a/adminSiteClient/VariableEditPage.scss
+++ b/adminSiteClient/VariableEditPage.scss
@@ -1,0 +1,18 @@
+// The read-only indicator metadata page (`VariableEditPage.tsx`).
+
+.VariableEditPage {
+    figure {
+        width: 100%;
+        height: 500px;
+    }
+
+    .partial-grapher-configs .FieldsRow {
+        align-items: flex-start;
+    }
+}
+
+// antd's `Breadcrumb` carries no bottom margin of its own, unlike the
+// Bootstrap breadcrumb it replaces.
+.VariableEditPage__breadcrumb {
+    margin-bottom: 1rem;
+}

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -12,7 +12,12 @@ import YAML from "yaml"
 import * as _ from "lodash-es"
 import { AdminLayout } from "./AdminLayout.js"
 import { Link, LinkButton } from "./Link.js"
-import { FieldsRow, TextAreaField, CatalogPathField } from "./Forms.js"
+import {
+    FieldsRow,
+    TextAreaField,
+    TextField,
+    CatalogPathField,
+} from "./Forms.js"
 import {
     OwidVariableWithDataAndSource,
     DimensionProperty,
@@ -71,17 +76,7 @@ function ReadOnlyField({
             />
         )
     }
-    return (
-        <div className="form-group">
-            <label>{label}</label>
-            <input
-                type="text"
-                className="form-control"
-                value={displayValue}
-                disabled
-            />
-        </div>
-    )
+    return <TextField label={label} value={displayValue} disabled />
 }
 
 // XXX refactor with DatasetEditPage

--- a/adminSiteClient/VariableEditPage.tsx
+++ b/adminSiteClient/VariableEditPage.tsx
@@ -41,6 +41,7 @@ import {
 import { faCircleInfo } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { CATALOG_URL, DATA_API_URL } from "../settings/clientSettings.js"
+import { Breadcrumb, Col, Row } from "antd"
 
 interface VariablePageData extends Omit<
     OwidVariableWithDataAndSource,
@@ -116,19 +117,22 @@ class VariableEditor extends Component<{
 
         return (
             <main className="VariableEditPage">
-                <ol className="breadcrumb">
-                    <li className="breadcrumb-item">
-                        {variable.datasetNamespace}
-                    </li>
-                    <li className="breadcrumb-item">
-                        <Link to={`/datasets/${variable.datasetId}`}>
-                            {variable.datasetName}
-                        </Link>
-                    </li>
-                    <li className="breadcrumb-item active">{variable.name}</li>
-                </ol>
-                <div className="row">
-                    <div className="col">
+                <Breadcrumb
+                    className="VariableEditPage__breadcrumb"
+                    items={[
+                        { title: variable.datasetNamespace },
+                        {
+                            title: (
+                                <Link to={`/datasets/${variable.datasetId}`}>
+                                    {variable.datasetName}
+                                </Link>
+                            ),
+                        },
+                        { title: variable.name },
+                    ]}
+                />
+                <Row gutter={30}>
+                    <Col flex="1 1 0">
                         <section>
                             <h3>Indicator metadata</h3>
                             {isV2MetadataVariable && (
@@ -238,9 +242,9 @@ class VariableEditor extends Component<{
                                 />
                             </FieldsRow>
                         </section>
-                    </div>
+                    </Col>
                     {this.grapherState && (
-                        <div className="col">
+                        <Col flex="1 1 0">
                             <div className="topbar">
                                 <h3>Preview</h3>
                                 <LinkButton
@@ -250,11 +254,11 @@ class VariableEditor extends Component<{
                                 </LinkButton>
                             </div>
                             <Grapher grapherState={this.grapherState} />
-                        </div>
+                        </Col>
                     )}
-                </div>
-                <div className="row">
-                    <div className="col">
+                </Row>
+                <Row gutter={30}>
+                    <Col flex="1 1 0">
                         <section>
                             <h4>
                                 Data Page&nbsp;
@@ -313,7 +317,7 @@ class VariableEditor extends Component<{
                                 />
                             </FieldsRow>
                             <FieldsRow>
-                                <div className="col">
+                                <div>
                                     <ReadOnlyField
                                         label="Processing Level"
                                         value={variable.processingLevel}
@@ -352,11 +356,11 @@ class VariableEditor extends Component<{
                                 />
                             </FieldsRow>
                         </section>
-                    </div>
-                </div>
+                    </Col>
+                </Row>
                 <hr></hr>
-                <div className="row">
-                    <div className="col">
+                <Row gutter={30}>
+                    <Col flex="1 1 0">
                         <section>
                             <h3>
                                 Origins&nbsp;
@@ -369,8 +373,8 @@ class VariableEditor extends Component<{
                             </h3>
                             <OriginList origins={variable.origins || []} />
                         </section>
-                    </div>
-                </div>
+                    </Col>
+                </Row>
                 {variable.source && (
                     <section>
                         <h3>Source</h3>

--- a/adminSiteClient/VariableList.tsx
+++ b/adminSiteClient/VariableList.tsx
@@ -304,7 +304,7 @@ export class VariableList extends React.Component<VariableListProps> {
     override render() {
         const { props } = this
         return (
-            <table className="table table-bordered">
+            <table className="admin-table">
                 <thead>
                     <tr>
                         <th>Name</th>

--- a/adminSiteClient/VariableSelector.scss
+++ b/adminSiteClient/VariableSelector.scss
@@ -60,7 +60,12 @@
         margin-right: 5px;
     }
 
-    .badge {
+    // The "Archived" chip next to an archived indicator's name. It used to lean
+    // on Bootstrap's `.badge` for its box model; those two declarations are
+    // inlined here now.
+    .VariableSelector__badge {
+        display: inline-block;
+        white-space: nowrap;
         background-color: #999;
         border-radius: 2px;
         text-transform: uppercase;

--- a/adminSiteClient/VariableSelector.tsx
+++ b/adminSiteClient/VariableSelector.tsx
@@ -201,7 +201,9 @@ export class VariableSelector<
                 )}
                 {description ? `${description} — ` : null}
                 {name}
-                {isArchived && <span className="badge">Archived</span>}
+                {isArchived && (
+                    <span className="VariableSelector__badge">Archived</span>
+                )}
             </span>
         )
     }

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -14,20 +14,6 @@
 @import "bootstrap/scss/reboot";
 @import "bootstrap/scss/type";
 @import "bootstrap/scss/code";
-// Layout:
-@import "bootstrap/scss/grid";
-@import "bootstrap/scss/tables";
-// Form controls. `Forms.tsx` is on antd now, and so is the chart editor, but
-// raw `form-control` / `form-check` / `form-group` markup is still hand-written
-// on the pages Phase 5 covers — ExplorerCreatePage, UsersIndexPage, GdocsAdd,
-// VariableEditPage, CalloutFunctionsPage — and `admin.scss` also `@extend`s
-// `.form-control`:
-@import "bootstrap/scss/forms";
-// Chrome and navigation:
-@import "bootstrap/scss/breadcrumb";
-@import "bootstrap/scss/pagination";
-// Components:
-@import "bootstrap/scss/badge";
 // Helpers:
 @import "bootstrap/scss/utilities";
 @import "bootstrap/scss/print";
@@ -43,7 +29,14 @@
 //   buttons + button-group (every button in the admin is an antd `Button`),
 //   alert (every alert in the admin is an antd `Alert`),
 //   input-group (antd `Space.Compact` / `Input`'s `addonBefore` instead),
-//   list-group (`.editable-list` in `Forms.scss` instead).
+//   list-group (`.editable-list` in `Forms.scss` instead),
+//   forms (`Forms.tsx` and the pages around it are on antd primitives; the
+//   field chrome is `.form-field*` in `Forms.scss`),
+//   tables (index views are either an antd `Table` or `.admin-table`, see
+//   `AdminTable.scss`),
+//   grid (antd `Row`/`Col`, or a flex rule in the component's own stylesheet),
+//   badge (antd `Tag`), breadcrumb (antd `Breadcrumb`),
+//   pagination (antd `Pagination`).
 
 // Our own copy of the parts of Bootstrap's reboot the admin depends on, so that
 // removing `bootstrap/scss/reboot` above stays a small, deliberate step rather

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -87,6 +87,7 @@
 @import "./EditorFAQ.scss";
 @import "./EditableTags.scss";
 @import "./AdminSidebar.scss";
+@import "./AdminTable.scss";
 @import "./CalloutFunctionsPage.scss";
 @import "./GdocsAdd.scss";
 @import "./GdocsSettingsForms.scss";

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -81,6 +81,7 @@
 @import "./EditableTags.scss";
 @import "./AdminSidebar.scss";
 @import "./AdminTable.scss";
+@import "./ChartList.scss";
 @import "./CalloutFunctionsPage.scss";
 @import "./GdocsAdd.scss";
 @import "./GdocsSettingsForms.scss";
@@ -180,35 +181,6 @@ button {
 
 main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     padding: 2em;
-}
-
-.chartPreview {
-    width: 100%;
-    height: auto;
-    max-width: 140px;
-}
-
-.internalNotes {
-    font-size: 13px;
-    color: #666;
-    margin-top: 6px;
-}
-
-.ChartList {
-    .topRow {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        margin-bottom: 1em;
-
-        .form-field {
-            margin: 0;
-        }
-
-        input {
-            width: 500px;
-        }
-    }
 }
 
 .EditableTextarea__actions {
@@ -809,15 +781,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
 
 .ImageReplaceConfirmModal__strong-text {
     font-weight: bold;
-}
-
-.table-preview-col {
-    min-width: 140px;
-    width: 12.5%;
-}
-
-.table-preview-col--centered {
-    text-align: center;
 }
 
 .SvgTesterIndexPage__intro {

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -87,6 +87,10 @@
 @import "./EditorFAQ.scss";
 @import "./EditableTags.scss";
 @import "./AdminSidebar.scss";
+@import "./CalloutFunctionsPage.scss";
+@import "./GdocsAdd.scss";
+@import "./GdocsSettingsForms.scss";
+@import "./GdocsSettingsContentField.scss";
 @import "./GdocsIndexPage.scss";
 @import "./FeaturedMetricsPage.scss";
 @import "./FilesIndexPage.scss";
@@ -128,9 +132,7 @@ button {
 
     button,
     a,
-    .form-field__label,
-    .form-group > label,
-    .form-check > label {
+    .form-field__label {
         @extend .clickable;
     }
 
@@ -283,90 +285,13 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
         justify-content: space-between;
         margin-bottom: 1em;
 
-        .form-group {
+        .form-field {
             margin: 0;
         }
 
         input {
             width: 500px;
         }
-    }
-}
-
-.ImportPage {
-    .Importer {
-        max-width: 1000px;
-
-        input:not([type="submit"]),
-        select,
-        textarea,
-        button {
-            @extend .form-control;
-        }
-
-        label {
-            display: block;
-        }
-
-        textarea {
-            resize: none;
-        }
-
-        .updateWarning {
-            margin-top: 20px;
-            margin-bottom: 0;
-            text-align: center;
-            font-size: 1.2em;
-            font-weight: bold;
-        }
-
-        select.chooseDataset {
-            margin-bottom: 20px;
-            font-size: 1.2em;
-            max-width: 800px;
-            margin-left: auto;
-            margin-right: auto;
-        }
-    }
-
-    .ValidationView {
-        margin-top: 20px;
-    }
-
-    .EditVariable {
-        .variableProps > label {
-            margin-right: 10px;
-            line-height: normal;
-        }
-
-        .name,
-        .description {
-            width: 100%;
-        }
-    }
-
-    .importProgress {
-        background: white;
-        border: 1px solid #ccc;
-        border-radius: 4px;
-        padding: 20px;
-
-        .success {
-            color: #00a65a;
-        }
-
-        .error {
-            color: #dd4b39;
-        }
-
-        .progressInner {
-            overflow: auto;
-            margin: 10px;
-        }
-    }
-
-    section:not(:first-child) {
-        margin-top: 0;
     }
 }
 
@@ -535,14 +460,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     }
 }
 
-.TagEditPage {
-    .form-check-label {
-        &:has(input:disabled) {
-            cursor: default;
-        }
-    }
-}
-
 .DeploysPage {
     .all-published-notice {
         font-size: 18px;
@@ -596,68 +513,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
         font-weight: 400;
         color: #777;
     }
-}
-
-.GdocsAddForm {
-    .GdocsAddForm__instructions {
-        margin-left: 8px;
-        margin-bottom: 8px;
-    }
-    .validation-notice {
-        display: none;
-    }
-    input:invalid + .validation-notice {
-        display: block;
-        margin-top: 4px;
-        color: red;
-        padding-left: 5px;
-        pre {
-            color: red;
-        }
-    }
-    // don't show the validation notice when the input is blank (because that counts as "invalid")
-    input:placeholder-shown + .validation-notice {
-        display: none;
-    }
-}
-
-.GdocsEditPage,
-.GdocsSettingsForm {
-    .success {
-        color: #52c41a;
-    }
-
-    .warning {
-        color: #faad14;
-    }
-
-    .error {
-        color: #ff4d4f;
-    }
-    .muted {
-        color: rgba(0, 0, 0, 0.25);
-    }
-    h3.form-section-heading {
-        color: #757575;
-    }
-    .form-group:not(:first-child) h3.form-section-heading {
-        margin-top: 32px;
-    }
-}
-
-.GdocsSettingsForm__alert {
-    margin-bottom: 8px;
-}
-
-.GdocsSettingsContentField__imagePreview {
-    margin-top: 12px;
-}
-
-.GdocsSettingsContentField__imagePreviewImage {
-    display: block;
-    width: 100%;
-    border: 1px solid #d9d9d9;
-    border-radius: 4px;
 }
 
 .GdocsEditPage {
@@ -786,88 +641,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
 
     .GdocsCoverageMatrix__cell {
         border: 1px solid #e5e7eb;
-    }
-}
-
-.CalloutFunctionsPage {
-    padding: 24px;
-}
-
-.CalloutFunctionsPage__form {
-    margin-top: 16px;
-}
-
-.CalloutFunctionsPage__input-group {
-    display: flex;
-    gap: 8px;
-
-    input {
-        flex: 1;
-    }
-}
-
-.CalloutFunctionsPage__results {
-    background: #f9fafb;
-    border: 1px solid #e5e7eb;
-    border-radius: 6px;
-    padding: 16px;
-}
-
-.CalloutFunctionsPage__function-list {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.CalloutFunctionsPage__column-functions {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    padding: 8px 12px;
-    background: #fff;
-    border: 1px solid #e5e7eb;
-    border-radius: 4px;
-    margin-bottom: 8px;
-    ul {
-        width: 100%;
-        margin-top: 8px;
-        li {
-            margin-bottom: 4px;
-            list-style: none;
-        }
-    }
-
-    code {
-        flex: 1;
-        font-size: 14px;
-        color: #1f2937;
-    }
-}
-
-.GdocsSettingsForm {
-    .edit-in-gdocs {
-        position: relative;
-
-        a {
-            background-color: rgb(24, 144, 255, 0.8);
-            position: absolute;
-            top: 0;
-            right: 0;
-            bottom: 0;
-            left: 0;
-            z-index: 10;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: white;
-            text-decoration: none;
-            transition: all 0.2s;
-            opacity: 0;
-        }
-
-        &:hover a {
-            opacity: 1;
-        }
     }
 }
 

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -92,6 +92,8 @@
 @import "./GdocsAdd.scss";
 @import "./GdocsSettingsForms.scss";
 @import "./GdocsSettingsContentField.scss";
+@import "./GrapherConfigGridEditor.scss";
+@import "./VariableEditPage.scss";
 @import "./GdocsIndexPage.scss";
 @import "./FeaturedMetricsPage.scss";
 @import "./FilesIndexPage.scss";
@@ -162,86 +164,6 @@ button {
     }
 }
 
-.VariablesAnnotationPage {
-    display: flex;
-    flex-grow: 1;
-
-    > .sidebar {
-        min-width: 500px;
-        width: 500px;
-        min-height: 100%;
-        display: flex;
-        flex-direction: column;
-        overflow: hidden;
-        > .sidebar-content {
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-            align-items: stretch;
-            overflow-y: auto;
-            height: 100%;
-            > .preview {
-                flex: 0 0 auto;
-                // min-height: 500px;
-                border-top: 1px solid lightgray;
-                padding-top: 5px;
-            }
-            > section {
-                flex: 1 0 200px;
-            }
-        }
-    }
-
-    > .editor-view {
-        width: 100%;
-    }
-
-    .column-list-item {
-        padding: 3px;
-        border: lightgray 1px solid;
-        border-radius: 4px;
-
-        button {
-            margin-right: 0.5rem;
-        }
-    }
-
-    .column-list-item + .column-list-item {
-        margin-top: 4px;
-    }
-
-    .column-section {
-        overflow-y: auto;
-    }
-
-    .queryBuilder {
-        margin: 8px 0;
-    }
-
-    .rich-editor-confirm-buttons {
-        margin-top: 0.5rem;
-
-        button {
-            margin-right: 0.5rem;
-        }
-    }
-}
-
-// The bulk editor's sidebar uses an antd `Tabs` as a tab bar only — its panes
-// are rendered as siblings, below, so that `.sidebar-content`'s flex sizing
-// still reaches them. Hide the empty content area antd renders anyway.
-.VariablesAnnotationPage__tabs {
-    padding: 0.5rem 0.5rem 0;
-
-    > .ant-tabs-nav {
-        margin-bottom: 0;
-    }
-
-    > .ant-tabs-content-holder {
-        display: none;
-    }
-}
-
 /* Reusable utility classes */
 
 .draggable {
@@ -296,17 +218,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     }
 }
 
-.VariableEditPage {
-    figure {
-        width: 100%;
-        height: 500px;
-    }
-
-    .partial-grapher-configs .FieldsRow {
-        align-items: flex-start;
-    }
-}
-
 .EditableTextarea__actions {
     display: flex;
     flex-direction: row-reverse;
@@ -344,53 +255,6 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     height: 600px;
     margin: 0;
     min-width: 0;
-}
-
-.TestEmbedsPage {
-    figure,
-    iframe {
-        border: 0;
-        width: 914px;
-        height: 400px;
-    }
-
-    .row {
-        padding: 10px;
-        margin: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-    }
-
-    h3 {
-        width: 50%;
-        text-align: center;
-        margin: 0;
-    }
-
-    nav.pagination {
-        width: 100%;
-        text-align: center;
-    }
-}
-
-.VariableEditRow {
-    border-bottom: 1px solid #eee;
-    padding-bottom: 1em;
-    margin-bottom: 1em;
-
-    figure {
-        width: 100%;
-        height: 500px;
-    }
-}
-
-// to override the default annoying blue border from bootstrap on file upload
-.custom-file-input:focus ~ .custom-file-control {
-    box-shadow:
-        0 0 0 0.075rem #fff,
-        0 0 0 0.2rem #fff;
 }
 
 .TagBadge {


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

**Stacked on #7049** (← #7048 ← #7047 ← #7046 ← #7044). Phase 5 of the admin's Bootstrap→antd migration: the CRUD/index pages lose their last raw Bootstrap markup — forms, `table-bordered` tables, grid, badge, breadcrumb, pagination — and six more Bootstrap modules are deleted. Only `reboot`, `type`, `code`, `utilities`, `print` remain, all Phase 6 (which then removes the `bootstrap` dependency entirely).

The main judgment call to review: which tables became antd `<Table>` vs. a custom `.admin-table` class. Plain record lists (Users, Redirects, DatasetEditPage's explorer/multi-dim lists) went antd and gained column sorting. Lists with `@observer` row components, per-row tag editors that save independently, or externally-driven sort state (ChartList, DatasetList, VariableList, ExplorersListPage, ExplorerTagsPage) kept their markup under `.admin-table` — antd's `columns`/`dataSource` would have meant rewriting the row components for no gain.

⚠️ One area not exercised in a browser: the gdocs settings drawer (local dev has no Google service-account key, so gdoc preview pages 500). Its markup changes were review-verified; worth a click-through on staging.

<details><summary>Details</summary>

**Commits:** forms sweep (`b6ecc1ac96`), tables (`6b3d41e5ce`), grid/badge/breadcrumb/pagination (`ece0c0ec6a`), Forms.tsx `form-group` emission removal (`1cc8992d4b`), module pruning (`55fff185e4`), list-table scss extraction (`1155bee01a`).

**Forms sweep:** GdocsSettingsForms' `form-group` section wrappers → `GdocsSettingsForm__section`/`__help`/`__preview-entity`; GdocsAdd, the users invite modal and CalloutFunctionsPage → controlled antd `Input`; VariableEditPage's `ReadOnlyField` → disabled `TextField`; ExplorerCreatePage's "Show Preview" → antd `Checkbox`; GdocsSettingsContentField, GdocsManualBreadcrumbsInput, TagEditPage, DatasetEditPage's tag editor → the `form-field` classes. Form-submit/validation semantics preserved (empty add-user submit still blocked by native validation).

**Grid/badge/breadcrumb/pagination:** SourceList/VariableEditPage/DatasetEditPage two-column layouts → antd `Row gutter={30}`/`Col flex="1 1 0"`; explorer type badge → antd `Tag`; VariableEditPage breadcrumb → antd `Breadcrumb`; the bulk editor's hand-rolled pager → antd `Pagination simple` (keeps the "x to y of z" label, adds page jumping); two stragglers (ExplorerTagsPage native select, ExplorersListPage raw checkbox) → antd.

**Forms.tsx:** the legacy `form-group` class emission is gone — nothing keys off it anywhere anymore.

**SCSS (standing rule):** new `AdminTable.scss` (bordered look incl. `admin-table__row--danger`), `ChartList.scss`, `CalloutFunctionsPage.scss`, `GdocsAdd.scss`, `GdocsSettingsForms.scss`, `GdocsSettingsContentField.scss`, `GrapherConfigGridEditor.scss`, `VariableEditPage.scss`. Deleted dead blocks: `.ImportPage` (long-orphaned; held the last `@extend .form-control`), `.TestEmbedsPage`, `.VariableEditRow`, `.custom-file-input`, `.TagEditPage .form-check-label`.

**Module pruning:** `forms`, `grid`, `tables`, `badge`, `breadcrumb`, `pagination` deleted. Verified by compiling each module standalone and intersecting its emitted class names against every class token in `adminSiteClient/` — survivors were comment text or compound selectors whose other half is gone. Built `admin.css` loses 432 selectors / ~40KB, gains none.

**Verification:** typecheck, repo-wide lint, format clean; vitest 2336 passed. Headless QA on all 15 touched pages, mutation-free: sorted Users/Redirects tables, add-user modal validation, ChartList search narrowing, DatasetEditPage tab/filter, Explorers published-toggle (antd Tags counted), bulk-editor paging across 778k rows, GdocsAdd pattern-validation notice, CalloutFunctionsPage button enablement. No new console/page errors vs. baseline. ExplorerTagsPage's new-row select is legitimately empty in dev (all explorers tagged) — placeholder/dropdown render correctly.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
