### PR TITLE
✅🤖 stop the e2e worker tests leaking workerd

### DIFF
--- a/functions/test/grapher-config-r2.e2e.test.ts
+++ b/functions/test/grapher-config-r2.e2e.test.ts
@@ -1,10 +1,10 @@
 import path from "node:path"
 import { readFileSync } from "node:fs"
-import { beforeAll, afterAll, beforeEach, describe, expect, it } from "vitest"
-import { unstable_startWorker } from "wrangler"
+import { beforeEach, describe, expect, it } from "vitest"
 import { R2GrapherConfigDirectory } from "@ourworldindata/types"
+import { setUpTestWorker } from "./setUpTestWorker.js"
 
-let worker: Awaited<ReturnType<typeof unstable_startWorker>>
+const workerFetch = setUpTestWorker("./functions/test/wrangler.e2e.jsonc")
 
 const lifeExpectancyFixturePath = path.join(
     process.cwd(),
@@ -18,10 +18,6 @@ function makeSlugKey(slug: string, bucketPath = "v1"): string {
         R2GrapherConfigDirectory.publishedGrapherBySlug,
         `${slug}.json`,
     ].join("/")
-}
-
-async function workerFetch(pathname: string, init?: unknown) {
-    return worker.fetch(`http://example.com${pathname}`, init as never)
 }
 
 async function clearBuckets() {
@@ -60,17 +56,6 @@ async function r2HasKey(params: {
 }
 
 describe("grapher config endpoint with local R2 bindings", () => {
-    beforeAll(async () => {
-        worker = await unstable_startWorker({
-            config: "./functions/test/wrangler.e2e.jsonc",
-            dev: { logLevel: "none" },
-        })
-    })
-
-    afterAll(async () => {
-        await worker.dispose()
-    })
-
     beforeEach(async () => {
         await clearBuckets()
     })

--- a/functions/test/search.e2e.test.ts
+++ b/functions/test/search.e2e.test.ts
@@ -1,14 +1,9 @@
-import { beforeAll, afterAll, describe, expect, it } from "vitest"
-import { unstable_startWorker } from "wrangler"
+import { describe, expect, it } from "vitest"
+import { setUpTestWorker } from "./setUpTestWorker.js"
 
-let worker: Awaited<ReturnType<typeof unstable_startWorker>>
-
-async function workerFetch(
-    pathname: string,
-    init?: { method?: string; body?: string }
-) {
-    return worker.fetch(`http://example.com${pathname}`, init)
-}
+const workerFetch = setUpTestWorker(
+    "./functions/test/wrangler.search.e2e.jsonc"
+)
 
 // Runs the real /api/search handler inside an actual Workers (workerd)
 // runtime, unlike searchApi.integration.test.ts which exercises the same
@@ -16,17 +11,6 @@ async function workerFetch(
 // + fetch requester combination — not just the raw REST fetch it replaced —
 // works in the runtime it's deployed to.
 describe("search endpoint inside a real Workers runtime", () => {
-    beforeAll(async () => {
-        worker = await unstable_startWorker({
-            config: "./functions/test/wrangler.search.e2e.jsonc",
-            dev: { logLevel: "none" },
-        })
-    })
-
-    afterAll(async () => {
-        await worker.dispose()
-    })
-
     it("searches charts", async () => {
         const response = await workerFetch(
             "/api/search?type=charts&q=population&hitsPerPage=3"

--- a/functions/test/setUpTestWorker.ts
+++ b/functions/test/setUpTestWorker.ts
@@ -1,0 +1,44 @@
+import { afterAll, beforeAll } from "vitest"
+import { unstable_startWorker } from "wrangler"
+
+type TestWorker = Awaited<ReturnType<typeof unstable_startWorker>>
+
+type WorkerFetch = (
+    pathname: string,
+    init?: Parameters<TestWorker["fetch"]>[1]
+) => ReturnType<TestWorker["fetch"]>
+
+const STARTUP_TIMEOUT_MS = 60_000
+const TEARDOWN_TIMEOUT_MS = 30_000
+
+/**
+ * Boots a workerd runtime for the enclosing test file, registering the vitest
+ * hooks that start and dispose it
+ */
+export function setUpTestWorker(configPath: string): WorkerFetch {
+    let startup: Promise<TestWorker> | undefined
+
+    beforeAll(async () => {
+        // The assignment precedes the await because vitest abandons a slow
+        // hook but not the startup it began.
+        startup = unstable_startWorker({
+            config: configPath,
+            dev: { logLevel: "none" },
+        })
+        await startup
+    }, STARTUP_TIMEOUT_MS)
+
+    afterAll(async () => {
+        const worker = await startup?.catch(() => undefined)
+        await worker?.dispose()
+    }, TEARDOWN_TIMEOUT_MS)
+
+    return async (pathname, init) => {
+        const worker = await startup
+        if (!worker)
+            throw new Error(
+                `no worker for ${configPath}: setUpTestWorker must be called at file scope`
+            )
+        return worker.fetch(`http://example.com${pathname}`, init)
+    }
+}


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Both Cloudflare worker e2e suites held their worker in a module-level `let` assigned only once `unstable_startWorker` resolved. When the `beforeAll` hook ran out of time, vitest abandoned the hook but not the startup, so the variable stayed undefined, `afterAll` threw on `worker.dispose()`, and the worker that came up a moment later belonged to nobody. `dispose()` is the only thing that kills workerd and clears its `.wrangler/tmp` dirs, so each timed-out run left a process and two directories behind, which made the next run slower and likelier to time out in turn.

`setUpTestWorker` now holds the startup promise rather than its resolved value, so teardown disposes whatever came up regardless of when. Both hooks get explicit budgets in place of vitest's inherited 10s default, which was never sized for booting a workerd runtime.

- This only ever bit locally. Miniflare's `process.on("exit")` backstop fires in a forked child but not in a terminated worker thread, and CI runs `--pool=forks` while local runs use `pool: "threads"`. So the leak accumulated on developer machines and no CI run could ever show it.
- The 60s and 30s budgets are deliberately loose against a startup that measures well under 2s idle. A budget that is too tight used to cost a leaked process, and nothing is gained by sitting near the line.