### PR TITLE
🐛🤖 Stop title annotations from stretching the header title's line

### DIFF
--- a/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
+++ b/packages/@ourworldindata/components/src/MarkdownTextWrap/IRTokens.tsx
@@ -314,6 +314,19 @@ export class IRFragment extends IRElement {
                 style={{
                     display: "inline-block",
                     marginLeft: this.inlineGap || undefined,
+                    // Keep the fragment out of the line box calculation. The
+                    // line it sits on is already exactly as tall as this text
+                    // wrap says it is (its strut is the line's largest font
+                    // size times the line height), but a fragment rendered in
+                    // a different font can have its baseline sit low enough
+                    // within its own inline box for that box to poke out
+                    // below the strut and stretch the line. How far depends
+                    // on the font metrics the browser reads, so the same
+                    // fragment stretches the line in one browser and not in
+                    // another; zeroing the line height takes the fragment's
+                    // box out of the calculation without moving its glyphs,
+                    // which are positioned off the shared baseline.
+                    lineHeight: 0,
                     fontSize,
                     fontWeight,
                     fontFamily: fontFamily


### PR DESCRIPTION
Switching grapher tabs appends a year to the title, which nudged the
subtitle down by a fraction of a pixel in Firefox but not in Chrome.

A line rendered by MarkdownTextWrapHtml is exactly as tall as the text
wrap says it is: the line span carries the largest font size on the
line, so its strut is that size times the line height. The annotation
is rendered as a fragment in a different font, though, and its baseline
sits low enough inside its own inline box for that box to poke out
below the strut and stretch the line. How far depends on the font
metrics the browser reads — Firefox puts Lato's ascent at 15/18 em
where Chrome puts it at 18/18 — so Firefox stretched the line where
Chrome didn't.

Zeroing the fragment's line height keeps its box out of the line box
calculation; the glyphs don't move, since they're positioned off the
shared baseline. Not a Firefox-only bug after all: Chrome stretched the
line too when the annotation wrapped onto its own line, and both
browsers now render the title at its computed height at every width.