### PR TITLE
🐛🤖 prevent download previews shifting while loading

### DIFF
--- a/packages/@ourworldindata/components/src/DownloadButton/DownloadButton.scss
+++ b/packages/@ourworldindata/components/src/DownloadButton/DownloadButton.scss
@@ -26,6 +26,11 @@
         flex: 1;
     }
 
+    .download-button__preview-image {
+        flex: none;
+        margin-right: 24px;
+    }
+
     .download-button__preview-image img {
         display: block;
         box-shadow:
@@ -34,7 +39,7 @@
             0px 93px 37px 0px rgba(49, 37, 2, 0.01),
             0px 145px 41px 0px rgba(49, 37, 2, 0);
         padding: 0;
-        margin: 0 24px 0 0;
+        margin: 0;
     }
 
     .download-button__title {

--- a/packages/@ourworldindata/components/src/DownloadButton/DownloadButton.tsx
+++ b/packages/@ourworldindata/components/src/DownloadButton/DownloadButton.tsx
@@ -13,6 +13,7 @@ export function DownloadButton({
     description,
     icon,
     previewImageUrl,
+    previewImageDimensions,
     imageStyle,
     trackingNote,
     onClick,
@@ -23,6 +24,7 @@ export function DownloadButton({
     description: string
     icon?: "full" | "selected"
     previewImageUrl?: string
+    previewImageDimensions?: { width: number; height: number }
     imageStyle?: React.CSSProperties
     trackingNote?: string
     onClick: () => void | Promise<void>
@@ -62,9 +64,20 @@ export function DownloadButton({
                     )}
                 </div>
             )}
-            {previewImageUrl && (
-                <div className="download-button__preview-image">
-                    <img src={previewImageUrl} style={imageStyle} />
+            {(previewImageUrl || previewImageDimensions) && (
+                <div
+                    className="download-button__preview-image"
+                    style={previewImageDimensions}
+                >
+                    {previewImageUrl && (
+                        <img
+                            src={previewImageUrl}
+                            width={previewImageDimensions?.width}
+                            height={previewImageDimensions?.height}
+                            style={imageStyle}
+                            alt=""
+                        />
+                    )}
                 </div>
             )}
             <div className="download-button__content">

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -409,13 +409,11 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
             previewHeight = (targetHeight / targetWidth) * previewWidth
         }
 
-        const imageStyle = {
-            minWidth: previewWidth,
-            minHeight: previewHeight,
-            maxWidth: previewWidth,
-            maxHeight: previewHeight,
-            opacity: this.isReady ? 1 : 0,
+        const previewImageDimensions = {
+            width: Math.round(previewWidth),
+            height: Math.round(previewHeight),
         }
+        const imageStyle = { opacity: this.isReady ? 1 : 0 }
 
         return (
             <div>
@@ -466,6 +464,7 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                                 title="Image (PNG)"
                                 description="Suitable for most uses, widely compatible."
                                 previewImageUrl={pngPreviewUrl}
+                                previewImageDimensions={previewImageDimensions}
                                 onClick={this.onPngDownload}
                                 imageStyle={imageStyle}
                                 trackingNote="chart_download_modal_vis_png"
@@ -475,6 +474,7 @@ export class DownloadModalVisTab extends React.Component<DownloadModalProps> {
                                 title="Vector graphic (SVG)"
                                 description="For high quality prints, or further editing the chart in graphics software."
                                 previewImageUrl={svgPreviewUrl}
+                                previewImageDimensions={previewImageDimensions}
                                 onClick={this.onSvgDownload}
                                 imageStyle={imageStyle}
                                 trackingNote="chart_download_modal_vis_svg"


### PR DESCRIPTION
After opening the modal, the images loading with a slight delay were causing the button content to jump.