### PR TITLE
🐛🤖 dedupe react-aria in bespoke bundles

### DIFF
--- a/bespoke/projects/causes-of-death/vite.config.ts
+++ b/bespoke/projects/causes-of-death/vite.config.ts
@@ -3,6 +3,7 @@ import pluginReact from "@vitejs/plugin-react"
 import { viteCssPosition } from "vite-plugin-css-position"
 import pluginSwc from "@rollup/plugin-swc"
 
+import { DEDUPED_PACKAGES } from "../../shared/viteDedupe.js"
 import { entrypoints } from "./package.json"
 
 export default defineConfig({
@@ -38,19 +39,7 @@ export default defineConfig({
         }),
     ],
     resolve: {
-        // The linked @ourworldindata/* packages and the shared
-        // bespoke/{components,hooks} workspaces resolve their dependencies
-        // relative to their real paths, which would load a second copy of
-        // React (breaking hooks) or @tanstack/react-query (breaking the
-        // QueryClient context, since each copy has its own React context).
-        // This forces these to resolve to a single copy in this project's
-        // node_modules.
-        dedupe: [
-            "react",
-            "react-dom",
-            "@react-stately/flags",
-            "@tanstack/react-query",
-        ],
+        dedupe: DEDUPED_PACKAGES,
     },
     build: {
         lib: {

--- a/bespoke/projects/demography/vite.config.ts
+++ b/bespoke/projects/demography/vite.config.ts
@@ -3,6 +3,7 @@ import pluginReact from "@vitejs/plugin-react"
 import { viteCssPosition } from "vite-plugin-css-position"
 import pluginSwc from "@rollup/plugin-swc"
 
+import { DEDUPED_PACKAGES } from "../../shared/viteDedupe.js"
 import { entrypoints } from "./package.json"
 
 export default defineConfig({
@@ -38,19 +39,7 @@ export default defineConfig({
         }),
     ],
     resolve: {
-        // The linked @ourworldindata/* packages and the shared
-        // bespoke/{components,hooks} workspaces resolve their dependencies
-        // relative to their real paths, which would load a second copy of
-        // React (breaking hooks) or @tanstack/react-query (breaking the
-        // QueryClient context, since each copy has its own React context).
-        // This forces these to resolve to a single copy in this project's
-        // node_modules.
-        dedupe: [
-            "react",
-            "react-dom",
-            "@react-stately/flags",
-            "@tanstack/react-query",
-        ],
+        dedupe: DEDUPED_PACKAGES,
     },
     build: {
         lib: {

--- a/bespoke/projects/example/vite.config.ts
+++ b/bespoke/projects/example/vite.config.ts
@@ -3,6 +3,7 @@ import pluginReact from "@vitejs/plugin-react"
 import { viteCssPosition } from "vite-plugin-css-position"
 import pluginSwc from "@rollup/plugin-swc"
 
+import { DEDUPED_PACKAGES } from "../../shared/viteDedupe.js"
 import { entrypoints } from "./package.json"
 
 export default defineConfig({
@@ -38,11 +39,7 @@ export default defineConfig({
         }),
     ],
     resolve: {
-        // The linked @ourworldindata/* packages resolve React relative
-        // to their real paths, which would load a second copy of React
-        // and break hooks. This forces all React imports to resolve to
-        // the single copy in this project's node_modules.
-        dedupe: ["react", "react-dom", "@react-stately/flags"],
+        dedupe: DEDUPED_PACKAGES,
     },
     build: {
         lib: {

--- a/bespoke/projects/food-trade/vite.config.ts
+++ b/bespoke/projects/food-trade/vite.config.ts
@@ -3,6 +3,7 @@ import pluginReact from "@vitejs/plugin-react"
 import { viteCssPosition } from "vite-plugin-css-position"
 import pluginSwc from "@rollup/plugin-swc"
 
+import { DEDUPED_PACKAGES } from "../../shared/viteDedupe.js"
 import { entrypoints } from "./package.json"
 
 export default defineConfig({
@@ -38,19 +39,7 @@ export default defineConfig({
         }),
     ],
     resolve: {
-        // The linked @ourworldindata/* packages resolve React relative
-        // to their real paths, which would load a second copy of React
-        // and break hooks. This forces all React imports to resolve to
-        // the single copy in this project's node_modules.
-        dedupe: [
-            "react",
-            "react-dom",
-            "@react-stately/flags",
-            "react-aria",
-            "react-aria-components",
-            "react-stately",
-            "@react-aria/overlays",
-        ],
+        dedupe: DEDUPED_PACKAGES,
     },
     build: {
         lib: {

--- a/bespoke/projects/migrant-demographics/vite.config.ts
+++ b/bespoke/projects/migrant-demographics/vite.config.ts
@@ -3,6 +3,7 @@ import pluginReact from "@vitejs/plugin-react"
 import { viteCssPosition } from "vite-plugin-css-position"
 import pluginSwc from "@rollup/plugin-swc"
 
+import { DEDUPED_PACKAGES } from "../../shared/viteDedupe.js"
 import { entrypoints } from "./package.json"
 
 export default defineConfig({
@@ -38,22 +39,7 @@ export default defineConfig({
         }),
     ],
     resolve: {
-        // The linked @ourworldindata/* packages (and the shared bespoke
-        // components/hooks workspaces) resolve their dependencies relative
-        // to their real paths, which would load second copies and break
-        // hooks, the react-query context, and react-aria overlays. This
-        // forces all imports to resolve to the single copy in this
-        // project's node_modules.
-        dedupe: [
-            "react",
-            "react-dom",
-            "@react-stately/flags",
-            "react-aria",
-            "react-aria-components",
-            "react-stately",
-            "@react-aria/overlays",
-            "@tanstack/react-query",
-        ],
+        dedupe: DEDUPED_PACKAGES,
     },
     build: {
         lib: {

--- a/bespoke/projects/migration/vite.config.ts
+++ b/bespoke/projects/migration/vite.config.ts
@@ -3,6 +3,7 @@ import pluginReact from "@vitejs/plugin-react"
 import { viteCssPosition } from "vite-plugin-css-position"
 import pluginSwc from "@rollup/plugin-swc"
 
+import { DEDUPED_PACKAGES } from "../../shared/viteDedupe.js"
 import { entrypoints } from "./package.json"
 
 export default defineConfig({
@@ -38,19 +39,7 @@ export default defineConfig({
         }),
     ],
     resolve: {
-        // The linked @ourworldindata/* packages resolve React relative
-        // to their real paths, which would load a second copy of React
-        // and break hooks. This forces all React imports to resolve to
-        // the single copy in this project's node_modules.
-        dedupe: [
-            "react",
-            "react-dom",
-            "@react-stately/flags",
-            "react-aria",
-            "react-aria-components",
-            "react-stately",
-            "@react-aria/overlays",
-        ],
+        dedupe: DEDUPED_PACKAGES,
     },
     build: {
         lib: {

--- a/bespoke/shared/viteDedupe.ts
+++ b/bespoke/shared/viteDedupe.ts
@@ -1,0 +1,17 @@
+/**
+ * The linked `@ourworldindata/*` packages and the shared
+ * `bespoke/{components,hooks}` workspaces resolve their dependencies relative to
+ * their real paths, so each would otherwise load its own copy. Every package
+ * here keeps state in module or context scope, where a second copy splits it in
+ * two: React hooks, the react-query `QueryClient` context, react-aria's
+ * `shadowDOM()` flag and its React contexts.
+ */
+export const DEDUPED_PACKAGES = [
+    "react",
+    "react-dom",
+    "@tanstack/react-query",
+    "react-aria",
+    "react-aria-components",
+    "react-stately",
+    "@react-stately/flags",
+]


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

The dropdowns in the causes-of-death bespoke viz never opened on touch, though they were fine with a mouse. Bespoke bundles carried two copies of react-aria and react-stately, one from `bespoke/node_modules` and one from the repo-root `node_modules` reached through the symlinked grapher package. `shadowDOM()` is module state in react-stately, so `enableShadowDOM()` flipped the bespoke copy's flag while grapher's `Dropdown` read the root copy's, which stayed `false`.