### PR TITLE
🐛🤖 keep a tapped legend bin highlighted on touch devices

### DIFF
--- a/packages/@ourworldindata/grapher/src/hooks.test.tsx
+++ b/packages/@ourworldindata/grapher/src/hooks.test.tsx
@@ -5,7 +5,10 @@
 import { act, render } from "@testing-library/react"
 import { useRef } from "react"
 import { afterEach, expect, it, vi } from "vitest"
-import { useElementBounds } from "./hooks.js"
+import {
+    useDismissOnOutsidePointerDownOrUnmount,
+    useElementBounds,
+} from "./hooks.js"
 
 let resizeObserverCallback: ResizeObserverCallback | undefined
 
@@ -37,6 +40,15 @@ function BoundsProbe(): React.ReactElement {
             {bounds ? `${bounds.width}x${bounds.height}` : "unmeasured"}
         </div>
     )
+}
+
+function DismissProbe({
+    onDismiss,
+}: {
+    onDismiss: () => void
+}): React.ReactElement {
+    useDismissOnOutsidePointerDownOrUnmount(onDismiss)
+    return <div />
 }
 
 function reportResize(width: number, height: number): void {
@@ -74,4 +86,13 @@ it("preserves the last non-zero bounds while an element is hidden", () => {
 
     act(() => reportResize(700, 500))
     expect(getByTestId("probe")).toHaveTextContent("700x500")
+})
+
+it("dismisses when the component holding it unmounts", () => {
+    const onDismiss = vi.fn()
+    const { unmount } = render(<DismissProbe onDismiss={onDismiss} />)
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    unmount()
+    expect(onDismiss).toHaveBeenCalledOnce()
 })

--- a/packages/@ourworldindata/grapher/src/hooks.ts
+++ b/packages/@ourworldindata/grapher/src/hooks.ts
@@ -216,3 +216,21 @@ export function useElementBounds<T extends Bounds | null = Bounds>(
 
     return bounds
 }
+
+/**
+ * Runs `onDismiss` on the next pointerdown that reaches the document.
+ *
+ * A component marks its own area as inside by stopping pointerdown propagation
+ * at its root. Pointer type is deliberately not checked; on a hybrid
+ * mouse-and-touch device a highlight left by a tap has to be dismissable with
+ * the mouse.
+ */
+export function useDismissOnOutsidePointerDown(
+    onDismiss: (() => void) | undefined
+): void {
+    useEffect(() => {
+        if (!onDismiss) return
+        document.addEventListener("pointerdown", onDismiss, { passive: true })
+        return () => document.removeEventListener("pointerdown", onDismiss)
+    }, [onDismiss])
+}

--- a/packages/@ourworldindata/grapher/src/hooks.ts
+++ b/packages/@ourworldindata/grapher/src/hooks.ts
@@ -217,20 +217,15 @@ export function useElementBounds<T extends Bounds | null = Bounds>(
     return bounds
 }
 
-/**
- * Runs `onDismiss` on the next pointerdown that reaches the document.
- *
- * A component marks its own area as inside by stopping pointerdown propagation
- * at its root. Pointer type is deliberately not checked; on a hybrid
- * mouse-and-touch device a highlight left by a tap has to be dismissable with
- * the mouse.
- */
-export function useDismissOnOutsidePointerDown(
+export function useDismissOnOutsidePointerDownOrUnmount(
     onDismiss: (() => void) | undefined
 ): void {
     useEffect(() => {
         if (!onDismiss) return
         document.addEventListener("pointerdown", onDismiss, { passive: true })
-        return () => document.removeEventListener("pointerdown", onDismiss)
+        return () => {
+            document.removeEventListener("pointerdown", onDismiss)
+            onDismiss()
+        }
     }, [onDismiss])
 }

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalCategoricalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalCategoricalColorLegend.tsx
@@ -5,7 +5,7 @@ import {
     resolveLegendTextStyle,
 } from "./LegendStyleConfig"
 import { HorizontalCategoricalColorLegendState } from "./HorizontalCategoricalColorLegendState"
-import { useDismissOnOutsidePointerDown } from "../hooks.js"
+import { useDismissOnOutsidePointerDownOrUnmount } from "../hooks.js"
 import { HorizontalColorLegendProps } from "./HorizontalColorLegendTypes"
 import {
     CATEGORICAL_BIN_STROKE_WIDTH,
@@ -29,7 +29,9 @@ export function HorizontalCategoricalColorLegend(
     const { marks, rectPadding } = state
 
     const isHoverable = interactive && !!onMouseOver
-    useDismissOnOutsidePointerDown(isHoverable ? onMouseLeave : undefined)
+    useDismissOnOutsidePointerDownOrUnmount(
+        isHoverable ? onMouseLeave : undefined
+    )
 
     return (
         <g

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalCategoricalColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalCategoricalColorLegend.tsx
@@ -5,6 +5,7 @@ import {
     resolveLegendTextStyle,
 } from "./LegendStyleConfig"
 import { HorizontalCategoricalColorLegendState } from "./HorizontalCategoricalColorLegendState"
+import { useDismissOnOutsidePointerDown } from "../hooks.js"
 import { HorizontalColorLegendProps } from "./HorizontalColorLegendTypes"
 import {
     CATEGORICAL_BIN_STROKE_WIDTH,
@@ -24,9 +25,11 @@ export function HorizontalCategoricalColorLegend(
         onMouseEnter,
         onMouseOver,
         onMouseLeave,
-        onTouchSelect,
     } = props
     const { marks, rectPadding } = state
+
+    const isHoverable = interactive && !!onMouseOver
+    useDismissOnOutsidePointerDown(isHoverable ? onMouseLeave : undefined)
 
     return (
         <g
@@ -87,33 +90,31 @@ export function HorizontalCategoricalColorLegend(
                     )
                 })}
             </g>
-            {interactive && (
-                <g>
+            {isHoverable && (
+                <g id={makeFigmaId("hit-areas")}>
                     {marks.map((mark, index) => {
-                        const isTouchSelection = (
-                            event: React.PointerEvent
-                        ): boolean =>
-                            event.pointerType === "touch" && !!onTouchSelect
                         const pointerEnter = (
                             event: React.PointerEvent
                         ): void => {
-                            if (!isTouchSelection(event))
+                            if (event.pointerType !== "touch")
                                 onMouseEnter?.(mark.bin)
                         }
                         const pointerOver = (
                             event: React.PointerEvent
                         ): void => {
-                            if (!isTouchSelection(event))
+                            if (event.pointerType !== "touch")
                                 onMouseOver?.(mark.bin)
                         }
                         const pointerLeave = (
                             event: React.PointerEvent
                         ): void => {
-                            if (!isTouchSelection(event)) onMouseLeave?.()
+                            if (event.pointerType !== "touch") onMouseLeave?.()
                         }
                         const pointerUp = (event: React.PointerEvent): void => {
-                            if (event.pointerType === "touch")
-                                onTouchSelect?.(mark.bin)
+                            if (event.pointerType === "touch") {
+                                onMouseEnter?.(mark.bin)
+                                onMouseOver?.(mark.bin)
+                            }
                         }
 
                         return (
@@ -124,7 +125,6 @@ export function HorizontalCategoricalColorLegend(
                                 onPointerLeave={pointerLeave}
                                 onPointerUp={pointerUp}
                             >
-                                {/* for hover interaction */}
                                 <rect
                                     x={x + mark.x}
                                     y={y + mark.y - rectPadding / 2}

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegendTypes.ts
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalColorLegendTypes.ts
@@ -63,7 +63,6 @@ export interface HorizontalColorLegendProps<State> {
     onMouseEnter?: (bin: ColorScaleBin) => void
     onMouseOver?: (bin: ColorScaleBin) => void
     onMouseLeave?: () => void
-    onTouchSelect?: (bin: ColorScaleBin) => void
 }
 
 /**

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalNumericColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalNumericColorLegend.tsx
@@ -19,7 +19,7 @@ import {
     HorizontalColorLegendProps,
     PositionedBin,
 } from "./HorizontalColorLegendTypes"
-import { useDismissOnOutsidePointerDown } from "../hooks.js"
+import { useDismissOnOutsidePointerDownOrUnmount } from "../hooks.js"
 import {
     ARROW_SIZE,
     DEFAULT_NUMERIC_BIN_STROKE,
@@ -51,12 +51,15 @@ export function HorizontalNumericColorLegend(
     } = state
 
     const isHoverable = interactive && !!onMouseOver
-    useDismissOnOutsidePointerDown(isHoverable ? onMouseLeave : undefined)
+    useDismissOnOutsidePointerDownOrUnmount(
+        isHoverable ? onMouseLeave : undefined
+    )
 
     const defaultTextColor =
         styleConfig?.text?.default?.color ?? DEFAULT_TEXT_COLOR
 
     const bottomY = y + height
+    const labelStripHeight = Math.max(0, height - binSize)
 
     const markerStyleFor = (bin: ColorScaleBin): LegendMarkerStyle =>
         resolveLegendMarkerStyle(styleConfig, binEmphasis?.get(bin), {
@@ -201,7 +204,7 @@ export function HorizontalNumericColorLegend(
                             x={x + positionedBin.x}
                             y={y}
                             width={positionedBin.width}
-                            height={Math.max(0, height - binSize)}
+                            height={labelStripHeight}
                             fill="transparent"
                             pointerEvents="all"
                             onPointerUp={onPointerUp(positionedBin.bin)}

--- a/packages/@ourworldindata/grapher/src/legend/HorizontalNumericColorLegend.tsx
+++ b/packages/@ourworldindata/grapher/src/legend/HorizontalNumericColorLegend.tsx
@@ -19,6 +19,7 @@ import {
     HorizontalColorLegendProps,
     PositionedBin,
 } from "./HorizontalColorLegendTypes"
+import { useDismissOnOutsidePointerDown } from "../hooks.js"
 import {
     ARROW_SIZE,
     DEFAULT_NUMERIC_BIN_STROKE,
@@ -39,7 +40,6 @@ export function HorizontalNumericColorLegend(
         onMouseEnter,
         onMouseOver,
         onMouseLeave,
-        onTouchSelect,
     } = props
     const {
         numericLabels,
@@ -49,6 +49,9 @@ export function HorizontalNumericColorLegend(
         title,
         titlePosition,
     } = state
+
+    const isHoverable = interactive && !!onMouseOver
+    useDismissOnOutsidePointerDown(isHoverable ? onMouseLeave : undefined)
 
     const defaultTextColor =
         styleConfig?.text?.default?.color ?? DEFAULT_TEXT_COLOR
@@ -65,14 +68,14 @@ export function HorizontalNumericColorLegend(
     const onPointerEnter =
         (bin: ColorScaleBin) =>
         (event: React.PointerEvent): void => {
-            if (event.pointerType === "touch" && onTouchSelect) return
+            if (event.pointerType === "touch") return
 
             onMouseEnter?.(bin)
             onMouseOver?.(bin)
         }
 
     const onPointerLeave = (event: React.PointerEvent): void => {
-        if (event.pointerType === "touch" && onTouchSelect) return
+        if (event.pointerType === "touch") return
 
         onMouseLeave?.()
     }
@@ -80,7 +83,10 @@ export function HorizontalNumericColorLegend(
     const onPointerUp =
         (bin: ColorScaleBin) =>
         (event: React.PointerEvent): void => {
-            if (event.pointerType === "touch") onTouchSelect?.(bin)
+            if (event.pointerType === "touch") {
+                onMouseEnter?.(bin)
+                onMouseOver?.(bin)
+            }
         }
 
     const renderBin = (
@@ -90,7 +96,7 @@ export function HorizontalNumericColorLegend(
         const bin = positionedBin.bin
         const style = markerStyleFor(bin)
         const fill = bin.patternRef ? `url(#${bin.patternRef})` : style.fill
-        const inert = isHighlightOverlay || !interactive
+        const inert = isHighlightOverlay || !isHoverable
 
         return (
             <NumericBinRect
@@ -116,8 +122,6 @@ export function HorizontalNumericColorLegend(
             />
         )
     }
-
-    const showTouchHitAreas = interactive && !!onTouchSelect
 
     return (
         <g
@@ -189,9 +193,7 @@ export function HorizontalNumericColorLegend(
                     )
                 })}
             </g>
-            {showTouchHitAreas && (
-                // Add invisible hit areas above each swatch for touch interaction.
-                // They are the height of the legend labels, and only handle touch events.
+            {isHoverable && (
                 <g id={makeFigmaId("swatch-hit-areas")} aria-hidden="true">
                     {positionedBins.map((positionedBin, index) => (
                         <rect

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.test.ts
@@ -37,28 +37,24 @@ it("filters out non-map entities from colorScaleColumn", () => {
     )
 })
 
-it("pins a map bracket selected by touch until the next touch", () => {
+it("highlights the countries of a hovered legend bracket", () => {
     const chartState = new MapChartState({ manager })
     const chart = new MapChart({ chartState })
-    const [firstBracket, secondBracket] = chartState.colorScale.legendBins
+    const bracket = chartState.colorScale.legendBins.find((bin) =>
+        chartState.series.some((series) => bin.contains(series.value))
+    )!
 
-    expect(firstBracket).toBeDefined()
-    expect(secondBracket).toBeDefined()
+    expect(chart.getHoverState("France").background).toBe(false)
 
-    chart.onLegendMouseOver(firstBracket)
-    chart.onLegendTouchSelect(firstBracket)
+    chart.onLegendMouseOver(bracket)
+    for (const series of chartState.series) {
+        expect(chart.getHoverState(series.seriesName).active).toBe(
+            bracket.contains(series.value)
+        )
+    }
+
     chart.onLegendMouseLeave()
-    chart.onLegendMouseOver(secondBracket)
-
-    expect(chart.hoverBracket).toBe(firstBracket)
-
-    chart.onDocumentPointerDown()
-
-    expect(chart.hoverBracket).toBeUndefined()
-
-    chart.onLegendMouseOver(secondBracket)
-
-    expect(chart.hoverBracket).toBe(secondBracket)
+    expect(chart.getHoverState("France").background).toBe(false)
 })
 
 it("combines projected data with its historical counterpart", () => {

--- a/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapChart.tsx
@@ -96,17 +96,7 @@ export class MapChart
         })
     }
 
-    /**
-     * The currently hovered map bracket.
-     *
-     * Hovering a map bracket highlights all countries within that bracket on the map.
-     */
     hoverBracket: MapBracket | undefined = undefined
-    /**
-     * For touch events, we "pin" the hover bracket into an active state until the user taps outside of the legend.
-     * This is to create a better touch device experience.
-     */
-    private isHoverBracketPinnedBecauseOfTouchEvent = false
 
     tooltipState = new TooltipState<{
         featureId: string
@@ -201,7 +191,6 @@ export class MapChart
         this.onMapMouseLeave()
         this.onLegendMouseLeave()
         document.removeEventListener("keydown", this.onDocumentKeyDown)
-        document.removeEventListener("pointerdown", this.onDocumentPointerDown)
     }
 
     @action.bound onLegendMouseEnter(bracket: MapBracket): void {
@@ -212,18 +201,11 @@ export class MapChart
     }
 
     @action.bound onLegendMouseOver(bracket: MapBracket): void {
-        if (this.isHoverBracketPinnedBecauseOfTouchEvent) return
         this.hoverBracket = bracket
     }
 
     @action.bound onLegendMouseLeave(): void {
-        if (this.isHoverBracketPinnedBecauseOfTouchEvent) return
         this.hoverBracket = undefined
-    }
-
-    @action.bound onLegendTouchSelect(bracket: MapBracket): void {
-        this.hoverBracket = bracket
-        this.isHoverBracketPinnedBecauseOfTouchEvent = true
     }
 
     @computed get mapConfig(): MapConfig {
@@ -247,18 +229,6 @@ export class MapChart
         }
     }
 
-    // Clear the pinned hover bracket when the user taps outside of the legend.
-    // This only applies to when the hover bracket is currently pinned because of a touch event.
-    // But it doesn't check that the pointer event here is a touch event, because otherwise we would
-    // get into weird states with hybrid devices that have both touch and mouse input.
-    //
-    // Note that the legend itself stops propagation of pointer events, so this event handler will
-    // only be called when the user taps outside of the legend.
-    @action.bound onDocumentPointerDown(): void {
-        this.hoverBracket = undefined
-        this.isHoverBracketPinnedBecauseOfTouchEvent = false
-    }
-
     @computed get externalLegend(): ExternalColorLegendData | undefined {
         if (this.manager.showLegend) return undefined
 
@@ -274,7 +244,6 @@ export class MapChart
         exposeInstanceOnWindow(this)
 
         document.addEventListener("keydown", this.onDocumentKeyDown)
-        document.addEventListener("pointerdown", this.onDocumentPointerDown)
     }
 
     @computed private get legendData(): ColorScaleBin[] {
@@ -647,7 +616,6 @@ export class MapChart
                         onMouseEnter={this.onLegendMouseEnter}
                         onMouseOver={this.onLegendMouseOver}
                         onMouseLeave={this.onLegendMouseLeave}
-                        onTouchSelect={this.onLegendTouchSelect}
                     />
                 )}
                 {categoryLegendState && (
@@ -661,7 +629,6 @@ export class MapChart
                         onMouseEnter={this.onLegendMouseEnter}
                         onMouseOver={this.onLegendMouseOver}
                         onMouseLeave={this.onLegendMouseLeave}
-                        onTouchSelect={this.onLegendTouchSelect}
                     />
                 )}
             </>


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

On a phone, tapping a bin in a horizontal colour legend highlighted it and cleared it again within the same tap, everywhere except the map. #6864 moved both horizontal legends from mouse to pointer events and compensated for touch through an opt-in `onTouchSelect` prop that only `MapChart` passed, so every other legend that reacts to hover lost the sticky highlight mouse emulation used to give it. Sticking on tap is now the legends' own behaviour: a tap activates a bin on pointerup, and the next pointerdown that reaches the document clears it.

- **Fix.** A legend that unmounts while a bin is held no longer leaves the highlight behind with nothing able to clear it, which showed up as every country faded and none highlighted. Reachable when the legend data collapses to a single bin mid-hold, which timeline autoplay can do.
- Dismissal relies on the legend root stopping pointerdown, and that stop is global, so two colour legends on one page can both hold a highlight: a tap inside one never reaches the other's document listener. It predates the branch, but only maps pinned back then, so nobody hit it. Making every colour legend pin is what turns it into a common case, and I want to fix it separately.
- The numeric legend's invisible touch hit-area now renders for every hoverable legend rather than only the map. It sits over the labels above the swatches and handles pointerup only, so mouse hover is unaffected, and static exports skip it because they pass `interactive={false}`.
- `VerticalColorLegend` is deliberately untouched. It was never migrated to pointer events, so its sticky highlight still comes from mouse emulation, which clears the previous legend by itself. That migration is unfinished.
- Only visible under a finger. On a phone, tap a bin: the highlight should stay until you tap outside the legend. One example per legend and layout:
    - Numeric legend: [a map](http://staging-site-legend-tap/grapher/life-expectancy?tab=map), [a faceted map](http://staging-site-legend-tap/grapher/average-monthly-surface-temperature), [a line chart coloured by a numeric scale](http://staging-site-legend-tap/grapher/birth-rate-colored-by-peak-birth-month)
    - Categorical legend: [a stacked discrete bar](http://staging-site-legend-tap/grapher/per-capita-energy-stacked), [a marimekko](http://staging-site-legend-tap/grapher/co2-per-capita-marimekko), [a faceted line chart](http://staging-site-legend-tap/grapher/co2-emissions-and-gdp), [a faceted stacked bar](http://staging-site-legend-tap/grapher/tree-cover-loss-by-dominant-driver)

