### PR TITLE
🐛 Respect isPublished on the by-uuid grapher config route

### DIFF
--- a/functions/_common/grapherTools.test.ts
+++ b/functions/_common/grapherTools.test.ts
@@ -8,7 +8,7 @@ import { GrapherState } from "@ourworldindata/grapher"
 import { OwidTableSlugs } from "@ourworldindata/types"
 import {
     GrapherIdentifier,
-    isUnpublishedChartRequestedByUuid,
+    isUnpublishedChartHiddenFromPublicSite,
     rewriteJsonLdText,
 } from "./grapherTools.js"
 
@@ -93,7 +93,7 @@ describe(rewriteJsonLdText, () => {
     })
 })
 
-describe(isUnpublishedChartRequestedByUuid, () => {
+describe(isUnpublishedChartHiddenFromPublicSite, () => {
     const uuid: GrapherIdentifier = {
         type: "uuid",
         id: "0191b6c7-5595-70b2-8d30-fa03fccd7add",
@@ -102,24 +102,50 @@ describe(isUnpublishedChartRequestedByUuid, () => {
 
     it("hides a chart that is not published", () => {
         expect(
-            isUnpublishedChartRequestedByUuid(uuid, { isPublished: false })
+            isUnpublishedChartHiddenFromPublicSite(
+                uuid,
+                { isPublished: false },
+                "production"
+            )
         ).toBe(true)
     })
 
     it("serves a published chart", () => {
         expect(
-            isUnpublishedChartRequestedByUuid(uuid, { isPublished: true })
+            isUnpublishedChartHiddenFromPublicSite(
+                uuid,
+                { isPublished: true },
+                "production"
+            )
         ).toBe(false)
     })
 
     it("serves a config with no isPublished field, as narrative charts have", () => {
-        expect(isUnpublishedChartRequestedByUuid(uuid, {})).toBe(false)
+        expect(
+            isUnpublishedChartHiddenFromPublicSite(uuid, {}, "production")
+        ).toBe(false)
     })
 
     it("leaves the by-slug route alone, which serves published configs only", () => {
         expect(
-            isUnpublishedChartRequestedByUuid(slug, { isPublished: false })
+            isUnpublishedChartHiddenFromPublicSite(
+                slug,
+                { isPublished: false },
+                "production"
+            )
         ).toBe(false)
+    })
+
+    it("keeps serving drafts on staging, which the preview tooling needs", () => {
+        for (const environment of ["staging", "development"]) {
+            expect(
+                isUnpublishedChartHiddenFromPublicSite(
+                    uuid,
+                    { isPublished: false },
+                    environment
+                )
+            ).toBe(false)
+        }
     })
 })
 

--- a/functions/_common/grapherTools.test.ts
+++ b/functions/_common/grapherTools.test.ts
@@ -6,7 +6,11 @@ import {
 } from "@ourworldindata/core-table"
 import { GrapherState } from "@ourworldindata/grapher"
 import { OwidTableSlugs } from "@ourworldindata/types"
-import { rewriteJsonLdText } from "./grapherTools.js"
+import {
+    GrapherIdentifier,
+    isUnpublishedChartRequestedByUuid,
+    rewriteJsonLdText,
+} from "./grapherTools.js"
 
 describe("download", () => {
     const originalTable = SynthesizeGDPTable()
@@ -86,6 +90,36 @@ describe(rewriteJsonLdText, () => {
         expect(rewritten).toBe(
             '{"description":"\\u003c/script>\\u003cscript>alert(1)\\u003c/script>"}'
         )
+    })
+})
+
+describe(isUnpublishedChartRequestedByUuid, () => {
+    const uuid: GrapherIdentifier = {
+        type: "uuid",
+        id: "0191b6c7-5595-70b2-8d30-fa03fccd7add",
+    }
+    const slug: GrapherIdentifier = { type: "slug", id: "life-expectancy" }
+
+    it("hides a chart that is not published", () => {
+        expect(
+            isUnpublishedChartRequestedByUuid(uuid, { isPublished: false })
+        ).toBe(true)
+    })
+
+    it("serves a published chart", () => {
+        expect(
+            isUnpublishedChartRequestedByUuid(uuid, { isPublished: true })
+        ).toBe(false)
+    })
+
+    it("serves a config with no isPublished field, as narrative charts have", () => {
+        expect(isUnpublishedChartRequestedByUuid(uuid, {})).toBe(false)
+    })
+
+    it("leaves the by-slug route alone, which serves published configs only", () => {
+        expect(
+            isUnpublishedChartRequestedByUuid(slug, { isPublished: false })
+        ).toBe(false)
     })
 })
 

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -195,15 +195,26 @@ async function fetchMultiDimGrapherConfig(
  * published charts. The by-uuid routes read `config/by-uuid`, which holds a
  * config for every chart, so they have to check publication themselves.
  *
+ * Only on the public site. Staging serves the same functions through wrangler,
+ * and previewing a chart before it is published is what a staging server is
+ * for: the ETL preview tooling and the chart-preview VS Code extension both
+ * fetch drafts from `staging-site-<branch>`, which is reachable on the tailnet
+ * only.
+ *
  * Tests for `false` rather than "not true" deliberately: narrative charts are
  * addressed by UUID too and their configs carry no `isPublished` field, so they
  * must keep resolving.
  */
-export function isUnpublishedChartRequestedByUuid(
+export function isUnpublishedChartHiddenFromPublicSite(
     identifier: GrapherIdentifier,
-    grapherConfig: GrapherInterface
+    grapherConfig: GrapherInterface,
+    environment: string
 ): boolean {
-    return identifier.type === "uuid" && grapherConfig.isPublished === false
+    return (
+        environment === "production" &&
+        identifier.type === "uuid" &&
+        grapherConfig.isPublished === false
+    )
 }
 
 export async function fetchGrapherConfig({
@@ -275,7 +286,13 @@ export async function fetchGrapherConfig({
     } else {
         grapherConfig = config as GrapherInterface
     }
-    if (isUnpublishedChartRequestedByUuid(identifier, grapherConfig)) {
+    if (
+        isUnpublishedChartHiddenFromPublicSite(
+            identifier,
+            grapherConfig,
+            env.ENV
+        )
+    ) {
         throw new StatusError(404)
     }
     console.log("grapher title", grapherConfig.title)

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -190,6 +190,22 @@ async function fetchMultiDimGrapherConfig(
     }
 }
 
+/**
+ * The by-slug routes read `config/by-slug-published`, which only ever holds
+ * published charts. The by-uuid routes read `config/by-uuid`, which holds a
+ * config for every chart, so they have to check publication themselves.
+ *
+ * Tests for `false` rather than "not true" deliberately: narrative charts are
+ * addressed by UUID too and their configs carry no `isPublished` field, so they
+ * must keep resolving.
+ */
+export function isUnpublishedChartRequestedByUuid(
+    identifier: GrapherIdentifier,
+    grapherConfig: GrapherInterface
+): boolean {
+    return identifier.type === "uuid" && grapherConfig.isPublished === false
+}
+
 export async function fetchGrapherConfig({
     identifier,
     env,
@@ -258,6 +274,9 @@ export async function fetchGrapherConfig({
         )
     } else {
         grapherConfig = config as GrapherInterface
+    }
+    if (isUnpublishedChartRequestedByUuid(identifier, grapherConfig)) {
+        throw new StatusError(404)
     }
     console.log("grapher title", grapherConfig.title)
     const result: FetchGrapherConfigResult = {


### PR DESCRIPTION
## Human summary

We should only serve published charts from the by-uuid route (not draft charts).

> _Written by Claude Opus 5 — @pabloarosado at the wheel._

The by-slug routes read `config/by-slug-published`, so they only ever return published charts. The by-uuid routes read `config/by-uuid`, which holds a config for every chart, and return whatever they find. On the public site the two should behave the same way.

This makes a by-uuid request 404 when the config it resolved to says `isPublished: false`. The check sits in `fetchGrapherConfig`, which `.config.json` and the `.png` / `.svg` handlers all go through, so one place covers the three routes.

Two deliberate limits on the check:

- It applies only where `env.ENV` is `production`. Staging runs the same functions under `wrangler`, and previewing a chart before publishing it is what a staging server is for. Both the ETL preview helper and the chart-preview VS Code extension fetch drafts from `staging-site-<branch>`, which is reachable on the tailnet only.
- It tests for `isPublished === false` rather than "not true". Narrative charts are addressed by UUID too and their configs carry no `isPublished` field, so testing for `true` would stop resolving them.

Both limits have a unit test that fails if the predicate is written the other way.