### PR TITLE
Auto-label issues opened by listed handles with "site"

### DIFF
--- a/.github/workflows/project-automations.yml
+++ b/.github/workflows/project-automations.yml
@@ -53,3 +53,18 @@ jobs:
         with:
           add-labels: "staging-viz"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+  site_label:
+    name: Add "site" label to site team's issues
+    runs-on: ubuntu-latest
+    # To have your own new issues labelled "site", add your GitHub handle to
+    # the list below.
+    if: >
+      github.event_name == 'issues' && github.event.action == 'opened' &&
+      contains(fromJSON('["mlbrgl"]'), github.actor)
+    permissions:
+      issues: write
+    steps:
+      - uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
+        with:
+          add-labels: "site"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> _Written by Claude Opus 5 — @mlbrgl at the wheel._

Adds a `site_label` job to `project-automations.yml`, modelled on the existing `staging_viz` job: issues opened by a handle in the list get the `site` label automatically.

The handle list is a JSON array (`contains(fromJSON('["mlbrgl"]'), github.actor)`) rather than a `==` comparison, so anyone who wants the same for their issues just adds `, "theirhandle"` inside the brackets.

Two caveats: it only fires on `opened`, and it keys on the issue opener (`github.actor`), not the assignee — so an issue someone else files for you will not get labelled.

<details><summary>Details</summary>

- Job is gated with `github.event_name == 'issues' && github.event.action == 'opened'`, so the `labeled`/`unlabeled` triggers already on the workflow cannot cause a loop.
- Scoped `permissions: issues: write` at the job level, matching the other label jobs; the workflow keeps `permissions: {}` at the top level.
- Reuses the already-pinned `andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4` SHA, so pinact stays happy.
- Verified the file still parses as YAML and that the `if` expression resolves to the intended single-line expression.
- No TS/SCSS touched, so format/lint/typecheck are unaffected.

</details>