### PR TITLE
Lazy-mount bespoke components via IntersectionObserver

### DIFF
--- a/site/gdocs/components/BespokeComponent.tsx
+++ b/site/gdocs/components/BespokeComponent.tsx
@@ -2,6 +2,7 @@ import { EnrichedBlockBespokeComponent } from "@ourworldindata/types"
 import { LoadingIndicator } from "@ourworldindata/components"
 import cx from "clsx"
 import { useEffect, useMemo, useRef, useState } from "react"
+import { useIntersectionObserver } from "usehooks-ts"
 import { BESPOKE_COMPONENT_REGISTRY } from "../../bespokeComponentRegistry.js"
 import { mountBespokeComponentInShadow } from "../../../bespoke/shared/bespokeComponentShadowDom.js"
 import { BESPOKE_BASE_URL } from "../../../settings/clientSettings.js"
@@ -52,6 +53,13 @@ export function BespokeComponent({
     const [isLoading, setIsLoading] = useState(true)
     const [error, setError] = useState<string | null>(null)
 
+    // Defer loading the component's JS until it approaches the viewport
+    const { ref: intersectionRef, isIntersecting: hasBeenVisible } =
+        useIntersectionObserver({
+            rootMargin: "400px",
+            freezeOnceVisible: true,
+        })
+
     const definition = useMemo(
         () => BESPOKE_COMPONENT_REGISTRY[block.bundle],
         [block.bundle]
@@ -63,6 +71,8 @@ export function BespokeComponent({
     }, [definition])
 
     useEffect(() => {
+        if (!hasBeenVisible) return
+
         const container = containerRef.current
         if (!container) return
 
@@ -113,14 +123,21 @@ export function BespokeComponent({
             }
             container.shadowRoot?.replaceChildren()
         }
-    }, [block.bundle, block.variant, block.config, definition, scriptUrl])
+    }, [
+        block.bundle,
+        block.variant,
+        block.config,
+        definition,
+        scriptUrl,
+        hasBeenVisible,
+    ])
 
     if (error) {
         return <BespokeError className={className} message={error} />
     }
 
     return (
-        <div className={className}>
+        <div className={className} ref={intersectionRef}>
             {isLoading && <LoadingIndicator />}
             <div ref={containerRef}></div>
         </div>

--- a/site/gdocs/components/KeyInsights.test.tsx
+++ b/site/gdocs/components/KeyInsights.test.tsx
@@ -20,11 +20,25 @@ import * as _ from "lodash-es"
 
 const KEY_INSIGHTS_SLUG = "key-insights"
 
-//from https://stackoverflow.com/a/62148101
+// Mock that reports every observed element as immediately intersecting,
+// so lazily-mounted components (e.g. BespokeComponent) render right away
 beforeAll(() => {
     const IntersectionObserverMock = class IntersectionObserverMock {
+        constructor(private readonly callback: IntersectionObserverCallback) {}
+        thresholds = [0]
         disconnect = vi.fn()
-        observe = vi.fn()
+        observe = vi.fn((target: Element) => {
+            this.callback(
+                [
+                    {
+                        target,
+                        isIntersecting: true,
+                        intersectionRatio: 1,
+                    } as IntersectionObserverEntry,
+                ],
+                this as unknown as IntersectionObserver
+            )
+        })
         unobserve = vi.fn()
     }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

We probably should've done this from the beginning - only load & mount the bespoke component (in a gdoc) once it nears the viewport.

## How to test this:
1. Set a breakpoint at the beginning of `bespokeComponentShadowDom.ts#mountBespokeComponentInShadow`, it should only fire once the component becomes visible.
2. Then, go to these pages to test:
    - [Child mortality](http://staging-site-bespoke-viz-intersection-obs/child-mortality), here the bespoke component is inside the fourth key insight ("Most children die from preventable causes")
    - [Migration](http://staging-site-bespoke-viz-intersection-obs/migration), here you need to scroll quite a bit down until you reach the bespoke viz.
    - [This South Korea article](http://staging-site-bespoke-viz-intersection-obs/south-koreas-population-is-set-to-shrink-what-would-it-take-to-stop-the-decline) has 8 bespoke components overall, they should all load one-after-another.

Note that the first load can take a while on staging servers (it's way better on prod), so if it takes really long, just try and reload the page.

<details><summary>Details</summary>

- `site/gdocs/components/BespokeComponent.tsx`: added `useIntersectionObserver` from `usehooks-ts` (already a site dependency); its ref sits on the outer wrapper div, and the mount effect returns early until `hasBeenVisible` is true. `hasBeenVisible` was added to the effect's dependency array so mounting runs once the block nears the viewport.
- Because `freezeOnceVisible: true` is set, scrolling away after mount does not unmount the component.
- Error states (unknown bundle, failed script/CSS load) now only surface once the block is near the viewport, since nothing is attempted before then. The loading indicator still renders in place beforehand, as it did before this change.
- Verified with `yarn typecheck`, `yarn testLintChanged`, and `yarn testFormatChanged`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)