### PR TITLE
Enable asyncStackTraces in knex

### DIFF
--- a/db/db.ts
+++ b/db/db.ts
@@ -107,6 +107,7 @@ export function setKnexInstance(knexInstance: Knex<any, any[]>): void {
 const getNewKnexInstance = (): Knex<any, any[]> => {
     return knex({
         client: "mysql2",
+        asyncStackTraces: true,
         connection: {
             host: GRAPHER_DB_HOST,
             user: GRAPHER_DB_USER,

--- a/db/tests/dbTestConfig.ts
+++ b/db/tests/dbTestConfig.ts
@@ -10,6 +10,7 @@ import {
 
 export const dbTestConfig = {
     client: "mysql2",
+    asyncStackTraces: true,
     connection: {
         database: GRAPHER_TEST_DB_NAME,
         user: GRAPHER_TEST_DB_USER,


### PR DESCRIPTION
To help us debug MySQL errors and avoid Sentry grouping unrelated errors together.