### PR TITLE
🔨🤖 rewrite the grapher modal with react-aria-components

### DIFF
--- a/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/ChartUtils.tsx
@@ -28,9 +28,6 @@ import { LineChartSeries } from "../lineCharts/LineChartConstants"
 import { SelectionArray } from "../selection/SelectionArray"
 import { ChartManager } from "./ChartManager"
 import {
-    GRAPHER_SIDE_PANEL_CLASS,
-    GRAPHER_TIMELINE_CLASS,
-    GRAPHER_SETTINGS_CLASS,
     SVG_STYLE_PROPS,
     BASE_FONT_SIZE,
     Patterns,
@@ -137,20 +134,6 @@ export const makeSelectionArray = (
     selection instanceof SelectionArray
         ? selection
         : new SelectionArray(selection ?? [])
-
-export function isElementInteractive(element: HTMLElement): boolean {
-    const interactiveTags = ["a", "button", "input"]
-    const interactiveClassNames = [
-        GRAPHER_TIMELINE_CLASS,
-        GRAPHER_SIDE_PANEL_CLASS,
-        GRAPHER_SETTINGS_CLASS,
-    ].map((className) => `.${className}`)
-
-    const selector = [...interactiveTags, ...interactiveClassNames].join(", ")
-
-    // check if the target is an interactive element or contained within one
-    return element.closest(selector) !== null
-}
 
 export function getShortNameForEntity(entityName: string): string | undefined {
     const region = getRegionByName(entityName)

--- a/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
+++ b/packages/@ourworldindata/grapher/src/controls/Dropdown.tsx
@@ -61,14 +61,6 @@ export interface DropdownProps<DropdownOption extends BasicDropdownOption> {
     "aria-label"?: string
 }
 
-// This attribute and function are being used to detect whether a dropdown is currently open in order to prevent modals or drawers from being dismissed by their click-outside handler.
-// React-Aria portals popovers (used for the dropdown menu) to the end of the document body, so we can't rely on simple DOM containment checks to determine if a click is happening inside the dropdown or not.
-const owidDropdownDataAttribute = "data-owid-dropdown"
-
-export function isOwidDropdownOpen(): boolean {
-    return document.querySelector(`[${owidDropdownDataAttribute}]`) !== null
-}
-
 function isOptionGroup<DropdownOption extends BasicDropdownOption>(
     item: DropdownCollectionItem<DropdownOption>
 ): item is DropdownOptionGroup<DropdownOption> {
@@ -170,7 +162,6 @@ export function Dropdown<DropdownOption extends BasicDropdownOption>({
     const popover = (
         <Popover
             className={cx("grapher-dropdown-menu", menuClassName)}
-            data-owid-dropdown=""
             offset={4}
         >
             {isSearchable ? (

--- a/packages/@ourworldindata/grapher/src/core/Grapher.tsx
+++ b/packages/@ourworldindata/grapher/src/core/Grapher.tsx
@@ -507,9 +507,7 @@ export class Grapher extends React.Component<GrapherProps> {
             return (
                 <FullScreen
                     onDismiss={this.dismissFullScreen}
-                    overlayColor={
-                        this.grapherState.isModalOpen ? "#999999" : "#fff"
-                    }
+                    isDimmed={this.grapherState.isModalOpen}
                 >
                     {this.renderGrapherComponent()}
                 </FullScreen>

--- a/packages/@ourworldindata/grapher/src/core/variables.scss
+++ b/packages/@ourworldindata/grapher/src/core/variables.scss
@@ -10,6 +10,9 @@ $active-text: $blue-90;
 $tooltip-fill: $gray-90;
 $tooltip-text: #fff;
 
+// Backdrop behind modals and the slide-in drawer
+$overlay-scrim: rgba(0, 0, 0, 0.1);
+
 // These should be between 0–100 in order to avoid conflicting with
 // site dropdowns, search overlays, etc.
 $zindex-chart: 1;

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.scss
@@ -8,4 +8,10 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    background-color: #fff;
+}
+
+.FullScreenOverlay--dimmed {
+    background-color: #ccc;
+    transition: background-color var(--duration-popover) var(--ease-out);
 }

--- a/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
+++ b/packages/@ourworldindata/grapher/src/fullScreen/FullScreen.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import cx from "clsx"
 import { action, makeObservable } from "mobx"
 import { observer } from "mobx-react"
 import { BodyPortal } from "@ourworldindata/components"
@@ -7,7 +8,7 @@ import { isTargetOutsideElement } from "../chart/ChartUtils"
 interface FullScreenProps {
     children: React.ReactNode
     onDismiss: () => void
-    overlayColor?: string
+    isDimmed?: boolean
 }
 
 @observer
@@ -43,13 +44,12 @@ export class FullScreen extends React.Component<FullScreenProps> {
         return (
             <BodyPortal>
                 <div
-                    className="FullScreenOverlay"
+                    className={cx("FullScreenOverlay", {
+                        "FullScreenOverlay--dimmed": this.props.isDimmed,
+                    })}
                     role="dialog"
                     aria-modal="true"
                     onClick={this.onDocumentClick}
-                    style={{
-                        backgroundColor: this.props.overlayColor ?? "#fff",
-                    }}
                 >
                     <div className="FullScreenContent" ref={this.content}>
                         {this.props.children}

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -76,6 +76,7 @@ export interface DownloadModalManager {
     detailsOrderedByReference?: string[]
     activeModal?: GrapherModal
     frameBounds?: Bounds
+    base: React.RefObject<HTMLDivElement | null>
     captionedChartBounds?: Bounds
     isOnChartOrMapTab?: boolean
     isOnArchivalPage?: boolean
@@ -152,6 +153,8 @@ export class DownloadModal extends React.Component<DownloadModalProps> {
     override render(): React.ReactElement {
         return (
             <Modal
+                ariaLabel="Download"
+                grapherRef={this.props.manager.base}
                 bounds={this.modalBounds}
                 onDismiss={this.onDismiss}
                 alignVertical="top"

--- a/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EmbedModal.tsx
@@ -18,6 +18,7 @@ export interface EmbedModalManager {
     hideExternalControlsInEmbedUrl: boolean
     setHideExternalControlsInEmbedUrl: (value: boolean) => void
     frameBounds?: Bounds
+    base: React.RefObject<HTMLDivElement | null>
     recommendedIframeEmbedHeight?: number
 }
 
@@ -118,6 +119,8 @@ export class EmbedModal extends React.Component<EmbedModalProps> {
         if (!embedOptions.length) return null
         return (
             <Modal
+                ariaLabel="Embed"
+                grapherRef={this.manager.base}
                 bounds={this.modalBounds}
                 alignVertical="bottom"
                 onDismiss={this.onDismiss}

--- a/packages/@ourworldindata/grapher/src/modal/EntitySelectorModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/EntitySelectorModal.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_GRAPHER_BOUNDS } from "../core/GrapherConstants"
 export interface EntitySelectorModalManager extends EntitySelectorManager {
     isEntitySelectorModalOrDrawerOpen?: boolean
     frameBounds?: Bounds
+    base: React.RefObject<HTMLDivElement | null>
 }
 
 @observer
@@ -44,6 +45,8 @@ export class EntitySelectorModal extends React.Component<{
     override render(): React.ReactElement {
         return (
             <Modal
+                ariaLabel="Entity selector"
+                grapherRef={this.manager.base}
                 onDismiss={this.onDismiss}
                 bounds={this.modalBounds}
                 isHeightFixed={true}

--- a/packages/@ourworldindata/grapher/src/modal/Modal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.scss
@@ -2,15 +2,29 @@
     --modal-padding: 24px;
 
     position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
 
-    // -1px to hide the frame border
-    top: -1px;
-    right: -1px;
-    bottom: -1px;
-    left: -1px;
-
-    background-color: rgba(0, 0, 0, 0.4);
+    background-color: $overlay-scrim;
     z-index: $zindex-modal;
+    opacity: 1;
+    transition: opacity var(--duration-popover) var(--ease-out);
+
+    // Modals are unmounted on dismiss, so only the entering phase ever renders
+    &[data-entering] {
+        opacity: 0;
+
+        .modal-content--top,
+        .modal-content--bottom {
+            transform: scale(0.97);
+        }
+
+        .modal-content--center {
+            transform: translateY(-50%) scale(0.97);
+        }
+    }
 
     .modal-content {
         position: absolute;
@@ -18,11 +32,44 @@
         background: #fff;
         box-shadow: 0px 4px 30px 0px rgba(0, 0, 0, 0.15);
         min-height: 150px;
+        transition: transform var(--duration-popover) var(--ease-out);
+    }
+
+    .modal-content--top {
+        transform-origin: center top;
+    }
+
+    .modal-content--bottom {
+        transform-origin: center bottom;
+    }
+
+    .modal-content--center {
+        top: 50%;
+        transform: translateY(-50%);
     }
 
     .modal-dialog {
         height: 100%;
         outline: none;
+    }
+
+    // Drop the panel's scale only. The overlay's opacity transition is what
+    // React Aria waits on before unmounting, so it must survive.
+    @media (prefers-reduced-motion: reduce) {
+        .modal-content {
+            transition: none;
+        }
+
+        &[data-entering] {
+            .modal-content--top,
+            .modal-content--bottom {
+                transform: none;
+            }
+
+            .modal-content--center {
+                transform: translateY(-50%);
+            }
+        }
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/modal/Modal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.scss
@@ -12,17 +12,17 @@
     background-color: rgba(0, 0, 0, 0.4);
     z-index: $zindex-modal;
 
-    .modal-wrapper {
-        position: relative;
-        height: 100%;
+    .modal-content {
+        position: absolute;
+        border-radius: 4px;
+        background: #fff;
+        box-shadow: 0px 4px 30px 0px rgba(0, 0, 0, 0.15);
+        min-height: 150px;
+    }
 
-        .modal-content {
-            position: absolute;
-            border-radius: 4px;
-            background: #fff;
-            box-shadow: 0px 4px 30px 0px rgba(0, 0, 0, 0.15);
-            min-height: 150px;
-        }
+    .modal-dialog {
+        height: 100%;
+        outline: none;
     }
 }
 

--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -1,9 +1,6 @@
 import * as React from "react"
 import { Bounds, bind } from "@ourworldindata/utils"
-import {
-    isElementInteractive,
-    isTargetOutsideElement,
-} from "../chart/ChartUtils"
+import { isTargetOutsideElement } from "../chart/ChartUtils"
 import { isOwidDropdownOpen } from "../controls/Dropdown"
 
 export class Modal extends React.Component<{
@@ -31,9 +28,6 @@ export class Modal extends React.Component<{
         if (
             this.contentRef?.current &&
             isTargetOutsideElement(e.target!, this.contentRef.current) &&
-            // clicking on an interactive element should not dismiss the modal
-            // (this is especially important for the suggested chart review tool)
-            !isElementInteractive(e.target as HTMLElement) &&
             !isOwidDropdownOpen()
         )
             this.props.onDismiss()

--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import cx from "clsx"
 import { UNSAFE_PortalProvider } from "react-aria"
 import { Dialog, Modal as AriaModal, ModalOverlay } from "react-aria-components"
 import { Bounds } from "@ourworldindata/utils"
@@ -37,9 +38,6 @@ export function Modal({
         contentStyle.bottom = bounds.y
     } else if (alignVertical === "top") {
         contentStyle.top = bounds.y
-    } else {
-        contentStyle.top = "50%"
-        contentStyle.transform = "translateY(-50%)"
     }
 
     return (
@@ -52,7 +50,13 @@ export function Modal({
                 }}
                 isDismissable
             >
-                <AriaModal className="modal-content" style={contentStyle}>
+                <AriaModal
+                    className={cx(
+                        "modal-content",
+                        `modal-content--${alignVertical}`
+                    )}
+                    style={contentStyle}
+                >
                     <Dialog className="modal-dialog" aria-label={ariaLabel}>
                         {/* Restore the default portal container for nested
                             overlays such as dropdowns. */}

--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -1,86 +1,67 @@
 import * as React from "react"
-import { Bounds, bind } from "@ourworldindata/utils"
-import { isTargetOutsideElement } from "../chart/ChartUtils"
-import { isOwidDropdownOpen } from "../controls/Dropdown"
+import { UNSAFE_PortalProvider } from "react-aria"
+import { Dialog, Modal as AriaModal, ModalOverlay } from "react-aria-components"
+import { Bounds } from "@ourworldindata/utils"
 
-export class Modal extends React.Component<{
+interface ModalProps {
     bounds: Bounds
     onDismiss: () => void
+    ariaLabel: string
+    grapherRef: React.RefObject<HTMLDivElement | null>
     children?: React.ReactNode
-    isHeightFixed?: boolean // by default, the modal height is not fixed but fits to the content
+    /** By default the modal height fits its content */
+    isHeightFixed?: boolean
     alignVertical?: "top" | "center" | "bottom"
-}> {
-    contentRef = React.createRef<HTMLDivElement>()
+}
 
-    private get bounds(): Bounds {
-        return this.props.bounds
+export function Modal({
+    bounds,
+    onDismiss,
+    ariaLabel,
+    grapherRef,
+    children,
+    isHeightFixed = false,
+    alignVertical = "center",
+}: ModalProps): React.ReactElement {
+    const contentStyle: React.CSSProperties = {
+        left: bounds.left,
+        width: bounds.width,
+        maxHeight: bounds.height,
     }
 
-    private get isHeightFixed(): boolean {
-        return this.props.isHeightFixed ?? false
+    if (isHeightFixed) {
+        contentStyle.height = bounds.height
     }
 
-    private get alignVertical(): "top" | "center" | "bottom" {
-        return this.props.alignVertical ?? "center"
+    if (alignVertical === "bottom") {
+        contentStyle.bottom = bounds.y
+    } else if (alignVertical === "top") {
+        contentStyle.top = bounds.y
+    } else {
+        contentStyle.top = "50%"
+        contentStyle.transform = "translateY(-50%)"
     }
 
-    @bind onDocumentClick(e: MouseEvent): void {
-        if (
-            this.contentRef?.current &&
-            isTargetOutsideElement(e.target!, this.contentRef.current) &&
-            !isOwidDropdownOpen()
-        )
-            this.props.onDismiss()
-    }
-
-    @bind onDocumentKeyDown(e: KeyboardEvent): void {
-        if (e.key === "Escape") this.props.onDismiss()
-    }
-
-    override componentDidMount(): void {
-        document.addEventListener("click", this.onDocumentClick)
-        document.addEventListener("keydown", this.onDocumentKeyDown)
-    }
-
-    override componentWillUnmount(): void {
-        document.removeEventListener("click", this.onDocumentClick)
-        document.removeEventListener("keydown", this.onDocumentKeyDown)
-    }
-
-    override render(): React.ReactElement {
-        const { bounds } = this
-
-        const contentStyle: React.CSSProperties = {
-            left: bounds.left,
-            width: bounds.width,
-            maxHeight: bounds.height,
-        }
-
-        if (this.isHeightFixed) {
-            contentStyle.height = bounds.height
-        }
-
-        if (this.alignVertical === "bottom") {
-            contentStyle.bottom = bounds.y
-        } else if (this.alignVertical === "top") {
-            contentStyle.top = bounds.y
-        } else {
-            contentStyle.top = "50%"
-            contentStyle.transform = "translateY(-50%)"
-        }
-
-        return (
-            <div className="modal-overlay">
-                <div className="modal-wrapper">
-                    <div
-                        className="modal-content"
-                        style={contentStyle}
-                        ref={this.contentRef}
-                    >
-                        {this.props.children}
-                    </div>
-                </div>
-            </div>
-        )
-    }
+    return (
+        <UNSAFE_PortalProvider getContainer={() => grapherRef.current}>
+            <ModalOverlay
+                className="modal-overlay"
+                isOpen
+                onOpenChange={(isOpen) => {
+                    if (!isOpen) onDismiss()
+                }}
+                isDismissable
+            >
+                <AriaModal className="modal-content" style={contentStyle}>
+                    <Dialog className="modal-dialog" aria-label={ariaLabel}>
+                        {/* Restore the default portal container for nested
+                            overlays such as dropdowns. */}
+                        <UNSAFE_PortalProvider getContainer={null}>
+                            {children}
+                        </UNSAFE_PortalProvider>
+                    </Dialog>
+                </AriaModal>
+            </ModalOverlay>
+        </UNSAFE_PortalProvider>
+    )
 }

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -57,6 +57,7 @@ export interface SourcesModalManager {
     showAdminControls?: boolean
     activeModal?: GrapherModal
     frameBounds?: Bounds
+    base: React.RefObject<HTMLDivElement | null>
     isEmbeddedInADataPage?: boolean
     isNarrow?: boolean
     fontSize?: number
@@ -335,6 +336,8 @@ export class SourcesModal extends React.Component<SourcesModalProps> {
     override render(): React.ReactElement {
         return (
             <Modal
+                ariaLabel="Sources"
+                grapherRef={this.manager.base}
                 bounds={this.modalBounds}
                 isHeightFixed={true}
                 onDismiss={this.onDismiss}

--- a/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.scss
+++ b/packages/@ourworldindata/grapher/src/slideInDrawer/SlideInDrawer.scss
@@ -6,7 +6,7 @@
     bottom: 0;
     overflow: clip;
     z-index: $zindex-controls-drawer;
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: $overlay-scrim;
     transition: background-color var(--duration-drawer) var(--ease-drawer);
 
     &[data-entering],


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

Rewrites Grapher's modal using React Aria

- **Behaviour change.** `useModalOverlay` locks page scroll and marks everything outside the modal `inert`, and offers no way to opt out. While a chart's Download or Sources modal is open, a reader cannot scroll the article or click anything else on the page.
- **Behaviour change.** A click on a link or button outside the chart now dismisses an open modal. The exemption came from #2811, for the chart revision tool whose table was dropped in `1748446282000-DropSuggestedChartRevisionsTable`. Let's try to remove it and only add it back when someone complains.
- `isOwidDropdownOpen` and its `data-owid-dropdown` marker are gone. React Aria stacks open overlays and only lets the topmost answer an outside press, and our `Dropdown` is a RAC `Popover`, so it sits on that stack. Narrower than the old check, which suppressed dismissal for any open dropdown anywhere on the page.