### PR TITLE
✨🤖 (colour-legends) drop the numeric legend's touch layer from static exports

### DIFF
--- a/packages/@ourworldindata/grapher/src/legend/HorizontalNumericColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalNumericColorLegend.tsx
@@ -35,6 +35,7 @@ interface HorizontalNumericColorLegendProps {
     onMouseOver?: (bin: ColorScaleBin) => void
     onMouseLeave?: () => void
     onTouchSelect?: (bin: ColorScaleBin) => void
+    isStatic?: boolean
 }
 
 export function HorizontalNumericColorLegend(
@@ -50,6 +51,7 @@ export function HorizontalNumericColorLegend(
         onMouseOver,
         onMouseLeave,
         onTouchSelect,
+        isStatic,
     } = props
     const {
         numericLabels,
@@ -135,6 +137,8 @@ export function HorizontalNumericColorLegend(
         )
     }
 
+    const showTouchHitAreas = !isStatic && !!onTouchSelect
+
     return (
         <g
             id={makeFigmaId("numeric-color-legend")}
@@ -205,7 +209,7 @@ export function HorizontalNumericColorLegend(
                     )
                 })}
             </g>
-            {onTouchSelect && (
+            {showTouchHitAreas && (
                 // Add invisible hit areas above each swatch for touch interaction.
                 // They are the height of the legend labels, and only handle touch events.
                 <g id={makeFigmaId("swatch-hit-areas")} aria-hidden="true">

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -652,6 +652,7 @@ export class MapChart
                         onMouseOver={this.onLegendMouseOver}
                         onMouseLeave={this.onLegendMouseLeave}
                         onTouchSelect={this.onLegendTouchSelect}
+                        isStatic={this.isStatic}
                     />
                 )}
                 {categoryLegendState && (


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

The numeric colour legend draws an invisible hit area above each swatch so a touch can select a bin, gated only on whether the caller passed `onTouchSelect`. Its categorical sibling takes `isStatic` and drops the equivalent layer entirely, so a static map export has been carrying touch targets from one legend and not the other. `MapChart` is the only caller that passes `onTouchSelect` here, and it already passed `isStatic` to the categorical legend three lines below.

- **Behaviour change.** 2128 reference SVGs lose their `swatch-hit-areas` group, around 1 KB each. That markup ships on every static map thumbnail we serve, so this is a small size win and not only test churn. Nothing renders differently: I exported [human-development-index](http://staging-site-legend-touch/grapher/human-development-index) with and without the change, and that group is the only difference between the two files.
- The references had already drifted from master before this branch. A fresh export also picks up the `inapplicablePattern` defs from the `inapplicableEntities` work, so the regenerated diff will not read as purely hit-areas.
- The visible bin rects still get hover handlers attached when static, which neither of the other two legends does. React handlers are not serialised, so it makes no difference to the output, and I would rather not add churn to a branch whose whole point is a controlled output change.
- I gate on a named `showTouchHitAreas` instead of inlining `!isStatic && onTouchSelect &&` the way the sibling legends inline their single condition. With three operands oxfmt breaks the condition across lines and re-indents the whole block, which reads worse than the name does.