### PR TITLE
🚧 test: turn the site nav red to exercise the screenshot diff

### DIFF
--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -9,7 +9,7 @@
     position: relative;
     z-index: $zindex-lightbox;
     border-bottom: $header-border-height solid $vermillion;
-    background-color: $oxford-blue;
+    background-color: $vermillion;
 
     @include sm-only {
         .wrapper {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

**Not for merge.** A deliberate visual change to exercise the site-screenshots diff end to end, now that owid/site-screenshots#10 has raised the settle budget from 60 to 180 seconds.

`.site-navigation` goes from `$oxford-blue` to `$vermillion`: the nav bar sits at the top of all seven screenshotted pages, and a colour swap changes no layout, so each page should come back differing in exactly that band and nowhere else. If the screenshots step instead fails with "never settled", the budget still isn't enough.

The diff will show up at https://github.com/owid/site-screenshots/compare/ss-diff-test once the "Site screenshots diff" step has run.

<details><summary>Details</summary>

Skipped the usual pre-commit checks deliberately: the change is one SCSS declaration, so `yarn typecheck` and `yarn testLintChanged` (oxlint, JS/TS only) have nothing to look at, and the edit preserves the surrounding formatting verbatim.

Delete the branch once the diff has been eyeballed; the staging server goes with it.
</details>
