### PR TITLE
Use <details> for the mobile site menu

### DIFF
--- a/site/SiteConstants.ts
+++ b/site/SiteConstants.ts
@@ -19,6 +19,13 @@ export const MEDIUM_BREAKPOINT_MEDIA_QUERY = "(max-width: 960px)"
 export const TOUCH_DEVICE_MEDIA_QUERY =
     "(hover: none), (pointer: coarse), (pointer: none)"
 
+// <details> elements sharing a name form an exclusive accordion: opening one
+// closes the others. Shared by all collapsible sections of the mobile site
+// menu (topic areas, Resources, About). In browsers without support
+// (Chrome <120, Safari <17.2, Firefox <130), sections still expand/collapse
+// but don't auto-close each other.
+export const MOBILE_MENU_DETAILS_NAME = "site-mobile-menu"
+
 export const DATA_INSIGHTS_ATOM_FEED_NAME = "atom-data-insights.xml"
 
 export const DEFAULT_ATOM_FEED_PROPS = {

--- a/site/SiteMobileArea.scss
+++ b/site/SiteMobileArea.scss
@@ -1,8 +1,8 @@
 .SiteMobileArea {
-    .SiteNavigationToggle.active {
+    details[open] {
         background-color: #d5e7fe;
     }
-    .SiteNavigationToggle__button {
+    .SiteMobileArea__summary {
         display: flex;
         width: 100%;
         align-items: center;
@@ -11,8 +11,8 @@
         padding: 8px 16px;
         color: $blue-60;
         line-height: 21px;
-        &.active {
-            color: $blue-90;
-        }
+    }
+    details[open] > .SiteMobileArea__summary {
+        color: $blue-90;
     }
 }

--- a/site/SiteMobileArea.tsx
+++ b/site/SiteMobileArea.tsx
@@ -11,6 +11,10 @@ export const SiteMobileArea = ({ area }: { area: TagGraphNode }) => {
         event: React.ToggleEvent<HTMLDetailsElement>
     ) => {
         if (event.newState !== "open") return
+        const rect = event.currentTarget.getBoundingClientRect()
+        const isFullyVisible =
+            rect.top >= 0 && rect.bottom <= window.innerHeight
+        if (isFullyVisible) return
         event.currentTarget.scrollIntoView({
             behavior: getPrefersReducedMotion() ? "auto" : "smooth",
         })

--- a/site/SiteMobileArea.tsx
+++ b/site/SiteMobileArea.tsx
@@ -1,37 +1,35 @@
-import { useEffect, useRef } from "react"
+import * as React from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCaretDown } from "@fortawesome/free-solid-svg-icons"
 import { SiteNavigationTopic } from "./SiteNavigationTopic.js"
 import { TagGraphNode, getAllChildrenOfArea } from "@ourworldindata/utils"
-import { SiteNavigationToggle } from "./SiteNavigationToggle.js"
 import { getPrefersReducedMotion } from "@ourworldindata/components"
+import { MOBILE_MENU_DETAILS_NAME } from "./SiteConstants.js"
 
-export const SiteMobileArea = ({
-    area,
-    isActive,
-    toggleArea,
-}: {
-    area: TagGraphNode
-    isActive: boolean
-    toggleArea: (area: TagGraphNode) => void
-}) => {
-    const areaRef = useRef<HTMLLIElement>(null)
-
-    useEffect(() => {
-        if (isActive && areaRef.current) {
-            areaRef.current.scrollIntoView({
-                behavior: getPrefersReducedMotion() ? "auto" : "smooth",
-            })
-        }
-    }, [isActive])
+export const SiteMobileArea = ({ area }: { area: TagGraphNode }) => {
+    const scrollAreaIntoView = (
+        event: React.ToggleEvent<HTMLDetailsElement>
+    ) => {
+        if (event.newState !== "open") return
+        event.currentTarget.scrollIntoView({
+            behavior: getPrefersReducedMotion() ? "auto" : "smooth",
+        })
+    }
 
     return (
-        <li key={area.id} className="SiteMobileArea" ref={areaRef}>
-            <SiteNavigationToggle
-                ariaLabel={
-                    isActive ? `Collapse ${area.name}` : `Expand ${area.name}`
-                }
-                isActive={isActive}
-                onToggle={() => toggleArea(area)}
-                dropdown={
+        <li className="SiteMobileArea">
+            <details
+                name={MOBILE_MENU_DETAILS_NAME}
+                onToggle={scrollAreaIntoView}
+            >
+                <summary className="SiteMobileArea__summary">
+                    {area.name}
+                    <FontAwesomeIcon
+                        className="SiteMobileMenu__caret"
+                        icon={faCaretDown}
+                    />
+                </summary>
+                <div className="SiteMobileMenu__dropdown">
                     <ul>
                         {getAllChildrenOfArea(area)
                             .filter((topic) => topic.slug)
@@ -42,11 +40,8 @@ export const SiteMobileArea = ({
                                 />
                             ))}
                     </ul>
-                }
-                withCaret={true}
-            >
-                {area.name}
-            </SiteNavigationToggle>
+                </div>
+            </details>
         </li>
     )
 }

--- a/site/SiteMobileMenu.scss
+++ b/site/SiteMobileMenu.scss
@@ -17,23 +17,28 @@
         }
     }
 
-    .section__header,
-    .SiteNavigationToggle--lvl1 .SiteNavigationToggle__button {
+    summary {
+        list-style: none;
+        cursor: pointer;
+
+        &::-webkit-details-marker {
+            display: none;
+        }
+    }
+
+    .section__header {
         @include h3-bold;
         color: $blue-60;
         margin: 0;
         padding: 12px 16px;
-        background: none;
-        border: none;
         width: 100%;
         display: flex;
         align-items: center;
         justify-content: space-between;
-        cursor: pointer;
+    }
 
-        &.active {
-            color: $blue-90;
-        }
+    details[open] > .section__header {
+        color: $blue-90;
     }
 
     .section__dropdown--topics {
@@ -43,11 +48,14 @@
         row-gap: 4px;
     }
 
-    .SiteNavigationToggle__caret {
+    .SiteMobileMenu__caret {
         font-size: 12px;
         margin-right: 8px;
     }
-    .SiteNavigationToggle__dropdown {
+    details[open] > summary .SiteMobileMenu__caret {
+        transform: rotate(180deg);
+    }
+    .SiteMobileMenu__dropdown {
         ul {
             padding-bottom: 12px;
             display: flex;

--- a/site/SiteMobileMenu.tsx
+++ b/site/SiteMobileMenu.tsx
@@ -1,31 +1,26 @@
+import * as React from "react"
 import { useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
-import { TagGraphNode, TagGraphRoot } from "@ourworldindata/utils"
+import { TagGraphRoot } from "@ourworldindata/utils"
 import classnames from "clsx"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import { faTimes } from "@fortawesome/free-solid-svg-icons"
-import { SiteNavigationToggle } from "./SiteNavigationToggle.js"
-import { Menu } from "./SiteConstants.js"
+import { faCaretDown, faTimes } from "@fortawesome/free-solid-svg-icons"
 import { SiteAbout } from "./SiteAbout.js"
 import { SiteResources } from "./SiteResources.js"
 import { SiteMobileArea } from "./SiteMobileArea.js"
 import { SEARCH_BASE_PATH } from "./search/searchUtils.js"
 import { FeedbackForm } from "./Feedback.js"
-import { Button } from "@ourworldindata/components"
+import { Button, getPrefersReducedMotion } from "@ourworldindata/components"
 import { buildLatestPagePath } from "./latest/latestUtils.js"
+import { MOBILE_MENU_DETAILS_NAME } from "./SiteConstants.js"
 
 export const SiteMobileMenu = ({
     tagGraph,
-    menu,
-    toggleMenu,
     className,
 }: {
     tagGraph?: TagGraphRoot
-    menu: Menu | null
-    toggleMenu: (menu: Menu) => void
     className?: string
 }) => {
-    const [activeArea, setActiveArea] = useState<TagGraphNode | null>(null)
     const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
     const menuRef = useRef<HTMLDivElement>(null)
 
@@ -36,11 +31,19 @@ export const SiteMobileMenu = ({
             document.documentElement.classList.remove("no-scroll")
         }
     }, [isFeedbackOpen])
-    const toggleArea = (area: TagGraphNode) => {
-        if (activeArea === area) {
-            setActiveArea(null)
-        } else {
-            setActiveArea(area)
+
+    const scrollMenuIntoView = (
+        event: React.ToggleEvent<HTMLDetailsElement>
+    ) => {
+        if (event.newState !== "open" || !menuRef.current) return
+        const menuBottomOffset = menuRef.current.getBoundingClientRect().bottom
+
+        // put bottom of the menu at the bottom of the viewport if it's offscreen
+        if (menuBottomOffset > window.innerHeight) {
+            window.scrollTo({
+                top: menuBottomOffset - window.innerHeight + window.scrollY,
+                behavior: getPrefersReducedMotion() ? "auto" : "smooth",
+            })
         }
     }
 
@@ -51,12 +54,7 @@ export const SiteMobileMenu = ({
                     <span className="section__header">Browse by topic</span>
                     <ul className="section__dropdown--topics">
                         {tagGraph?.children.map((area) => (
-                            <SiteMobileArea
-                                key={area.id}
-                                area={area}
-                                isActive={activeArea === area}
-                                toggleArea={toggleArea}
-                            />
+                            <SiteMobileArea key={area.id} area={area} />
                         ))}
                     </ul>
                 </li>
@@ -71,42 +69,38 @@ export const SiteMobileMenu = ({
                     </a>
                 </li>
                 <li>
-                    <SiteNavigationToggle
-                        ariaLabel="Toggle resources menu"
-                        isActive={menu === Menu.Resources}
-                        onToggle={() =>
-                            toggleMenu(
-                                menu === Menu.Resources
-                                    ? Menu.Topics
-                                    : Menu.Resources
-                            )
-                        }
-                        dropdown={<SiteResources />}
-                        withCaret={true}
-                        className="SiteNavigationToggle--lvl1"
-                        shouldScrollIntoView
-                        menuRef={menuRef}
+                    <details
+                        name={MOBILE_MENU_DETAILS_NAME}
+                        onToggle={scrollMenuIntoView}
                     >
-                        Resources
-                    </SiteNavigationToggle>
+                        <summary className="section__header">
+                            Resources
+                            <FontAwesomeIcon
+                                className="SiteMobileMenu__caret"
+                                icon={faCaretDown}
+                            />
+                        </summary>
+                        <div className="SiteMobileMenu__dropdown">
+                            <SiteResources />
+                        </div>
+                    </details>
                 </li>
                 <li>
-                    <SiteNavigationToggle
-                        ariaLabel="Toggle about menu"
-                        isActive={menu === Menu.About}
-                        onToggle={() =>
-                            toggleMenu(
-                                menu === Menu.About ? Menu.Topics : Menu.About
-                            )
-                        }
-                        dropdown={<SiteAbout />}
-                        withCaret={true}
-                        className="SiteNavigationToggle--lvl1"
-                        shouldScrollIntoView
-                        menuRef={menuRef}
+                    <details
+                        name={MOBILE_MENU_DETAILS_NAME}
+                        onToggle={scrollMenuIntoView}
                     >
-                        About
-                    </SiteNavigationToggle>
+                        <summary className="section__header">
+                            About
+                            <FontAwesomeIcon
+                                className="SiteMobileMenu__caret"
+                                icon={faCaretDown}
+                            />
+                        </summary>
+                        <div className="SiteMobileMenu__dropdown">
+                            <SiteAbout />
+                        </div>
+                    </details>
                 </li>
                 <li>
                     <a href="/donate" className="donate">

--- a/site/SiteNavigation.tsx
+++ b/site/SiteNavigation.tsx
@@ -121,8 +121,6 @@ export const SiteNavigation = ({
                             className="SiteNavigationToggle--mobile-menu hide-sm-up"
                             dropdown={
                                 <SiteMobileMenu
-                                    menu={menu}
-                                    toggleMenu={toggleMenu}
                                     tagGraph={tagGraph}
                                     className="hide-sm-up"
                                 />

--- a/site/SiteNavigationToggle.tsx
+++ b/site/SiteNavigationToggle.tsx
@@ -1,9 +1,7 @@
 import * as React from "react"
-import { useEffect } from "react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons"
 import cx from "clsx"
-import { getPrefersReducedMotion } from "@ourworldindata/components"
 
 export const SiteNavigationToggle = ({
     ariaLabel,
@@ -13,8 +11,6 @@ export const SiteNavigationToggle = ({
     withCaret = false,
     dropdown,
     className,
-    shouldScrollIntoView = false,
-    menuRef,
 }: {
     ariaLabel: string
     children: React.ReactNode
@@ -23,24 +19,7 @@ export const SiteNavigationToggle = ({
     withCaret?: boolean
     dropdown?: React.ReactNode
     className?: string
-    shouldScrollIntoView?: boolean
-    menuRef?: React.RefObject<HTMLDivElement | null>
 }) => {
-    useEffect(() => {
-        if (shouldScrollIntoView && isActive && menuRef?.current) {
-            const menuBottomOffset =
-                menuRef.current.getBoundingClientRect().bottom
-
-            // put bottom of the menu at the bottom of the viewport if it's offscreen
-            if (menuBottomOffset > window.innerHeight) {
-                window.scrollTo({
-                    top: menuBottomOffset - window.innerHeight + window.scrollY,
-                    behavior: getPrefersReducedMotion() ? "auto" : "smooth",
-                })
-            }
-        }
-    }, [shouldScrollIntoView, menuRef, isActive])
-
     return (
         <div
             className={cx("SiteNavigationToggle", className, {


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

The mobile site menu's collapsible sections (topic areas, Resources, About) are now native `<details>`/`<summary>` elements instead of button toggles backed by React state. They all share one `name` attribute, so the browser enforces the one-open-at-a-time accordion natively, and the `activeArea`/`menu` state plumbing is gone.

Two things worth knowing:

- **Browser support**: the exclusive-accordion behavior of `<details name>` needs Chrome 120+ / Safari 17.2+ / Firefox 130+, which is above our targets in `docs/browser-support.md`. This degrades gracefully — in older browsers sections still expand and collapse, they just don't auto-close each other. If we're happy with that trade-off, I'd add a line to `browser-support.md` on merge.
- **Small behavior change**: topic areas and Resources/About used to be independently collapsible (one of each could be open); now they're all in one exclusive group. Also, an area only scrolls into view on expand if it isn't already fully visible, instead of always.

<details><summary>Details</summary>

## Implementation notes

- `site/SiteMobileArea.tsx` — each topic area is an uncontrolled `<details>`; the scroll-into-view on expand moved from a `useEffect` into the native `toggle` event handler and now first checks whether the expanded element is already fully inside the viewport (a plain bounds check suffices since the site header isn't fixed/sticky).
- `site/SiteMobileMenu.tsx` — Resources and About are `<details>` in the same name group; opening one still scrolls the menu bottom into view when it's offscreen (also via the `toggle` event). The `menu`/`toggleMenu` props are removed since the sections no longer touch navigation-level state.
- `site/SiteConstants.ts` — the shared name lives here as `MOBILE_MENU_DETAILS_NAME` (it can't live in `SiteMobileMenu.tsx` without an import cycle with `SiteMobileArea.tsx`), with a comment documenting the exclusive-accordion semantics and support caveat.
- `site/SiteNavigationToggle.tsx` — dropped the now-unused `shouldScrollIntoView`/`menuRef` props and their effect; the mobile menu was their only consumer. Desktop nav is otherwise untouched.
- SCSS — `SiteMobileMenu.scss`/`SiteMobileArea.scss` style `summary` directly (marker hidden, pointer cursor) and use `details[open]` for the active color/background and caret rotation, replacing the `.active` class and the JS caret-icon swap.

## Accessibility

The old aria-labels ("Expand X", "Toggle resources menu") are intentionally dropped: `<summary>` has an implicit button role and screen readers announce expanded/collapsed natively, so the visible text is the right accessible name.

Section content is now always in the DOM (hidden by the closed `<details>`), which lets Chrome's find-in-page auto-expand a matching section.

## Test plan

Verified with Playwright against the dev server at 390×844:

- all 12 `<details>` share one name; opening any one closes whatever else was open, across the areas/sections boundary
- expanding an area that fits on screen no longer scrolls (`scrollY` stays put); expanding one that extends past the bottom edge still scrolls it into view
- screenshots confirm the active highlight, caret flip, and indentation match the previous design
- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` all pass

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)