### PR TITLE
Strip detail-on-demand links from the readme in data downloads

### DIFF
--- a/functions/_common/readmeTools.test.ts
+++ b/functions/_common/readmeTools.test.ts
@@ -1,0 +1,37 @@
+import { expect, it, describe } from "vitest"
+
+import { SynthesizeNonCountryTable } from "@ourworldindata/core-table"
+import { GrapherState } from "@ourworldindata/grapher"
+import { ColumnTypeNames } from "@ourworldindata/types"
+import { getRandomNumberGenerator } from "@ourworldindata/utils"
+import { constructReadme } from "./readmeTools.js"
+
+describe(constructReadme, () => {
+    it("strips detail-on-demand links but keeps their visible label", () => {
+        const table = SynthesizeNonCountryTable({
+            columnDefs: [
+                {
+                    slug: "population",
+                    type: ColumnTypeNames.Population,
+                    name: "Population",
+                    sourceName: "Test source",
+                    descriptionShort:
+                        "Measured in [terawatt-hours](#dod:watt-hours).",
+                    generator: getRandomNumberGenerator(1e7, 1e9),
+                    growthRateGenerator: getRandomNumberGenerator(-5, 5),
+                },
+            ],
+        })
+        const grapherState = new GrapherState({ table, ySlugs: "population" })
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const readme = constructReadme(
+            grapherState,
+            columns,
+            new URLSearchParams("")
+        )
+
+        expect(readme).not.toContain("#dod:")
+        expect(readme).toContain("Measured in terawatt-hours.")
+    })
+})

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -12,6 +12,7 @@ import {
     getCitationLong,
     prepareSourcesForDisplay,
     formatDate,
+    stripDetailOnDemandLinks,
 } from "@ourworldindata/utils"
 import type { CoreColumn } from "@ourworldindata/core-table"
 import { GrapherState } from "@ourworldindata/grapher"
@@ -358,5 +359,10 @@ ${sources.join("\n")}
 
     `
     }
-    return readme
+    // Detail-on-demand links (e.g. [terawatt-hours](#dod:watt-hours)) render as
+    // hover tooltips on the website, but the readme ships inside a downloaded
+    // zip where they're just dead links. Strip them here, over the fully
+    // assembled document, so any field that starts carrying DoD links later
+    // is covered automatically.
+    return stripDetailOnDemandLinks(readme)
 }


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The `readme.md` shipped inside a chart's data-download zip (served at `<slug>.readme.md`) contains detail-on-demand links like `[terawatt-hours](#dod:watt-hours)`. Those render as hover tooltips on the website, but a downloaded markdown file has no such tooltip — there it's a dead link that just clutters the text.

`assembleMetadata` already handles this for `<slug>.metadata.json` via a `stripDetailOnDemandLinks` pass (`functions/_common/metadataTools.ts`), following the same approach as owid/etl#6491, which strips DoD links from ETL's multidim download packages. The readme path was missed. This PR closes that gap by applying the existing `stripDetailOnDemandLinks` helper (from `@ourworldindata/utils`) over the fully assembled readme string in `constructReadme`, right before it's returned — covering both the single-column and multi-column branches in one place, so any field that starts carrying DoD links later is covered automatically too.

### What I verified

- Before: `curl -s https://ourworldindata.org/grapher/per-capita-energy-stacked.readme.md | grep -c '#dod:'` → `8`.
- After: added a unit test (`functions/_common/readmeTools.test.ts`) that builds a minimal `GrapherState` with a column whose `descriptionShort` contains `[terawatt-hours](#dod:watt-hours)`, calls `constructReadme`, and asserts the output contains no `#dod:` occurrences while the visible label `Measured in terawatt-hours.` survives. Passes.

<details><summary>Details</summary>

- `functions/_common/readmeTools.ts`: import `stripDetailOnDemandLinks` from `@ourworldindata/utils` and wrap the final `return readme` with it, instead of returning the raw assembled string.
- `functions/_common/readmeTools.test.ts`: new test file (neither `readmeTools` nor `metadataTools` had existing tests). Uses `SynthesizeNonCountryTable` + `GrapherState` + `constructReadme` directly rather than going through `assembleReadme`/`downloadFunctions.ts`, since that module pulls in font/image-generation dependencies that fail under vitest's import analysis.
- Checks run: `yarn testFormatChanged` (clean), `yarn testLintChanged` (clean), `yarn typecheck` (clean, no output), `yarn test run --reporter dot functions/_common/readmeTools.test.ts functions/_common/grapherTools.test.ts functions/_common/analytics.test.ts` (3 files, 6 tests, all passed).

</details>
