### PR TITLE
🎉🤖 render a fallback for bespoke viz without JavaScript

### DIFF
--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -686,6 +686,7 @@ export function enrichedBlockToRawBlock(
                     variant: b.variant,
                     size: b.size,
                     config: b.config,
+                    fallbackImageFilename: b.fallbackImageFilename,
                 },
             }
         })

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -1073,6 +1073,7 @@ export const enrichedBlockExamples: Record<
         variant: "income-chart",
         size: BlockSize.Wide,
         config: { foo: "bar" },
+        fallbackImageFilename: "example-widget-fallback.png",
         parseErrors: [],
     },
 }

--- a/db/model/Gdoc/gdocUtils.ts
+++ b/db/model/Gdoc/gdocUtils.ts
@@ -206,6 +206,10 @@ export function extractFilenamesFromBlock(
         .with({ type: "video" }, (item) => {
             if (item.filename) filenames.add(item.filename)
         })
+        .with({ type: "bespoke-component" }, (item) => {
+            if (item.fallbackImageFilename)
+                filenames.add(item.fallbackImageFilename)
+        })
         .with({ type: "research-and-writing" }, (item) => {
             getAllLinksFromResearchAndWritingBlock(item).forEach(
                 (link: EnrichedBlockResearchAndWritingLink) => {
@@ -291,8 +295,7 @@ export function extractFilenamesFromBlock(
                     "topic-page-intro",
                     "data-callout",
                     "data-callout-group",
-                    "country-profile-selector",
-                    "bespoke-component"
+                    "country-profile-selector"
                 ),
             },
             _.noop

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -1068,6 +1068,7 @@ function* rawBlockBespokeComponentToArchieMLString(
     yield* propertyToArchieMLString("bundle", block.value)
     yield* propertyToArchieMLString("variant", block.value)
     yield* propertyToArchieMLString("size", block.value)
+    yield* propertyToArchieMLString("fallbackImageFilename", block.value)
     if (block.value.config) {
         yield `{.config}`
         for (const [key, value] of Object.entries(block.value.config)) {

--- a/db/model/Gdoc/rawToEnriched.ts
+++ b/db/model/Gdoc/rawToEnriched.ts
@@ -513,12 +513,28 @@ const parseBespokeComponent = (
         }
     }
 
+    const rawFallbackImageFilename = raw.value.fallbackImageFilename
+    if (
+        rawFallbackImageFilename &&
+        typeof rawFallbackImageFilename !== "string"
+    ) {
+        parseErrors.push({
+            message: "fallbackImageFilename, if specified, must be a string",
+        })
+    }
+
+    const fallbackImageFilename =
+        typeof rawFallbackImageFilename === "string"
+            ? rawFallbackImageFilename
+            : undefined
+
     return {
         type: "bespoke-component",
         bundle: raw.value.bundle,
         variant: raw.value.variant,
         size,
         config,
+        fallbackImageFilename,
         parseErrors,
     }
 }

--- a/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/BespokeComponent.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/archieMLComponents/BespokeComponent.ts
@@ -7,6 +7,7 @@ export type RawBlockBespokeComponent = {
         variant?: string
         size?: BlockSize
         config?: Record<string, string>
+        fallbackImageFilename?: string
     }
 }
 
@@ -16,4 +17,5 @@ export type EnrichedBlockBespokeComponent = {
     variant?: string
     size: BlockSize
     config: Record<string, string>
+    fallbackImageFilename?: string
 } & EnrichedBlockWithParseErrors

--- a/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
+++ b/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
@@ -256,7 +256,7 @@
     },
     {
         "name": "bespoke-component",
-        "text": "{.bespoke-component}\nbundle: \nvariant: \nsize: \n{.config}\nfoo: \n{}\n{}",
+        "text": "{.bespoke-component}\nbundle: \nvariant: \nsize: \nfallbackImageFilename: \n{.config}\nfoo: \n{}\n{}",
         "keyword": "+bespoke-component"
     },
     {

--- a/site/gdocs/components/BespokeComponent.scss
+++ b/site/gdocs/components/BespokeComponent.scss
@@ -8,3 +8,17 @@
     color: $vermillion;
     font-size: 14px;
 }
+
+.bespoke-component__fallback-image {
+    picture {
+        // fixes strange extra height that is otherwise added to the element on firefox
+        display: flex;
+
+        border: 1px solid $gray-20;
+    }
+
+    img {
+        width: 100%;
+        height: auto;
+    }
+}

--- a/site/gdocs/components/BespokeComponent.tsx
+++ b/site/gdocs/components/BespokeComponent.tsx
@@ -1,11 +1,14 @@
 import {
     EnrichedBlockBespokeComponent,
     HIDE_IF_JS_DISABLED_CLASSNAME,
+    HIDE_IF_JS_ENABLED_CLASSNAME,
 } from "@ourworldindata/types"
 import { LoadingIndicator } from "@ourworldindata/components"
 import cx from "clsx"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useIntersectionObserver } from "usehooks-ts"
+import Image from "./Image.js"
+import { useImage } from "../utils.js"
 import { BESPOKE_COMPONENT_REGISTRY } from "../../bespokeComponentRegistry.js"
 import { mountBespokeComponentInShadow } from "../../../bespoke/shared/bespokeComponentShadowDom.js"
 import { BESPOKE_BASE_URL } from "../../../settings/clientSettings.js"
@@ -30,10 +33,6 @@ const makeAbsoluteWithBaseUrl = (url: string, baseUrl: string | undefined) => {
  * an external ES module into a Shadow DOM. This allows embedding
  * independently-built components that bundle their own JS and CSS,
  * isolated from the rest of the page styles.
- *
- * On the server, this renders a loading indicator and the site's no-JS warning
- * block. On the client, useEffect dynamically imports the module and calls its
- * `mount` function.
  *
  * Example ArchieML:
  * {.bespoke-component}
@@ -68,6 +67,8 @@ export function BespokeComponent({
         () => BESPOKE_COMPONENT_REGISTRY[block.bundle],
         [block.bundle]
     )
+
+    const fallbackImage = useImage(block.fallbackImageFilename)
 
     const scriptUrl = useMemo(() => {
         if (!definition || !BESPOKE_BASE_URL.trim()) return undefined
@@ -147,7 +148,19 @@ export function BespokeComponent({
                     <LoadingIndicator />
                 </div>
             )}
-            <div className="js--show-warning-block-if-js-disabled" />
+            {fallbackImage ? (
+                <Image
+                    className={cx(
+                        HIDE_IF_JS_ENABLED_CLASSNAME,
+                        "bespoke-component__fallback-image"
+                    )}
+                    imageData={fallbackImage}
+                    containerType={`bespoke-component--${block.size}`}
+                    shouldLightbox={false}
+                />
+            ) : (
+                <div className="js--show-warning-block-if-js-disabled" />
+            )}
             <div ref={containerRef}></div>
         </div>
     )

--- a/site/gdocs/components/BespokeComponent.tsx
+++ b/site/gdocs/components/BespokeComponent.tsx
@@ -1,4 +1,7 @@
-import { EnrichedBlockBespokeComponent } from "@ourworldindata/types"
+import {
+    EnrichedBlockBespokeComponent,
+    HIDE_IF_JS_DISABLED_CLASSNAME,
+} from "@ourworldindata/types"
 import { LoadingIndicator } from "@ourworldindata/components"
 import cx from "clsx"
 import { useEffect, useMemo, useRef, useState } from "react"
@@ -28,8 +31,9 @@ const makeAbsoluteWithBaseUrl = (url: string, baseUrl: string | undefined) => {
  * independently-built components that bundle their own JS and CSS,
  * isolated from the rest of the page styles.
  *
- * On the server, this renders an empty div. On the client, useEffect dynamically
- * imports the module and calls its `mount` function.
+ * On the server, this renders a loading indicator and the site's no-JS warning
+ * block. On the client, useEffect dynamically imports the module and calls its
+ * `mount` function.
  *
  * Example ArchieML:
  * {.bespoke-component}
@@ -138,7 +142,12 @@ export function BespokeComponent({
 
     return (
         <div className={className} ref={intersectionRef}>
-            {isLoading && <LoadingIndicator />}
+            {isLoading && (
+                <div className={HIDE_IF_JS_DISABLED_CLASSNAME}>
+                    <LoadingIndicator />
+                </div>
+            )}
+            <div className="js--show-warning-block-if-js-disabled" />
             <div ref={containerRef}></div>
         </div>
     )

--- a/site/gdocs/components/Image.tsx
+++ b/site/gdocs/components/Image.tsx
@@ -34,6 +34,7 @@ const gridSpan5 = generateResponsiveSizes(5)
 const gridSpan6 = generateResponsiveSizes(6)
 const gridSpan7 = generateResponsiveSizes(7)
 const gridSpan8 = generateResponsiveSizes(8)
+const gridSpan12 = generateResponsiveSizes(12)
 
 export type ImageParentContainer =
     | Exclude<Container, "sticky-right-left-heading-column">
@@ -45,6 +46,9 @@ export type ImageParentContainer =
     | "latest-data-insight"
     | "chart-rows"
     | "pull-chart"
+    | "bespoke-component--narrow"
+    | "bespoke-component--wide"
+    | "bespoke-component--widest"
 
 const containerSizes: Record<ImageParentContainer, string> = {
     ["default"]: gridSpan8,
@@ -68,6 +72,9 @@ const containerSizes: Record<ImageParentContainer, string> = {
     ["latest-announcement"]: gridSpan6,
     ["chart-rows"]: gridSpan3Sm,
     ["pull-chart"]: gridSpan3Sm,
+    ["bespoke-component--narrow"]: gridSpan6,
+    ["bespoke-component--wide"]: gridSpan8,
+    ["bespoke-component--widest"]: gridSpan12,
 }
 
 export const LIGHTBOX_IMAGE_CLASS = "lightbox-image"


### PR DESCRIPTION
A bespoke component is client-side JavaScript, so with JavaScript unavailable a bespoke embed rendered a spinner that never resolved. It now shows a fallback image if given, and the site's "JavaScript needs to be enabled" notice where it doesn't. 

The new prop on the `bespoke-component` archie is `fallbackImageFilename`

You can use this page for testing: http://staging-site-bespoke-nojs-fallback/sophias-test-article. The first embed has `fallbackImageFilename` set, the second doesn't.