### PR TITLE
🔨🤖 drop the dead cssUrl path from bespoke components

### DIFF
--- a/bespoke/readme.md
+++ b/bespoke/readme.md
@@ -52,14 +52,13 @@ export const BESPOKE_COMPONENT_REGISTRY: Record<
 > = {
     "income-plots": {
         scriptUrl: "/income-plots/index.js",
-        cssUrl: "/income-plots/index.css", // optional
     },
 }
 ```
 
-The URLs are resolved against `BESPOKE_BASE_URL` (defaults to the local dev server, `http://localhost:8089`).
+The URL is resolved against `BESPOKE_BASE_URL` (defaults to the local dev server, `http://localhost:8089`).
 
-The `cssUrl` is optional — if your component manages its own styles (e.g. via `vite-plugin-css-position` injecting CSS into the Shadow DOM from JS), you can omit it.
+A bundle carries its own styles. `vite-plugin-css-position` inlines them into the ES module so they land inside the shadow root.
 
 ## Embedding in Google Docs
 
@@ -180,14 +179,14 @@ Each project under `bespoke/projects/` is fully self-contained. A project has it
 This means each project is responsible for:
 
 - Managing its own dependencies (projects are yarn workspaces of `bespoke/` — run `yarn install` from there)
-- Defining its own build command that produces the ES-module output (and optionally a CSS file)
+- Defining its own build command that produces the ES-module output, with its styles bundled in
 - Bundling everything it needs — shared site styles, fonts, etc. are not available inside the Shadow DOM
 
 Projects can import shared code from `bespoke/components/` if needed, but must bundle it into their output.
 
 ### Build setup
 
-Projects use [Vite library mode](https://vite.dev/guide/build.html#library-mode) to produce the ESM module and optionally a CSS file. A minimal `vite.config.ts`:
+Projects use [Vite library mode](https://vite.dev/guide/build.html#library-mode) to produce the ESM module. A minimal `vite.config.ts`:
 
 ```ts
 import { defineConfig } from "vite"
@@ -296,7 +295,6 @@ To fix this, add a `dev-only-global-css` entrypoint to your project's `package.j
 {
     "entrypoints": {
         "js": "src/index.tsx",
-        "css": "src/index.css", // optional
         "dev-only-global-css": "src/dev-only-global-css.css"
     }
 }
@@ -307,7 +305,7 @@ The dev server will inject this stylesheet into the demo page's `<head>` (outsid
 ## Creating a new bespoke component
 
 1. Create a new directory under `bespoke/projects/`
-2. Set up your project with its own `package.json` and build tooling to output an ESM module (`.mjs`) and optionally a CSS file
+2. Set up your project with its own `package.json` and build tooling to output an ESM module (`.mjs`) with its styles bundled in
 3. Export a `mount` function from the entry point
 4. Register the bundle in [site/bespokeComponentRegistry.ts](../site/bespokeComponentRegistry.ts)
 5. Add the `{.bespoke-component}` block in your Google Doc

--- a/bespoke/server/component-demo.html
+++ b/bespoke/server/component-demo.html
@@ -80,7 +80,6 @@
                     mountBespokeComponentInShadow({
                         container,
                         scriptUrl: "/{{PROJECT}}/{{ENTRYPOINT_JS}}",
-                        cssUrl: "{{CSS_URL}}" || undefined,
                         variant: variant.name,
                         config: variant.demoConfig,
                     })

--- a/bespoke/server/devServer.ts
+++ b/bespoke/server/devServer.ts
@@ -345,13 +345,6 @@ function serveDemoPage(
     const jsEntrypoint = BUILD_MODE
         ? "index.js"
         : (entrypoints?.js ?? "src/index.ts")
-    const cssUrl = BUILD_MODE
-        ? entrypoints?.css
-            ? `/${projectName}/index.css`
-            : ""
-        : entrypoints?.css
-          ? `/${projectName}/${entrypoints.css}`
-          : ""
     const viteDevScripts = BUILD_MODE
         ? ""
         : `<script type="module">
@@ -365,14 +358,13 @@ function serveDemoPage(
         .replaceAll("{{PROJECT}}", projectName)
         .replaceAll("{{VITE_DEV_SCRIPTS}}", viteDevScripts)
         .replaceAll("{{ENTRYPOINT_JS}}", jsEntrypoint)
-        .replaceAll("{{CSS_URL}}", cssUrl)
         .replaceAll("{{DEV_ONLY_GLOBAL_CSS}}", devOnlyGlobalCss)
     res.writeHead(200, { "Content-Type": "text/html" })
     res.end(html)
 }
 
 // Read the "entrypoints" field from a project's package.json,
-// mapping e.g. { js: "src/index.ts", css: "src/index.css" }
+// mapping e.g. { js: "src/index.ts" }
 function getProjectEntrypoints(
     projectName: string
 ): Record<string, string> | null {
@@ -388,11 +380,10 @@ function getProjectEntrypoints(
 // Map well-known filenames to the entrypoints key they correspond to
 const ENTRYPOINT_ALIASES: Record<string, string> = {
     "index.js": "js",
-    "index.css": "css",
 }
 
-// If the request is for /<project>/index.js or /<project>/index.css,
-// redirect to the actual source entrypoint so Vite can serve it
+// If the request is for /<project>/index.js, redirect to the actual
+// source entrypoint so Vite can serve it
 function tryEntrypointRedirect(
     projectName: string,
     pathname: string,
@@ -510,9 +501,9 @@ const server = http.createServer(
             return
         }
 
-        // In dev mode, redirect /<project>/index.js and /<project>/index.css
-        // to actual source entrypoints so Vite can serve them.
-        // In build mode, these files exist as-is in dist/, so no redirect needed.
+        // In dev mode, redirect /<project>/index.js to the actual source
+        // entrypoint so Vite can serve it.
+        // In build mode, that file exists as-is in dist/, so no redirect needed.
         if (
             !BUILD_MODE &&
             tryEntrypointRedirect(

--- a/bespoke/server/readme.md
+++ b/bespoke/server/readme.md
@@ -28,7 +28,7 @@ Pass `--build` to build each project before serving it via `vite preview` instea
 yarn startBespokeDevServer --build
 ```
 
-In build mode, the demo page uses the built output files (`index.js`, `index.css`) instead of source entrypoints. The `/__bespoke/` Vite instance still runs in dev mode to serve the demo infrastructure.
+In build mode, the demo page uses the built output file (`index.js`) instead of the source entrypoint. The `/__bespoke/` Vite instance still runs in dev mode to serve the demo infrastructure.
 
 ### Demo page
 
@@ -43,15 +43,14 @@ The demo page reads the `entrypoints` field from each project's `package.json` t
 ```json
 {
     "entrypoints": {
-        "js": "src/index.ts",
-        "css": "src/index.css" // optional
+        "js": "src/index.ts"
     }
 }
 ```
 
-Only `js` is required. If `css` is omitted, the demo page won't load a separate stylesheet — useful when your component injects its own styles via `vite-plugin-css-position`, which is recommended.
+The demo page never loads a separate stylesheet: a project bundles its styles into the module with `vite-plugin-css-position`, so they land inside the Shadow DOM.
 
-In dev mode, requests for `/<project>/index.js` and `/<project>/index.css` are redirected to the corresponding source entrypoints so Vite can serve them. In build mode, these files exist as-is in the build output.
+In dev mode, requests for `/<project>/index.js` are redirected to the source entrypoint so Vite can serve it. In build mode, that file exists as-is in the build output.
 
 ## Staging
 

--- a/bespoke/shared/bespokeComponentShadowDom.ts
+++ b/bespoke/shared/bespokeComponentShadowDom.ts
@@ -1,28 +1,10 @@
 import type { BespokeComponentModule } from "./bespokeComponentTypes.ts"
 
 /**
- * Load a CSS stylesheet into a shadow root by appending a <link> element.
- * Resolves when the stylesheet has finished loading.
- */
-export function loadCssIntoShadow(
-    shadowRoot: ShadowRoot,
-    cssUrl: string
-): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-        const link = document.createElement("link")
-        link.rel = "stylesheet"
-        link.href = cssUrl
-        link.onload = () => resolve()
-        link.onerror = () => reject(new Error(`Failed to load CSS: ${cssUrl}`))
-        shadowRoot.appendChild(link)
-    })
-}
-
-/**
  * Mount a bespoke component into a shadow DOM container.
  *
- * Creates (or reuses) a shadow root on the given element, loads the CSS,
- * dynamically imports the JS module, and calls its `mount` function.
+ * Creates (or reuses) a shadow root on the given element, dynamically imports
+ * the JS module, and calls its `mount` function.
  *
  * Returns a dispose function that cleans up the mounted component.
  * Respects the provided AbortSignal to cancel mid-flight.
@@ -30,14 +12,12 @@ export function loadCssIntoShadow(
 export async function mountBespokeComponentInShadow({
     container,
     scriptUrl,
-    cssUrl,
     variant,
     config,
     signal,
 }: {
     container: HTMLDivElement
     scriptUrl: string
-    cssUrl?: string
     variant?: string
     config?: Record<string, string>
     signal?: AbortSignal
@@ -48,18 +28,10 @@ export async function mountBespokeComponentInShadow({
     }
     shadowRoot.replaceChildren()
 
-    const promises = []
-    if (cssUrl) {
-        promises.push(loadCssIntoShadow(shadowRoot, cssUrl))
-    }
-    const jsPromise = import(
+    const module = (await import(
         /* @vite-ignore */
         scriptUrl
-    ) as Promise<BespokeComponentModule>
-    promises.push(jsPromise)
-
-    await Promise.all(promises)
-    const module = await jsPromise
+    )) as BespokeComponentModule
 
     if (signal?.aborted) return {}
 

--- a/bespoke/shared/bespokeComponentTypes.ts
+++ b/bespoke/shared/bespokeComponentTypes.ts
@@ -29,6 +29,4 @@ export type BespokeComponentVariantsList<VariantName extends string = string> =
 export interface BespokeComponentDefinition {
     /** URL to the ES module that exports the component's mount function */
     scriptUrl: string
-    /** URL to the component's CSS stylesheet (loaded into shadow DOM) */
-    cssUrl?: string
 }

--- a/settings/clientSettings.ts
+++ b/settings/clientSettings.ts
@@ -131,8 +131,8 @@ export const SLACK_DI_PITCHES_CHANNEL_ID: string =
 
 export const IS_RUNNING_INSIDE_VITEST: boolean = !!process.env.VITEST
 
-// Base URL for bespoke component assets. When set, scriptUrl and cssUrl from
-// the bespoke component registry are resolved relative to this URL instead of
+// Base URL for bespoke component assets. When set, the scriptUrl from the
+// bespoke component registry is resolved relative to this URL instead of
 // the current origin. Useful for pointing to the bespoke dev server during
 // local development (e.g. "http://localhost:8089").
 export const BESPOKE_BASE_URL: string =

--- a/site/gdocs/components/BespokeComponent.tsx
+++ b/site/gdocs/components/BespokeComponent.tsx
@@ -24,7 +24,7 @@ const makeAbsoluteWithBaseUrl = (url: string, baseUrl: string | undefined) => {
  *
  * This is not a normal React component - it renders client-only and mounts
  * an external ES module into a Shadow DOM. This allows embedding
- * independently-built components that have their own bundled JS and CSS,
+ * independently-built components that bundle their own JS and CSS,
  * isolated from the rest of the page styles.
  *
  * On the server, this renders an empty div. On the client, useEffect dynamically
@@ -57,19 +57,9 @@ export function BespokeComponent({
         [block.bundle]
     )
 
-    const { scriptUrl, cssUrl } = useMemo(() => {
-        if (!definition || !BESPOKE_BASE_URL.trim())
-            return { scriptUrl: undefined, cssUrl: undefined }
-
-        return {
-            scriptUrl: makeAbsoluteWithBaseUrl(
-                definition.scriptUrl,
-                BESPOKE_BASE_URL
-            ),
-            cssUrl:
-                definition.cssUrl &&
-                makeAbsoluteWithBaseUrl(definition.cssUrl, BESPOKE_BASE_URL),
-        }
+    const scriptUrl = useMemo(() => {
+        if (!definition || !BESPOKE_BASE_URL.trim()) return undefined
+        return makeAbsoluteWithBaseUrl(definition.scriptUrl, BESPOKE_BASE_URL)
     }, [definition])
 
     useEffect(() => {
@@ -93,7 +83,6 @@ export function BespokeComponent({
         mountBespokeComponentInShadow({
             container,
             scriptUrl,
-            cssUrl,
             variant: block.variant,
             config: block.config,
             signal: abortController.signal,
@@ -124,14 +113,7 @@ export function BespokeComponent({
             }
             container.shadowRoot?.replaceChildren()
         }
-    }, [
-        block.bundle,
-        block.variant,
-        block.config,
-        definition,
-        scriptUrl,
-        cssUrl,
-    ])
+    }, [block.bundle, block.variant, block.config, definition, scriptUrl])
 
     if (error) {
         return <BespokeError className={className} message={error} />


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

A bespoke component's registry entry could name a stylesheet URL, which the mount chain would load into the shadow root before importing the module. We're not using it. Styles get inside the shadow root by a different route: `vite-plugin-css-position` inlines them into the ES module.

I am removing it now because I am about to add a `metadataUrl` to the same interface for the featured viz methods block.