### PR TITLE
🐛🤖 stop reporting unchecked charts as visible changes

### DIFF
--- a/adminSiteClient/SvgTesterSuitePage.scss
+++ b/adminSiteClient/SvgTesterSuitePage.scss
@@ -158,8 +158,15 @@ $svg-tester-error-frame: #dda4a0;
     }
 }
 
-.SvgTesterSuitePage__chart-type {
+.SvgTesterSuitePage__chart-type,
+.SvgTesterSuitePage__status {
     margin-left: 8px;
+}
+
+// The chart type beside it is neutral, so the one status that is a finding
+// needs the weight the headline gives its numbers
+.SvgTesterSuitePage__status.is-changed {
+    font-weight: bold;
 }
 
 .SvgTesterQueryParams {

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -42,6 +42,7 @@ import pMap from "p-map"
 import {
     compareSvgsVisually,
     encodeVerdicts,
+    groupByVisualVerdict,
     readVerdicts,
     VISUAL_DIFF_CONCURRENCY,
     type VisualVerdict,
@@ -187,17 +188,10 @@ export function SvgTesterSuitePage() {
 
     const applied = verdictBySvg ?? NO_VISUAL_RESULTS
 
-    const grouped = useMemo(() => {
-        const byVerdict = _.groupBy(
-            visible,
-            (entry) => applied[entry.svgFilename] ?? "changed"
-        )
-        return {
-            changed: byVerdict.changed ?? [],
-            unknown: byVerdict.unknown ?? [],
-            identical: byVerdict.identical ?? [],
-        }
-    }, [visible, applied])
+    const grouped = useMemo(
+        () => groupByVisualVerdict(visible, applied),
+        [visible, applied]
+    )
 
     const populatedVerdicts = VISUAL_VERDICTS.filter(
         (verdict) => grouped[verdict].length > 0

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -42,9 +42,11 @@ import pMap from "p-map"
 import {
     compareSvgsVisually,
     encodeVerdicts,
-    groupByVisualVerdict,
+    groupByVisualStatus,
     readVerdicts,
     VISUAL_DIFF_CONCURRENCY,
+    VISUAL_STATUSES,
+    type VisualStatus,
     type VisualVerdict,
     writeVerdicts,
 } from "./svgVisualDiff.js"
@@ -68,19 +70,15 @@ const KIND_LABELS: Record<SvgTesterVerifyErrorEntry["kind"], string> = {
 
 const CHART_TYPE_PARAM = "chartType"
 
-/** Ordered as the list shows them: what to review first comes first */
-const VISUAL_VERDICT_LABELS: Record<VisualVerdict, string> = {
+const VISUAL_STATUS_LABELS: Record<VisualStatus, string> = {
     changed: "Visible change",
     unknown: "Couldn't check",
+    pending: "Not checked yet",
     identical: "No visible change",
 }
 
-const VISUAL_VERDICTS = Object.keys(VISUAL_VERDICT_LABELS) as VisualVerdict[]
-
 /** Which differences to list, once we know which ones only changed in markup */
-type VisualFilter = VisualVerdict | "all"
-
-const DEFAULT_VISUAL_FILTER: VisualFilter = "changed"
+type VisualFilter = VisualStatus | "all"
 
 /** How many of a run's differences turned out to be markup-only */
 interface VisualSummary {
@@ -126,9 +124,8 @@ export function SvgTesterSuitePage() {
 
     // Not in the URL, unlike the chart type: which differences render
     // identically is only known once this session has checked them
-    const [visualFilter, setVisualFilter] = useState<VisualFilter>(
-        DEFAULT_VISUAL_FILTER
-    )
+    // Unset until the reader picks one, so the default can follow the check
+    const [visualFilter, setVisualFilter] = useState<VisualFilter>()
 
     const { data, isLoading, isError, dataUpdatedAt } = useQuery({
         queryKey: ["svgtester-results", suite],
@@ -189,20 +186,20 @@ export function SvgTesterSuitePage() {
     const applied = verdictBySvg ?? NO_VISUAL_RESULTS
 
     const grouped = useMemo(
-        () => groupByVisualVerdict(visible, applied),
+        () => groupByVisualStatus(visible, applied),
         [visible, applied]
     )
 
-    const populatedVerdicts = VISUAL_VERDICTS.filter(
-        (verdict) => grouped[verdict].length > 0
+    const populatedStatuses = VISUAL_STATUSES.filter(
+        (status) => grouped[status].length > 0
     )
     // Nothing to filter when every difference is in the same bucket
-    const showVisualFilter = populatedVerdicts.length > 1
+    const showVisualFilter = populatedStatuses.length > 1
 
     const visualFilterOptions = [
-        ...populatedVerdicts.map((verdict) => ({
-            value: verdict,
-            label: `${VISUAL_VERDICT_LABELS[verdict]} (${grouped[verdict].length.toLocaleString()})`,
+        ...populatedStatuses.map((status) => ({
+            value: status,
+            label: `${VISUAL_STATUS_LABELS[status]} (${grouped[status].length.toLocaleString()})`,
         })),
         {
             value: "all" as const,
@@ -210,32 +207,42 @@ export function SvgTesterSuitePage() {
         },
     ]
 
-    // The selection sticks, so it can name a bucket since emptied
+    // What is worth reading moves as the check runs: the charts nobody has
+    // looked at yet while it is going, the ones that changed once it is done.
+    // The reader's own choice, once made, outranks both — and sticks, so it can
+    // name a bucket since emptied.
+    const wantedVisualFilter =
+        visualFilter ?? (isComplete ? "changed" : "pending")
     const effectiveVisualFilter: VisualFilter = visualFilterOptions.some(
-        (option) => option.value === visualFilter
+        (option) => option.value === wantedVisualFilter
     )
-        ? visualFilter
+        ? wantedVisualFilter
         : "all"
 
+    // Paired with the bucket each one was drawn from, so a card cannot label
+    // itself as something other than what it is listed under
     const shown = useMemo(
         () =>
-            effectiveVisualFilter === "all"
-                ? VISUAL_VERDICTS.flatMap((verdict) => grouped[verdict])
-                : grouped[effectiveVisualFilter],
+            (effectiveVisualFilter === "all"
+                ? VISUAL_STATUSES
+                : [effectiveVisualFilter]
+            ).flatMap((status) =>
+                grouped[status].map((entry) => ({ entry, status }))
+            ),
         [effectiveVisualFilter, grouped]
     )
 
     const cards = useMemo(
         () =>
-            shown.map((entry) => (
+            shown.map(({ entry, status }) => (
                 <DifferenceCard
                     key={anchorId(entry.viewId, entry.queryStr)}
                     suite={suite}
                     entry={entry}
-                    verdict={applied[entry.svgFilename] ?? "changed"}
+                    status={status}
                 />
             )),
-        [shown, suite, applied]
+        [shown, suite]
     )
 
     const visualSummary = differences.length
@@ -627,11 +634,11 @@ function CommitLabel({
 function DifferenceCard({
     suite,
     entry,
-    verdict,
+    status,
 }: {
     suite: string
     entry: SvgTesterVerifyDifferenceEntry
-    verdict: VisualVerdict
+    status: VisualStatus
 }) {
     const [mode, setMode] = useState<ViewMode>("side-by-side")
     const beforeUrl = svgUrl(suite, "references", entry)
@@ -666,16 +673,16 @@ function DifferenceCard({
                             {entry.chartType}
                         </Tag>
                     )}
-                    {verdict !== "changed" && (
+                    {status !== "changed" && (
                         <Tag
                             className="SvgTesterSuitePage__chart-type"
                             title={
-                                verdict === "unknown"
+                                status === "unknown"
                                     ? "This chart's pixels can't be read — an embedded <foreignObject> taints the canvas — so it may not have changed at all"
                                     : undefined
                             }
                         >
-                            {VISUAL_VERDICT_LABELS[verdict]}
+                            {VISUAL_STATUS_LABELS[status]}
                         </Tag>
                     )}
                 </span>

--- a/adminSiteClient/SvgTesterSuitePage.tsx
+++ b/adminSiteClient/SvgTesterSuitePage.tsx
@@ -77,6 +77,13 @@ const VISUAL_STATUS_LABELS: Record<VisualStatus, string> = {
     identical: "No visible change",
 }
 
+/** Only where the label leaves a question, which is where the check has no answer */
+const VISUAL_STATUS_HINTS: Partial<Record<VisualStatus, string>> = {
+    unknown:
+        "This chart's pixels can't be read — an embedded <foreignObject> taints the canvas — so it may not have changed at all",
+    pending: "The check hasn't got to this chart yet",
+}
+
 /** Which differences to list, once we know which ones only changed in markup */
 type VisualFilter = VisualStatus | "all"
 
@@ -673,18 +680,14 @@ function DifferenceCard({
                             {entry.chartType}
                         </Tag>
                     )}
-                    {status !== "changed" && (
-                        <Tag
-                            className="SvgTesterSuitePage__chart-type"
-                            title={
-                                status === "unknown"
-                                    ? "This chart's pixels can't be read — an embedded <foreignObject> taints the canvas — so it may not have changed at all"
-                                    : undefined
-                            }
-                        >
-                            {VISUAL_STATUS_LABELS[status]}
-                        </Tag>
-                    )}
+                    <Tag
+                        className={cx("SvgTesterSuitePage__status", {
+                            "is-changed": status === "changed",
+                        })}
+                        title={VISUAL_STATUS_HINTS[status]}
+                    >
+                        {VISUAL_STATUS_LABELS[status]}
+                    </Tag>
                 </span>
                 <SvgTesterChartLinks entry={entry} />
             </header>

--- a/adminSiteClient/svgVisualDiff.test.ts
+++ b/adminSiteClient/svgVisualDiff.test.ts
@@ -3,7 +3,7 @@ import {
     createVisualDiffChecker,
     decodeVerdicts,
     encodeVerdicts,
-    groupByVisualVerdict,
+    groupByVisualStatus,
     LoadPixels,
     RasterizedSvg,
     type VisualVerdict,
@@ -135,11 +135,11 @@ describe("the visual diff checker", () => {
     })
 })
 
-describe("splitting differences by verdict", () => {
+describe("splitting differences by status", () => {
     const entry = (svgFilename: string) => ({ svgFilename })
 
     it("puts each difference in the bucket its verdict names", () => {
-        const grouped = groupByVisualVerdict(
+        const grouped = groupByVisualStatus(
             [entry("a.svg"), entry("b.svg"), entry("c.svg")],
             { "a.svg": "identical", "b.svg": "changed", "c.svg": "unknown" }
         )
@@ -147,10 +147,11 @@ describe("splitting differences by verdict", () => {
         expect(grouped.changed).toEqual([entry("b.svg")])
         expect(grouped.unknown).toEqual([entry("c.svg")])
         expect(grouped.identical).toEqual([entry("a.svg")])
+        expect(grouped.pending).toEqual([])
     })
 
     it("keeps the order the differences came in", () => {
-        const grouped = groupByVisualVerdict(
+        const grouped = groupByVisualStatus(
             [entry("a.svg"), entry("b.svg"), entry("c.svg")],
             { "a.svg": "changed", "b.svg": "identical", "c.svg": "changed" }
         )
@@ -158,16 +159,31 @@ describe("splitting differences by verdict", () => {
         expect(grouped.changed).toEqual([entry("a.svg"), entry("c.svg")])
     })
 
-    it("counts a difference nothing is known about yet as changed", () => {
-        const grouped = groupByVisualVerdict([entry("a.svg")], {})
+    it("leaves a difference nothing is known about yet out of the changed bucket", () => {
+        const grouped = groupByVisualStatus([entry("a.svg")], {})
 
-        expect(grouped.changed).toEqual([entry("a.svg")])
+        expect(grouped.pending).toEqual([entry("a.svg")])
+        expect(grouped.changed).toEqual([])
+    })
+
+    it("keeps an unfinished check out of the changed bucket entirely", () => {
+        const grouped = groupByVisualStatus([entry("a.svg"), entry("b.svg")], {
+            "a.svg": "identical",
+        })
+
+        expect(grouped.changed).toEqual([])
+        expect(grouped.pending).toEqual([entry("b.svg")])
     })
 
     it("names every bucket even when nothing landed in it", () => {
-        const grouped = groupByVisualVerdict([], {})
+        const grouped = groupByVisualStatus([], {})
 
-        expect(grouped).toEqual({ changed: [], unknown: [], identical: [] })
+        expect(grouped).toEqual({
+            changed: [],
+            unknown: [],
+            pending: [],
+            identical: [],
+        })
     })
 })
 

--- a/adminSiteClient/svgVisualDiff.test.ts
+++ b/adminSiteClient/svgVisualDiff.test.ts
@@ -3,6 +3,7 @@ import {
     createVisualDiffChecker,
     decodeVerdicts,
     encodeVerdicts,
+    groupByVisualVerdict,
     LoadPixels,
     RasterizedSvg,
     type VisualVerdict,
@@ -131,6 +132,42 @@ describe("the visual diff checker", () => {
         await runIdleWork()
         await expect(second).resolves.toBe("identical")
         expect(loads).toBe(4)
+    })
+})
+
+describe("splitting differences by verdict", () => {
+    const entry = (svgFilename: string) => ({ svgFilename })
+
+    it("puts each difference in the bucket its verdict names", () => {
+        const grouped = groupByVisualVerdict(
+            [entry("a.svg"), entry("b.svg"), entry("c.svg")],
+            { "a.svg": "identical", "b.svg": "changed", "c.svg": "unknown" }
+        )
+
+        expect(grouped.changed).toEqual([entry("b.svg")])
+        expect(grouped.unknown).toEqual([entry("c.svg")])
+        expect(grouped.identical).toEqual([entry("a.svg")])
+    })
+
+    it("keeps the order the differences came in", () => {
+        const grouped = groupByVisualVerdict(
+            [entry("a.svg"), entry("b.svg"), entry("c.svg")],
+            { "a.svg": "changed", "b.svg": "identical", "c.svg": "changed" }
+        )
+
+        expect(grouped.changed).toEqual([entry("a.svg"), entry("c.svg")])
+    })
+
+    it("counts a difference nothing is known about yet as changed", () => {
+        const grouped = groupByVisualVerdict([entry("a.svg")], {})
+
+        expect(grouped.changed).toEqual([entry("a.svg")])
+    })
+
+    it("names every bucket even when nothing landed in it", () => {
+        const grouped = groupByVisualVerdict([], {})
+
+        expect(grouped).toEqual({ changed: [], unknown: [], identical: [] })
     })
 })
 

--- a/adminSiteClient/svgVisualDiff.ts
+++ b/adminSiteClient/svgVisualDiff.ts
@@ -53,6 +53,25 @@ export type LoadPixels = (
  */
 export type VisualVerdict = "identical" | "changed" | "unknown"
 
+/**
+ * The differences split by what the pixel check came to, each bucket keeping the
+ * order the report lists them in. The buckets are declared review-first, which
+ * is the order the report walks them in.
+ */
+export function groupByVisualVerdict<T extends { svgFilename: string }>(
+    entries: T[],
+    verdicts: Record<string, VisualVerdict>
+): Record<VisualVerdict, T[]> {
+    const grouped: Record<VisualVerdict, T[]> = {
+        changed: [],
+        unknown: [],
+        identical: [],
+    }
+    for (const entry of entries)
+        grouped[verdicts[entry.svgFilename] ?? "changed"].push(entry)
+    return grouped
+}
+
 export function createVisualDiffChecker(loadPixels: LoadPixels): {
     /**
      * What the two SVGs' pixels came to. Never rejects, and never hangs, and

--- a/adminSiteClient/svgVisualDiff.ts
+++ b/adminSiteClient/svgVisualDiff.ts
@@ -54,21 +54,36 @@ export type LoadPixels = (
 export type VisualVerdict = "identical" | "changed" | "unknown"
 
 /**
- * The differences split by what the pixel check came to, each bucket keeping the
- * order the report lists them in. The buckets are declared review-first, which
- * is the order the report walks them in.
+ * What the report knows about a chart, which is a verdict or the absence of one.
+ * The check never concludes "pending", so it is a status and not a verdict: a
+ * chart nobody has looked at yet must not read as one that changed.
  */
-export function groupByVisualVerdict<T extends { svgFilename: string }>(
+export type VisualStatus = VisualVerdict | "pending"
+
+/** Review-first, and the order the report lists the differences in */
+export const VISUAL_STATUSES: VisualStatus[] = [
+    "changed",
+    "unknown",
+    "pending",
+    "identical",
+]
+
+/**
+ * The differences split by what the pixel check came to, each bucket keeping the
+ * order the report lists them in.
+ */
+export function groupByVisualStatus<T extends { svgFilename: string }>(
     entries: T[],
     verdicts: Record<string, VisualVerdict>
-): Record<VisualVerdict, T[]> {
-    const grouped: Record<VisualVerdict, T[]> = {
+): Record<VisualStatus, T[]> {
+    const grouped: Record<VisualStatus, T[]> = {
         changed: [],
         unknown: [],
+        pending: [],
         identical: [],
     }
     for (const entry of entries)
-        grouped[verdicts[entry.svgFilename] ?? "changed"].push(entry)
+        grouped[verdicts[entry.svgFilename] ?? "pending"].push(entry)
     return grouped
 }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

The SVG tester report called a chart a visible change before it had looked at it. A chart the pixel check hadn't reached fell back to `"changed"`, and the card's status badge only rendered for a status other than `"changed"`, so "I found a real difference" and "I haven't started yet" were the same thing on screen. A thumbnail run with 11 differences read as 10 visible changes, when 9 of them were pure element reorders nobody had checked yet.

- **Fix.** "Not checked yet" is a value in the type now, rather than a `??` fallback in two places. `VisualVerdict` keeps the three outcomes the pixel check can actually conclude, and a new `VisualStatus` adds `pending` on top for what the report knows. The split only goes one way on purpose, so nothing can write a `pending` into storage or return one from a comparison.
- **Behaviour change.** Every card carries a status tag now, including "Visible change", which used to be the unlabelled default. Bold rather than coloured, because red and green already mean reference and current in the swipe and overlay views.
- **Behaviour change.** The filter default follows the check instead of sitting at "changed". The unchecked charts while it runs, the changed ones once it finishes, and your own pick outranks both. Leaving it fixed at "changed" would collapse the list to a single card the moment the first real change came back, with hundreds still unchecked.
- I haven't opened the report in a browser, so the thing worth confirming is that the "Visible change" count starts at zero and grows, rather than starting at the total and shrinking.
- The first commit is a pure move of the bucketing out of the 1100 line component and into `svgVisualDiff.ts`, where a test can reach it. Reading it on its own makes the second commit the behaviour change and nothing else.
