### PR TITLE
Remove stale PNG type from <Image>'s <source>

### DIFF
--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -193,7 +193,6 @@ export default function Image(props: {
                     <source
                         key={i}
                         {...props}
-                        type="image/png"
                         sizes={
                             containerSizes[containerType] ??
                             containerSizes.default


### PR DESCRIPTION
> _Written by OpenAI GPT-5 — @marcelgerber at the wheel._

Remove the hard-coded `image/png` type from responsive image sources. Cloudflare Images negotiates the response format from the request, so declaring every source as PNG is inaccurate.

<details><summary>Details</summary>

- Leaves the existing responsive `srcSet`, `sizes`, and media selection unchanged.
- Allows the browser and Cloudflare Images to negotiate the actual image format without a conflicting MIME hint.

Tests:
- `yarn fixFormatChanged`
- `yarn typecheck`
- `yarn testLintChanged`

</details>