### PR TITLE
Remove CTA announcements from the CMS

### DIFF
--- a/adminSiteClient/gdocsDeploy.ts
+++ b/adminSiteClient/gdocsDeploy.ts
@@ -143,7 +143,6 @@ export const checkIsLightningUpdate = (
         body: false,
         excerpt: false,
         "featured-image": false,
-        cta: false,
     }
     const authorLightningPropContentConfigMap: Record<
         keyof OwidGdocAuthorContent,

--- a/baker/algolia/utils/pagesChronological.ts
+++ b/baker/algolia/utils/pagesChronological.ts
@@ -212,19 +212,13 @@ function buildVariantPayload(
                         filenames.add(author.featuredImage)
                 }
 
-                if (g.content.cta) {
-                    payload.cta = g.content.cta
-                } else {
-                    copyAttachmentsIfPresent(payload, g)
-                    for (const f of extractFilenamesFromBlocks(
-                        g.content.body
-                    )) {
-                        filenames.add(f)
-                    }
-                    for (const doc of Object.values(g.linkedDocuments ?? {})) {
-                        if (doc["featured-image"]) {
-                            filenames.add(doc["featured-image"])
-                        }
+                copyAttachmentsIfPresent(payload, g)
+                for (const f of extractFilenamesFromBlocks(g.content.body)) {
+                    filenames.add(f)
+                }
+                for (const doc of Object.values(g.linkedDocuments ?? {})) {
+                    if (doc["featured-image"]) {
+                        filenames.add(doc["featured-image"])
                     }
                 }
 

--- a/db/model/Gdoc/GdocAnnouncement.ts
+++ b/db/model/Gdoc/GdocAnnouncement.ts
@@ -2,13 +2,11 @@ import {
     OwidGdocAnnouncementContent,
     OwidGdocAnnouncementInterface,
     OwidGdocBaseInterface,
-    excludeNullish,
     OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
 } from "@ourworldindata/utils"
 import { ANNOUNCEMENT_LATEST_TYPES } from "@ourworldindata/types"
 import { GdocBase } from "./GdocBase.js"
-import { extractUrl } from "./gdocUtils.js"
 
 export class GdocAnnouncement
     extends GdocBase
@@ -20,28 +18,8 @@ export class GdocAnnouncement
         super(id)
     }
 
-    protected override typeSpecificUrls(): string[] {
-        return excludeNullish([this.content.cta?.url])
-    }
-
     override _validateSubclass = async (): Promise<OwidGdocErrorMessage[]> => {
         const errors: OwidGdocErrorMessage[] = []
-        if (this.content.cta) {
-            if (!this.content.cta?.url || !this.content.cta?.text) {
-                errors.push({
-                    property: "content.cta",
-                    message: `If a top-level {.cta} property is set, its url and text value must be set.`,
-                    type: OwidGdocErrorMessageType.Error,
-                })
-            }
-            if (this.content.body?.length) {
-                errors.push({
-                    property: "content.cta",
-                    message: `An announcement with a top-level {.cta} block must have an empty body. Either remove the body content (and keep the CTA), or remove the {.cta} block (and keep the body).`,
-                    type: OwidGdocErrorMessageType.Error,
-                })
-            }
-        }
 
         // The kicker drives the announcement's category on /latest. Reject
         // unrecognized values at publish time so the indexer never has to
@@ -61,12 +39,6 @@ export class GdocAnnouncement
         }
 
         return errors
-    }
-
-    override _enrichSubclassContent = (content: Record<string, any>): void => {
-        if (content.cta?.url) {
-            content.cta.url = extractUrl(content.cta.url)
-        }
     }
 
     static create(obj: OwidGdocBaseInterface): GdocAnnouncement {

--- a/db/model/Gdoc/GdocBase.ts
+++ b/db/model/Gdoc/GdocBase.ts
@@ -1500,7 +1500,6 @@ export function rawGdocToMinimalPost(
         type: row.type as OwidGdocType,
         "featured-image": featuredImage,
         kicker: content.kicker,
-        cta: content.cta,
     }
 }
 

--- a/db/model/Gdoc/GdocHomepage.ts
+++ b/db/model/Gdoc/GdocHomepage.ts
@@ -6,17 +6,11 @@ import {
     OwidGdocMinimalPostInterface,
     OwidGdocType,
 } from "@ourworldindata/utils"
-import { getLinkType, getUrlTarget } from "@ourworldindata/components"
-import {
-    GdocBase,
-    getMinimalGdocPostsByIds,
-    loadLinkedChartsForSlugs,
-} from "./GdocBase.js"
+import { GdocBase } from "./GdocBase.js"
 import * as db from "../../db.js"
 import {
     OwidGdocBaseInterface,
     OwidGdocHomepageMetadata,
-    ContentGraphLinkType,
 } from "@ourworldindata/types"
 import { getLatestDataInsights } from "./GdocFactory.js"
 
@@ -88,68 +82,9 @@ export class GdocHomepage
             announcements: await db.getHomepageAnnouncements(knex),
         }
 
-        // Load linked charts/documents from announcement CTAs
-        // Because of announcement CTAs, announcements can have have their own links
-        // which aren't caught by the GdocBase loadLinkedDocuments/Charts methods
-        // So we need to add them here
-        await this.loadAnnouncementLinks(knex)
-
         const { dataInsights, imageMetadata } =
             await getLatestDataInsights(knex)
         this.latestDataInsights = dataInsights
         this.imageMetadata = Object.assign(this.imageMetadata, imageMetadata)
-    }
-
-    private async loadAnnouncementLinks(
-        knex: db.KnexReadonlyTransaction
-    ): Promise<void> {
-        const announcements = this.homepageMetadata.announcements
-        if (!announcements || announcements.length === 0) return
-
-        // Extract all CTA URLs from announcements
-        const ctaUrls = announcements
-            .map((announcement) => announcement.cta?.url)
-            .filter((url): url is string => !!url)
-
-        if (ctaUrls.length === 0) return
-
-        // Categorize URLs by link type
-        const gdocIds: string[] = []
-        const grapherSlugs: string[] = []
-        const explorerSlugs: string[] = []
-
-        for (const url of ctaUrls) {
-            const linkType = getLinkType(url)
-            const target = getUrlTarget(url)
-
-            if (linkType === ContentGraphLinkType.Gdoc) {
-                gdocIds.push(target)
-            } else if (linkType === ContentGraphLinkType.Grapher) {
-                grapherSlugs.push(target)
-            } else if (linkType === ContentGraphLinkType.Explorer) {
-                explorerSlugs.push(target)
-            }
-        }
-
-        // Load linked documents
-        if (gdocIds.length > 0) {
-            const linkedDocs = await getMinimalGdocPostsByIds(knex, gdocIds)
-            for (const doc of linkedDocs) {
-                this.linkedDocuments[doc.id] = doc
-            }
-        }
-
-        // Load linked charts using shared helper
-        if (grapherSlugs.length > 0 || explorerSlugs.length > 0) {
-            const linkedCharts = await loadLinkedChartsForSlugs(
-                knex,
-                grapherSlugs,
-                explorerSlugs
-            )
-
-            for (const chart of linkedCharts) {
-                this.linkedCharts[chart.originalSlug] = chart
-            }
-        }
     }
 }

--- a/packages/@ourworldindata/types/src/domainTypes/Latest.test.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Latest.test.ts
@@ -34,8 +34,7 @@ describe("chronological page record schema", () => {
                 ...baseRecord,
                 type: OwidGdocType.Announcement,
                 latestType: "announcement",
-                body: [],
-                cta: { text: "Read more", url: "/test-page" },
+                body: [{ type: "text" }],
             },
             {
                 ...baseRecord,
@@ -61,7 +60,6 @@ describe("chronological page record schema", () => {
             latestType: "data-insight",
             body: [],
             featuredImage: "article-only.png",
-            cta: { text: "Announcement only", url: "/test-page" },
         })
 
         expect(parsed.success).toBe(false)
@@ -71,7 +69,7 @@ describe("chronological page record schema", () => {
         const parsed = PageChronologicalRecordSchema.safeParse({
             ...baseRecord,
             type: OwidGdocType.TopicPage,
-            latestType: undefined,
+            latestType: "article",
         })
 
         expect(parsed.success).toBe(false)

--- a/packages/@ourworldindata/types/src/domainTypes/Latest.ts
+++ b/packages/@ourworldindata/types/src/domainTypes/Latest.ts
@@ -181,12 +181,6 @@ const PageChronologicalAnnouncementRecordPayloadSchema = z.strictObject({
     type: z.literal(OwidGdocType.Announcement),
     latestType: z.enum(ANNOUNCEMENT_LATEST_TYPES),
     body: OwidEnrichedGdocBlocksSchema,
-    cta: z.optional(
-        z.strictObject({
-            text: z.string(),
-            url: z.string(),
-        })
-    ),
     linkedAuthors: z.optional(
         castSchemaOutput<LinkedAuthor[]>(z.array(z.any()))
     ),

--- a/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Gdoc.ts
@@ -169,7 +169,6 @@ export interface OwidGdocMinimalPostInterface {
     type: OwidGdocType // used in useLinkedDocument to prepend /data-insights/ to the slug
     "featured-image"?: string // used in prominent links and research & writing block
     kicker?: string // used in homepage announcements
-    cta?: { text: string; url: string } // used in homepage announcements
     availableEntityCodes?: string[] // used for profile-type docs to resolve ?country=X links
 }
 
@@ -294,10 +293,6 @@ export interface OwidGdocAnnouncementContent {
     kicker?: string
     body: OwidEnrichedGdocBlock[]
     type: OwidGdocType.Announcement
-    cta?: {
-        text: string
-        url: string
-    }
 }
 
 export interface OwidGdocAnnouncementInterface extends OwidGdocBaseInterface {

--- a/site/gdocs/components/HomepageIntro.tsx
+++ b/site/gdocs/components/HomepageIntro.tsx
@@ -7,7 +7,7 @@ import {
     OwidGdocMinimalAnnouncementInterface,
 } from "@ourworldindata/types"
 import { dayjs, formatAuthors } from "@ourworldindata/utils"
-import { useLinkedChart, useLinkedDocument } from "../utils.js"
+import { useLinkedDocument } from "../utils.js"
 import { useDocumentContext } from "../DocumentContext.js"
 import Image, { ImageParentContainer } from "./Image.js"
 import { BlockErrorFallback } from "./BlockErrorBoundary.js"
@@ -144,26 +144,13 @@ function useIsOverflowing<T extends HTMLElement = HTMLElement>(
 
 function HomepageAnnouncement(props: {
     announcement: OwidGdocMinimalAnnouncementInterface
-    index: number
 }) {
-    const { announcement, index } = props
-    const { linkedChart } = useLinkedChart(announcement.cta?.url || "")
-    const { linkedDocument } = useLinkedDocument(announcement.cta?.url || "")
-    // If there's not enough space to show all of the third announcement, we link to the latest page, no matter what
-    // If there is enough space, it behaves as normal:
-    // - cta: link directly to the resource
-    // - no cta: link to the latest page
+    const { announcement } = props
     const announcementRef = useRef<HTMLLIElement>(null)
     const isOverflowing = useIsOverflowing(
         announcementRef as RefObject<HTMLElement>
     )
-    const latestPageLink = `/latest#${announcement.slug}`
-    const href = isOverflowing
-        ? latestPageLink
-        : linkedChart?.resolvedUrl ||
-          linkedDocument?.url ||
-          announcement.cta?.url ||
-          latestPageLink
+    const href = `/latest#${announcement.slug}`
 
     const publishedAtDayJs = dayjs(announcement.publishedAt)
     const publishedAtFormatted = publishedAtDayJs.isToday()
@@ -187,7 +174,8 @@ function HomepageAnnouncement(props: {
             <a
                 className="homepage-intro__announcement-link"
                 aria-labelledby={`announcement-${announcement.id}`}
-                tabIndex={index === 2 ? -1 : undefined}
+                // skip overflowing links to prevent inner scrolling that breaks the layout
+                tabIndex={isOverflowing ? -1 : undefined}
                 href={href}
             >
                 <span className="homepage-intro__announcement-meta h6-black-caps">
@@ -204,8 +192,7 @@ function HomepageAnnouncement(props: {
                     {announcement.excerpt}
                 </p>
                 <span className="homepage-intro__announcement-read-more body-3-medium">
-                    {announcement.cta ? announcement.cta.text : "Read more"}{" "}
-                    <FontAwesomeIcon icon={faArrowRight} />
+                    Read more <FontAwesomeIcon icon={faArrowRight} />
                 </span>
             </a>
         </li>
@@ -223,11 +210,10 @@ function HomepageAnnouncements() {
                 <h4 className="h3-bold">Updates and announcements</h4>
             </div>
             <ul className="homepage-intro__announcements-list">
-                {announcements.map((announcement, i) => (
+                {announcements.map((announcement) => (
                     <HomepageAnnouncement
                         announcement={announcement}
                         key={announcement.id}
-                        index={i}
                     />
                 ))}
             </ul>

--- a/site/gdocs/pages/Announcement.tsx
+++ b/site/gdocs/pages/Announcement.tsx
@@ -44,8 +44,6 @@ export const AnnouncementPage = ({
 }: AnnouncementProps): React.ReactElement => {
     const { linkedDocuments } = useContext(AttachmentsContext)
     const latestType = deriveAnnouncementLatestType(content.kicker)
-    // CTA-only announcements have an empty body (enforced by
-    // GdocAnnouncement._validateSubclass), so there's nothing to copy.
     const shouldShowCopySocialButton =
         SOCIAL_LATEST_TYPES.includes(latestType) && content.body.length > 0
     return (
@@ -58,9 +56,7 @@ export const AnnouncementPage = ({
                     slug={slug}
                     publishedAt={publishedAt}
                     authors={content.authors}
-                    excerpt={content.excerpt}
                     body={content.body}
-                    cta={content.cta}
                     isStandalone
                 />
                 {shouldShowCopySocialButton && (

--- a/site/latest/AnnouncementContent.scss
+++ b/site/latest/AnnouncementContent.scss
@@ -25,15 +25,6 @@
     }
 }
 
-.announcement-content__excerpt {
-    @include body-2-regular;
-    margin: 16px 0;
-
-    @include sm-only {
-        @include body-3-medium;
-    }
-}
-
 .announcement-content {
     .cta {
         @include sm-only {

--- a/site/latest/AnnouncementContent.tsx
+++ b/site/latest/AnnouncementContent.tsx
@@ -1,7 +1,6 @@
 import { LatestType, OwidEnrichedGdocBlock } from "@ourworldindata/types"
 import cx from "clsx"
 import LinkedAuthor from "../gdocs/components/LinkedAuthor.js"
-import { Cta } from "../gdocs/components/Cta.js"
 import { ExpandableText } from "./ExpandableText.js"
 import { LatestHitMetadata } from "./LatestHitMetadata.js"
 import { announcementContentTitleId } from "./latestUtils.js"
@@ -23,9 +22,7 @@ export const AnnouncementContent = ({
     slug,
     publishedAt,
     authors,
-    excerpt,
     body,
-    cta,
     isStandalone,
     shouldAutoExpand,
     selectedTopic,
@@ -37,9 +34,7 @@ export const AnnouncementContent = ({
     slug: string
     publishedAt: Date | string | null
     authors: string[]
-    excerpt: string
     body: OwidEnrichedGdocBlock[]
-    cta?: { text: string; url: string }
     /** When rendered as the standalone preview page: use h1, show full body
      * (no Read more truncation). */
     isStandalone?: boolean
@@ -82,24 +77,14 @@ export const AnnouncementContent = ({
             >
                 {title}
             </Heading>
-            {/* Body and {.cta} are mutually exclusive — see
-                GdocAnnouncement._validateSubclass. */}
-            {cta && cta.url && cta.text ? (
-                <>
-                    {authorByline}
-                    <p className="announcement-content__excerpt">{excerpt}</p>
-                    <Cta shouldRenderLinks text={cta.text} url={cta.url} />
-                </>
-            ) : (
-                <ExpandableText
-                    blocks={body}
-                    containerType="latest-announcement"
-                    alwaysExpanded={shouldAutoExpand || isStandalone}
-                    onReadMore={onReadMore}
-                >
-                    {authorByline}
-                </ExpandableText>
-            )}
+            <ExpandableText
+                blocks={body}
+                containerType="latest-announcement"
+                alwaysExpanded={shouldAutoExpand || isStandalone}
+                onReadMore={onReadMore}
+            >
+                {authorByline}
+            </ExpandableText>
         </div>
     )
 }

--- a/site/latest/LatestAnnouncementHit.tsx
+++ b/site/latest/LatestAnnouncementHit.tsx
@@ -38,9 +38,7 @@ export const LatestAnnouncementHit = ({
                     slug={hit.slug}
                     publishedAt={hit.date}
                     authors={hit.authors}
-                    excerpt={hit.excerpt}
                     body={hit.body}
-                    cta={hit.cta}
                     selectedTopic={selectedTopic}
                     onReadMore={() =>
                         analytics.logLatestAnnouncementExpand(hit, position)

--- a/site/latest/README.md
+++ b/site/latest/README.md
@@ -45,12 +45,13 @@ A single Algolia call ([`queryLatestPages`](../search/queries.ts)) issues three 
 
 The `/latest` filter offers five options: article, data insight, data update, website upgrade, announcement. The first two are distinct gdoc types, but the last three are all _announcement_ gdocs distinguished only by their editorial _kicker_. The indexer derives a `latestType` per record (kicker for announcements, gdoc type otherwise) so the filter can treat them as five separate values. The raw gdoc type stays on the record for card dispatch and the atom feed.
 
-### 6. Authoring choices create card variants within a type
+### 6. Articles are the only type with card variants
 
-Two content types expose editorial knobs that change what the card shows. Both follow the same shape: an authoring choice in the gdoc → conditional behavior in the indexer (which linked content to load) → variant rendering in the card.
+Articles expose two card-only override fields, and each follows the same shape: an authoring choice in the gdoc → conditional behavior in the indexer (which linked content to load) → variant rendering in the card.
 
-- **Articles** can supply two card-only override fields. `latest-feed-featured-image` swaps the card thumbnail (the article page itself still uses `featured-image`). `latest-feed-excerpt` switches the excerpt from the default plain text to ArticleBlocks (with internal links and formatting) plus a "Read the article" affordance — see [`LatestArticleHit`](./LatestArticleHit.tsx). The rich-excerpt path is also why the indexer conditionally loads linked charts/documents for articles.
-- **Announcements** come in two shapes: CTA (top-level `{.cta}` block, empty body — renders excerpt + a single CTA button) and non-CTA (body-driven, usually contains an inline `{.cta}` block). The indexer skips loading linked charts/documents for CTA announcements since the excerpt-only rendering doesn't need them. The CTA shape is under review in [owid/owid-grapher#6464](https://github.com/owid/owid-grapher/issues/6464); if removed, this branch collapses.
+`latest-feed-featured-image` swaps the card thumbnail (the article page itself still uses `featured-image`). `latest-feed-excerpt` switches the excerpt from the default plain text to ArticleBlocks (with internal links and formatting) plus a "Read the article" affordance — see [`LatestArticleHit`](./LatestArticleHit.tsx). The rich-excerpt path is also why the indexer conditionally loads linked charts/documents for articles.
+
+Every other type renders one way, so the indexer loads their linked content unconditionally.
 
 ### 7. Standalone announcement pages are a preview surface
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @mlbrgl at the wheel._

Removes the top-level `{.cta}` announcement shape (empty body + excerpt + one button), per the decision in #6464. Closes #7011. Every call-to-action now lives inside the body as an inline `{.cta}` block, which is unchanged.

**Do not merge/deploy yet:** the one published CTA announcement ([the Oxford Martin School one](https://ourworldindata.org/latest#max-roser-co-leads-new-oxford-martin-programme-on-forecasting-technological-change-with-data-to-be-hosted-on-our-world-in-data), gdoc `1qQqvByR-2TRuV_h6rIYisHGF96I0VFq5RRrPvVpngOI`) needs its CTA rewritten into the body first, otherwise it renders as title + excerpt with no link to the partner site. Drafts should be checked too (the public DB mirror only contains published gdocs).

- [x] rewrite to non-CTA announcement
- [x] ask Charlie if ok with content
- [x] republish
- [x] update docs (nothing found)

Product consequence (accepted in #7011): homepage announcements always link to `/latest#slug` with a "Read more" label — no more direct-to-target links with custom labels.

<details><summary>Details</summary>

**db layer**
- `GdocAnnouncement`: removed the cta/body mutual-exclusion and url/text validations, the `typeSpecificUrls` override, and `_enrichSubclassContent` (whose only job was `extractUrl` on `cta.url`). Kicker validation stays.
- `GdocBase.rawGdocToMinimalPost`: no longer copies `cta` onto minimal posts.
- `GdocHomepage`: deleted `loadAnnouncementLinks`, which existed solely to resolve linked charts/documents from announcement CTA urls (those weren't caught by the normal `loadLinkedDocuments`/`loadLinkedCharts` path).

**Types**
- `OwidGdocAnnouncementContent.cta` and `OwidGdocMinimalPostInterface.cta` removed.
- `PageChronologicalAnnouncementRecordPayloadSchema` no longer has `cta`. Safe despite `strictObject`: the schema is only parsed at index time in the baker on freshly built records; /latest never runtime-parses hits, so existing Algolia records carrying `cta` are ignored until the next chronological reindex naturally rewrites them.

**Admin**
- `gdocsDeploy.ts`: dropped `cta` from `announcementLightningPropContentConfigMap` (required — it's a `Record<keyof OwidGdocAnnouncementContent, boolean>`).

**Baker/Algolia**
- `pagesChronological.ts`: the announcement branch now unconditionally copies attachments and collects image filenames (previously skipped for CTA-shaped announcements). This also matters for #7009's image-led cards.

**Site**
- `AnnouncementContent`: removed the excerpt+button branch and the `cta`/`excerpt` props; only the `<ExpandableText>` body path remains. The `.announcement-content__excerpt` scss went with it; the nested `.announcement-content .cta` rule stays because it also styles body-level `{.cta}` blocks.
- `Announcement.tsx`, `LatestAnnouncementHit.tsx`: call sites updated. The `content.body.length > 0` guard on the copy-social button stays (still guards genuinely empty bodies).
- `HomepageIntro.tsx`: `href` is now always `/latest#slug`; removed the `useLinkedChart`/`useLinkedDocument` resolution of the cta url. `isOverflowing` is kept — it still drives the CSS modifier and tabIndex.

**Docs/tests**
- `site/latest/README.md` section 6 rewritten (announcements no longer have card variants).
- `Latest.test.ts`: dropped `cta` from the valid announcement fixture; the cross-variant rejection test still fails on `featuredImage` alone.
- `raycastSnippets.json`'s `{.cta}` snippet left alone — same ArchieML shape serves the body block.

**Test plan**: `yarn typecheck` clean; `yarn test run Latest.test.ts archieToEnriched.test.ts gdocUtils.test.ts` (23 passed); lint/format clean; grep sweep confirms all remaining `cta` references are the body-level block.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)