### PR TITLE
Fix duplicate rules and other issues in our SCSS

### DIFF
--- a/adminSiteClient/FilesIndexPage.scss
+++ b/adminSiteClient/FilesIndexPage.scss
@@ -25,7 +25,6 @@
     padding: 12px;
     border-bottom: 1px solid #e5e5e5;
     background-color: transparent;
-    display: block;
     width: 100%;
     text-align: left;
     display: flex;

--- a/packages/@ourworldindata/components/src/styles/typography.scss
+++ b/packages/@ourworldindata/components/src/styles/typography.scss
@@ -344,15 +344,6 @@ body {
     @include body-1-regular-superscript;
 }
 
-@mixin body-1-bold {
-    @include body-1-regular;
-    font-weight: 700;
-}
-
-.body-1-bold {
-    @include body-1-bold;
-}
-
 @mixin body-2-regular {
     font-family: $sans-serif-font-stack;
     font-size: 1rem;

--- a/packages/@ourworldindata/explorer/src/Explorer.scss
+++ b/packages/@ourworldindata/explorer/src/Explorer.scss
@@ -102,8 +102,7 @@ html.IsInIframe .ExplorerFigure,
     display: grid;
     grid-template-columns: 1fr 4fr;
     grid-template-rows: 1fr 9fr;
-    grid-row-gap: $explorer-grid-gap;
-    grid-column-gap: $explorer-grid-gap;
+    gap: $explorer-grid-gap;
 
     &.HideControls {
         display: block;

--- a/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
+++ b/packages/@ourworldindata/grapher/src/controls/entityPicker/EntityPicker.scss
@@ -189,7 +189,6 @@ $zindex-dropdown: 100;
         border: none;
         background-color: #fff;
         border-radius: 3px;
-        border: none;
         box-shadow: $light-shadow;
         padding: 11px 10px;
         padding-left: 2em;

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
@@ -33,7 +33,7 @@
 
         .axis-label {
             text {
-                font: 400 10px Lato, sans-serif;
+                font: 400 10px $lato;
                 letter-spacing: 0.01em;
                 font-style: italic;
                 text-anchor: end;

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapTooltip.scss
@@ -33,7 +33,7 @@
 
         .axis-label {
             text {
-                font: 400 10px Lato;
+                font: 400 10px Lato, sans-serif;
                 letter-spacing: 0.01em;
                 font-style: italic;
                 text-anchor: end;

--- a/site/ExplorerIndexPage.scss
+++ b/site/ExplorerIndexPage.scss
@@ -25,7 +25,6 @@
         }
 
         .explorer-index-page__card {
-            display: block;
             height: 100%;
             padding: 8px;
             display: flex;

--- a/site/blocks/Grid.scss
+++ b/site/blocks/Grid.scss
@@ -1,11 +1,11 @@
 .wp-block-owid-grid {
     display: grid;
-    grid-gap: $vertical-spacing;
+    gap: $vertical-spacing;
     grid-template-columns: repeat(1, 1fr);
     margin: $vertical-spacing 0;
 
     @media (min-width: 30rem) {
-        grid-gap: $padding-x-sm;
+        gap: $padding-x-sm;
         grid-template-columns: repeat(2, 1fr);
     }
 

--- a/site/css/content.scss
+++ b/site/css/content.scss
@@ -150,7 +150,6 @@ figure[data-explorer-src] {
 
 .article-content {
     span.add-country {
-        font-size: 0.9rem;
         font: 400 13px/16px $sans-serif-font-stack;
         letter-spacing: 0.01em;
         display: inline-flex;

--- a/site/css/covid.scss
+++ b/site/css/covid.scss
@@ -1,7 +1,7 @@
 .article-content ul.covid-country-tiles {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
-    grid-gap: 0.5rem;
+    gap: 0.5rem;
     padding: 0;
     list-style-type: none;
 

--- a/site/css/donate.scss
+++ b/site/css/donate.scss
@@ -65,7 +65,7 @@
     .donation-options--grid {
         @include lg-down {
             display: grid;
-            grid-gap: 8px;
+            gap: 8px;
             grid-template-columns: repeat(3, 1fr);
             & > * {
                 margin-right: 0;

--- a/site/css/forms.scss
+++ b/site/css/forms.scss
@@ -18,7 +18,6 @@ $checkbox-check-height: 4px;
 %owid-checkbox {
     display: inline-block;
     position: relative;
-    padding-left: $checkbox-icon-size;
     padding-left: calc(#{$checkbox-icon-size} + 0.5rem);
     margin-bottom: 0.5rem;
 

--- a/site/css/forms.scss
+++ b/site/css/forms.scss
@@ -27,11 +27,11 @@ $checkbox-check-height: 4px;
         z-index: $zindex-input;
         top: 50%;
         left: 0;
+        margin: 0;
         margin-top: -6px;
         width: $checkbox-icon-size;
         height: $checkbox-icon-size;
         cursor: pointer;
-        margin: 0;
         opacity: 0;
     }
 

--- a/site/css/newsletter-subscription.scss
+++ b/site/css/newsletter-subscription.scss
@@ -79,7 +79,6 @@
 .newsletter-subscription-header {
     display: flex;
     flex-wrap: wrap;
-    align-items: flex-start;
     gap: 8px 16px;
     margin-bottom: 8px;
     align-items: center;

--- a/site/gdocs/components/HomepageIntro.scss
+++ b/site/gdocs/components/HomepageIntro.scss
@@ -119,7 +119,6 @@
 .homepage-intro__announcements-header {
     display: flex;
     flex-wrap: wrap;
-    align-items: flex-start;
     gap: 8px 16px;
     align-items: center;
     svg {

--- a/site/gdocs/components/Image.scss
+++ b/site/gdocs/components/Image.scss
@@ -148,7 +148,6 @@
         }
         button,
         a {
-            padding: 0;
             display: block;
             text-align: left;
             background: none;

--- a/site/gdocs/pages/Homepage.scss
+++ b/site/gdocs/pages/Homepage.scss
@@ -57,7 +57,6 @@
         padding-right: 6px;
         list-style: none;
         &:before {
-            color: $blue-30;
             content: "•";
             margin-right: 6px;
             color: $blue-40;

--- a/site/search/SearchCountrySelector.scss
+++ b/site/search/SearchCountrySelector.scss
@@ -193,7 +193,6 @@
     position: relative;
     transition: 100ms background-color;
     width: 100%;
-    display: block;
     padding: 8px 0;
     color: $blue-90;
     display: flex;

--- a/site/search/SearchDataTopicsResultsSkeleton.scss
+++ b/site/search/SearchDataTopicsResultsSkeleton.scss
@@ -20,7 +20,7 @@
 
 .search-data-topic__list--skeleton {
     list-style: none;
-    grid-gap: var(--grid-gap);
+    gap: var(--grid-gap);
 
     @include sm-only {
         overflow-x: scroll;


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5 — @marcelgerber at the wheel._

From a one-off stylelint run (`stylelint-config-standard-scss`).

- **Checkbox hit target** (`site/css/forms.scss`): in `%owid-checkbox`, a later `margin: 0` erased the `margin-top: -6px` that vertically centers the invisible real checkbox input under the visible box, offsetting its hit target by ~8px. Used e.g. by the newsletter subscription form. This is the only commit that changes rendered behavior.
- **Dead `font-size`** (`site/css/content.scss`): removed a `font-size: 0.9rem` that the `font` shorthand on the next line immediately overrode.
- **Duplicated `body-1-bold`** (`components/src/styles/typography.scss`): the mixin and its companion class were pasted in twice, byte-identical.
- **Missing generic font fallback** (`grapher/src/mapCharts/MapTooltip.scss`): `font: 400 10px Lato` had no fallback if the webfont fails to load (now uses the `$lato` variable).
- **Stale duplicate declarations** (8 files): removed earlier, dead duplicates like `display: block` before `display: flex` — compiled CSS unchanged.
- **`grid-gap` → `gap`** (5 files): the deprecated aliases replaced with the standard properties; all supported browsers handle `gap`.

<details><summary>Details</summary>

## Verification

- Re-ran stylelint on all touched files: none of the targeted rules (`declaration-block-no-duplicate-properties`, `declaration-block-no-shorthand-property-overrides`, `scss/no-duplicate-mixins`, `font-family-no-missing-generic-family-keyword`, `property-no-deprecated` for grid-gap) fire anymore.
- Both SCSS entry points (`site/owid.scss`, `packages/@ourworldindata/grapher/src/core/grapher.scss`) compile cleanly with `sass`.
- `yarn typecheck` passes (SCSS-only change).
- oxfmt excludes `.scss` via its ignore rules, so no formatting pass applies.

## Safety notes per commit

- `forms.scss`: `margin: 0` was kept (it resets UA default margins) but moved before `margin-top: -6px` so the centering offset survives. The visible `label::before` box uses `-8px` (half of the 16px icon); the input's historical `-6px` was preserved rather than "corrected" to keep the change minimal.
- `typography.scss`: removing the *second* copy moves `.body-1-bold` earlier in the cascade relative to `.body-1-regular-underlined` / `.body-1-regular-superscript`. Verified the class is used in exactly one place (`site/latest/LatestDataInsightHit.tsx`) and never combined with those classes, so cascade order can't change any element's styles.
- Duplicate declarations: in every case the *earlier* declaration was removed, so the winning value — and thus compiled CSS — is unchanged. Files: `adminSiteClient/FilesIndexPage.scss`, `site/ExplorerIndexPage.scss`, `site/css/newsletter-subscription.scss`, `site/search/SearchCountrySelector.scss`, `site/gdocs/pages/Homepage.scss` (dead `color: $blue-30` before `$blue-40`), `site/gdocs/components/HomepageIntro.scss`, `site/gdocs/components/Image.scss`, `grapher/src/controls/entityPicker/EntityPicker.scss`.
- `Explorer.scss`: same-valued `grid-row-gap`/`grid-column-gap` pair collapsed into a single `gap`.
- `var(--grid-gap)` custom properties were deliberately left untouched — the variable name only resembles the deprecated property.
- MapTooltip is not part of static SVG exports, so no SVG regression run was needed; the font change only adds a fallback.

## Not included (from the same lint run)

The remaining ~2,480 findings are stylistic churn (blank-line rules that conflict with oxfmt being the formatter of record, `scss/load-partial-extension` fighting the repo's `@import "foo.scss"` convention, still-needed vendor prefixes, `rgba()` → `rgb()` notation, and false positives from the `@import`-inside-`.GrapherComponent` idiom). No stylelint config was added to the repo.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)