### PR TITLE
Copy Algolia search credentials into worktree envs

### DIFF
--- a/devTools/docker/setup-worktree-env.sh
+++ b/devTools/docker/setup-worktree-env.sh
@@ -81,6 +81,15 @@ for setting in \
     grep -q "^${setting%%=*}=" .env || echo "$setting" >> .env
 done
 
+# copy search-only Algolia credentials from the main checkout's .env if present
+MAIN_WORKTREE="$(git worktree list --porcelain | sed -n 's/^worktree //p' | head -n 1)"
+if [ -n "$MAIN_WORKTREE" ] && [ -e "$MAIN_WORKTREE/.env" ]; then
+    for var in ALGOLIA_ID ALGOLIA_SEARCH_KEY; do
+        line="$(grep -E "^[[:space:]]*${var}=" "$MAIN_WORKTREE/.env" | tail -n 1 || true)"
+        [ -n "$line" ] && echo "$line" >> .env
+    done
+fi
+
 echo "==> Wrote .env for this checkout:"
 echo "        TMUX_SESSION_NAME=$TMUX_SESSION_NAME"
 echo "        ADMIN_SERVER_PORT=$ADMIN_SERVER_PORT"


### PR DESCRIPTION
> _Written by OpenAI GPT-5 — @marcelgerber at the wheel._

Worktree setup now copies the search-only Algolia credentials from the main checkout when available. This lets worktree development use site search without manually duplicating those environment values.

<details><summary>Details</summary>

- Reads ALGOLIA_ID and ALGOLIA_SEARCH_KEY from the main worktree environment file.
- Leaves setup working when the main environment file or either value is absent.
- Verified with yarn typecheck, yarn testLintChanged, bash syntax validation, and git diff --check.

</details>