### PR TITLE
🚧 test: nav red again, to check the screenshot diff reporting

### DIFF
--- a/site/SiteNavigation.scss
+++ b/site/SiteNavigation.scss
@@ -9,7 +9,7 @@
     position: relative;
     z-index: $zindex-lightbox;
     border-bottom: $header-border-height solid $vermillion;
-    background-color: $oxford-blue;
+    background-color: $vermillion;
 
     @include sm-only {
         .wrapper {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

**Not for merge.** The same one-line change as #7061 (`.site-navigation` navy → vermillion), replayed on current master to check that owid/ops#640 and owid/etl#6761 work end to end.

New branch rather than a rebase of #7061 on purpose: owidbot runs on the staging container, from the etl clone made when that container was created, and #7061's container predates the etl merge. A fresh branch gets a fresh container, so no manual deploy is involved.

What to look for in owidbot's comment on this PR: **⚠️ 7 pages changed** on the Site-screenshots line, instead of the ✅ that a branch changing nothing would also get. The diff itself should again be rows 0–71 of every page and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
