### PR TITLE
🐛🤖 test metadataHelpers and fix what the tests found

### DIFF
--- a/functions/_common/metadataTools.ts
+++ b/functions/_common/metadataTools.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash-es"
 import { GrapherState } from "@ourworldindata/grapher"
-import { OwidTableSlugs, OwidOrigin } from "@ourworldindata/types"
+import { OwidTableSlugs } from "@ourworldindata/types"
 import {
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
@@ -72,55 +72,11 @@ export function assembleMetadata(
             timespan,
             tolerance,
             type,
-            origins,
-            sourceLink,
-            sourceName,
             owidVariableId,
             shortName,
         } = col.def
         const lastUpdated = getLastUpdatedFromVariable(col.def)
         const nextUpdate = getNextUpdateFromVariable(col.def)
-
-        let condensedOrigins:
-            | Partial<
-                  Pick<
-                      OwidOrigin,
-                      | "attribution"
-                      | "attributionShort"
-                      | "description"
-                      | "urlDownload"
-                      | "urlMain"
-                  >
-              >[]
-            | undefined = origins?.map((origin) => {
-            const {
-                attribution,
-                attributionShort,
-                description,
-                citationFull,
-                urlDownload,
-                urlMain,
-                dateAccessed,
-            } = origin
-            return {
-                attribution,
-                attributionShort,
-                description,
-                urlDownload,
-                urlMain,
-                dateAccessed,
-                citationFull,
-            }
-        })
-
-        if (!condensedOrigins || condensedOrigins.length === 0) {
-            condensedOrigins = [
-                {
-                    attribution: sourceName,
-                    urlMain: sourceLink,
-                },
-            ]
-        }
 
         const def = col.def
 

--- a/functions/_common/metadataTools.ts
+++ b/functions/_common/metadataTools.ts
@@ -4,9 +4,8 @@ import { OwidTableSlugs, OwidOrigin } from "@ourworldindata/types"
 import {
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
-    getCitationShort,
     getAttributionFragmentsFromVariable,
-    getCitationLong,
+    getIndicatorCitations,
     stripDetailOnDemandLinks,
 } from "@ourworldindata/utils"
 import { getGrapherFilters } from "./urlTools.js"
@@ -125,23 +124,16 @@ export function assembleMetadata(
 
         const def = col.def
 
-        const citationShort = getCitationShort(
-            condensedOrigins,
-            getAttributionFragmentsFromVariable(def),
-            def.owidProcessingLevel
-        )
-
-        const citationLong = getCitationLong(
-            col.titlePublicOrDisplayName,
-            def.origins ?? [],
-            col.source ?? {},
-            getAttributionFragmentsFromVariable(def),
-            def.presentation?.attributionShort,
-            def.presentation?.titleVariant,
-            def.owidProcessingLevel,
-            undefined,
-            undefined
-        )
+        const { short: citationShort, long: citationLong } =
+            getIndicatorCitations({
+                indicatorTitle: col.titlePublicOrDisplayName,
+                origins: def.origins ?? [],
+                source: col.source ?? {},
+                attributions: getAttributionFragmentsFromVariable(def),
+                attributionShort: def.presentation?.attributionShort,
+                titleVariant: def.presentation?.titleVariant,
+                owidProcessingLevel: def.owidProcessingLevel,
+            })
 
         const titleShort = col.titlePublicOrDisplayName.title
         const attributionShort = col.titlePublicOrDisplayName.attributionShort

--- a/functions/_common/metadataTools.ts
+++ b/functions/_common/metadataTools.ts
@@ -85,7 +85,10 @@ export function assembleMetadata(
                 indicatorTitle: col.titlePublicOrDisplayName,
                 origins: def.origins ?? [],
                 source: col.source ?? {},
-                attributions: getAttributionFragmentsFromVariable(def),
+                attributions: getAttributionFragmentsFromVariable({
+                    ...def,
+                    source: col.source,
+                }),
                 attributionShort: def.presentation?.attributionShort,
                 titleVariant: def.presentation?.titleVariant,
                 owidProcessingLevel: def.owidProcessingLevel,

--- a/functions/_common/readmeTools.test.ts
+++ b/functions/_common/readmeTools.test.ts
@@ -34,4 +34,34 @@ describe(constructReadme, () => {
         expect(readme).not.toContain("#dod:")
         expect(readme).toContain("Measured in terawatt-hours.")
     })
+
+    it("credits the source name alongside the origin producer", () => {
+        const table = SynthesizeNonCountryTable({
+            columnDefs: [
+                {
+                    slug: "population",
+                    type: ColumnTypeNames.Population,
+                    name: "Population",
+                    sourceName: "WHO",
+                    origins: [
+                        { producer: "IHME", datePublished: "2020-01-01" },
+                    ],
+                    generator: getRandomNumberGenerator(1e7, 1e9),
+                    growthRateGenerator: getRandomNumberGenerator(-5, 5),
+                },
+            ],
+        })
+        const grapherState = new GrapherState({ table, ySlugs: "population" })
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const readme = constructReadme(
+            grapherState,
+            columns,
+            new URLSearchParams("")
+        )
+
+        const attribution = "WHO; IHME (2020) – processed by Our World in Data"
+        expect(readme).toContain(attribution)
+        expect(readme).toContain(`Source: ${attribution}`)
+    })
 })

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -8,8 +8,7 @@ import {
     getPhraseForProcessingLevel,
     OwidColumnDef,
     getDateRange,
-    getCitationShort,
-    getCitationLong,
+    getIndicatorCitations,
     prepareSourcesForDisplay,
     formatDate,
     stripDetailOnDemandLinks,
@@ -36,28 +35,21 @@ export function* getCitationLines(
         ...def,
         source: { name: def.sourceName },
     })
-    const citationShort = getCitationShort(
-        def.origins ?? [],
-        attributionFragments,
-        def.owidProcessingLevel
-    )
+    const { short: citationShort, long: citationLong } = getIndicatorCitations({
+        indicatorTitle: col.titlePublicOrDisplayName,
+        origins: def.origins ?? [],
+        source: col.source ?? {},
+        attributions: attributionFragments,
+        attributionShort: def.presentation?.attributionShort,
+        titleVariant: def.presentation?.titleVariant,
+        owidProcessingLevel: def.owidProcessingLevel,
+    })
 
     yield citationShort
 
     yield ""
 
     yield "#### Full citation"
-    const citationLong = getCitationLong(
-        col.titlePublicOrDisplayName,
-        def.origins ?? [],
-        col.source ?? {},
-        attributionFragments,
-        def.presentation?.attributionShort,
-        def.presentation?.titleVariant,
-        def.owidProcessingLevel,
-        undefined,
-        undefined
-    )
     yield citationLong
 }
 

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -1,5 +1,6 @@
 import * as _ from "lodash-es"
 import {
+    formatAttributions,
     formatSourceDate,
     getAttributionFragmentsFromVariable,
     getLastUpdatedFromVariable,
@@ -174,7 +175,7 @@ export function getSource(attribution: string, def: OwidColumnDef): string {
 
 export function getAttribution(def: OwidColumnDef): string {
     const attributionFragments = getAttributionFragmentsFromVariable(def)
-    const attribution = attributionFragments.join("; ")
+    const attribution = formatAttributions(attributionFragments)
     if (attribution === "") {
         return def.sourceName ?? ""
     } else return attribution

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -5,7 +5,7 @@ import {
     getAttributionFragmentsFromVariable,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
-    getProcessingPhraseForAttribution,
+    getAttributionWithProcessing,
     OwidColumnDef,
     getDateRange,
     getIndicatorCitations,
@@ -161,18 +161,6 @@ export function* getSources(
     }
 }
 
-export function getSource(attribution: string, def: OwidColumnDef): string {
-    const processingLevelPhrase = getProcessingPhraseForAttribution(
-        attribution,
-        def.owidProcessingLevel
-    )
-    const fullProcessingPhrase = processingLevelPhrase
-        ? ` – ${processingLevelPhrase} by Our World In Data`
-        : ""
-    const source = `${attribution}${fullProcessingPhrase}`
-    return source
-}
-
 export function getAttribution(def: OwidColumnDef): string {
     const attributionFragments = getAttributionFragmentsFromVariable(def)
     const attribution = formatAttributions(attributionFragments)
@@ -217,7 +205,10 @@ function* columnReadmeText(col: CoreColumn) {
 
     const attribution = getAttribution(def)
 
-    const source = getSource(attribution, def)
+    const source = getAttributionWithProcessing(
+        attribution,
+        def.owidProcessingLevel
+    )
 
     yield* getCitationLines(def, col)
 

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -31,10 +31,7 @@ export function* getCitationLines(
         `If you have limited space (e.g. in data visualizations), you can use this abbreviated in-line citation:` +
             markdownNewlineEnding
     )
-    const attributionFragments = getAttributionFragmentsFromVariable({
-        ...def,
-        source: { name: def.sourceName },
-    })
+    const attributionFragments = getAttributionFragments(col)
     const { short: citationShort, long: citationLong } = getIndicatorCitations({
         indicatorTitle: col.titlePublicOrDisplayName,
         origins: def.origins ?? [],
@@ -161,12 +158,13 @@ export function* getSources(
     }
 }
 
-export function getAttribution(def: OwidColumnDef): string {
-    const attributionFragments = getAttributionFragmentsFromVariable(def)
-    const attribution = formatAttributions(attributionFragments)
-    if (attribution === "") {
-        return def.sourceName ?? ""
-    } else return attribution
+function getAttributionFragments(col: CoreColumn): string[] {
+    const def = col.def as OwidColumnDef
+    return getAttributionFragmentsFromVariable({ ...def, source: col.source })
+}
+
+export function getAttribution(col: CoreColumn): string {
+    return formatAttributions(getAttributionFragments(col))
 }
 
 export function* getDescription(
@@ -203,7 +201,7 @@ function* columnReadmeText(col: CoreColumn) {
 
     yield ""
 
-    const attribution = getAttribution(def)
+    const attribution = getAttribution(col)
 
     const source = getAttributionWithProcessing(
         attribution,

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -1,6 +1,5 @@
 import * as _ from "lodash-es"
 import {
-    excludeUndefined,
     formatSourceDate,
     getAttributionFragmentsFromVariable,
     getLastUpdatedFromVariable,
@@ -174,12 +173,7 @@ export function getSource(attribution: string, def: OwidColumnDef): string {
 }
 
 export function getAttribution(def: OwidColumnDef): string {
-    const producers = _.uniq(
-        excludeUndefined((def.origins ?? []).map((o) => o.producer))
-    )
-
-    const attributionFragments =
-        getAttributionFragmentsFromVariable(def) ?? producers
+    const attributionFragments = getAttributionFragmentsFromVariable(def)
     const attribution = attributionFragments.join("; ")
     if (attribution === "") {
         return def.sourceName ?? ""

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -5,7 +5,7 @@ import {
     getAttributionFragmentsFromVariable,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
-    getPhraseForProcessingLevel,
+    getProcessingPhraseForAttribution,
     OwidColumnDef,
     getDateRange,
     getIndicatorCitations,
@@ -162,10 +162,10 @@ export function* getSources(
 }
 
 export function getSource(attribution: string, def: OwidColumnDef): string {
-    const processingLevelPhrase =
-        attribution.toLowerCase() !== "our world in data"
-            ? getPhraseForProcessingLevel(def.owidProcessingLevel)
-            : undefined
+    const processingLevelPhrase = getProcessingPhraseForAttribution(
+        attribution,
+        def.owidProcessingLevel
+    )
     const fullProcessingPhrase = processingLevelPhrase
         ? ` – ${processingLevelPhrase} by Our World In Data`
         : ""

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -180,7 +180,7 @@ export function getAttribution(def: OwidColumnDef): string {
 
     const attributionFragments =
         getAttributionFragmentsFromVariable(def) ?? producers
-    const attribution = attributionFragments.join(", ")
+    const attribution = attributionFragments.join("; ")
     if (attribution === "") {
         return def.sourceName ?? ""
     } else return attribution

--- a/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import {
     OwidProcessingLevel,
-    getPhraseForProcessingLevel,
+    getProcessingPhraseForAttribution,
     formatSourceDate,
     getDateRange,
 } from "@ourworldindata/utils"
@@ -21,14 +21,14 @@ export const makeSource = ({
 }): React.ReactNode => {
     if (!attribution) return null
     const isEmbedded = isEmbeddedInADataPage ?? true
-    const processingLevelPhrase =
-        getPhraseForProcessingLevel(owidProcessingLevel)
-    const hideProcessingPhase =
-        attribution.toLowerCase() === "our world in data"
+    const processingLevelPhrase = getProcessingPhraseForAttribution(
+        attribution,
+        owidProcessingLevel
+    )
     return (
         <>
             <SimpleMarkdownText text={attribution} useParagraphs={false} />
-            {!hideProcessingPhase && (
+            {processingLevelPhrase && (
                 <>
                     {" – "}
                     {isEmbedded ? (

--- a/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
@@ -2,7 +2,6 @@ import * as React from "react"
 import {
     OwidProcessingLevel,
     getPhraseForProcessingLevel,
-    splitSourceTextIntoFragments,
     formatSourceDate,
     getDateRange,
 } from "@ourworldindata/utils"
@@ -86,6 +85,10 @@ export const makeUnitConversionFactor = ({
 }): React.ReactNode => {
     if (!unitConversionFactor || unitConversionFactor === 1) return null
     return unitConversionFactor
+}
+
+const splitSourceTextIntoFragments = (text: string | undefined): string[] => {
+    return text ? text.split(";").map((fragment) => fragment.trim()) : []
 }
 
 export const makeLinks = ({ link }: { link?: string }): React.ReactNode => {

--- a/packages/@ourworldindata/grapher/src/core/sourcesLine.ts
+++ b/packages/@ourworldindata/grapher/src/core/sourcesLine.ts
@@ -104,10 +104,6 @@ const getDimensionPropertiesForActiveTab = (
     return [y, x, color, size]
 }
 
-/**
- * Who to credit for the columns a chart draws, e.g. `"World Bank; UN WPP
- * (2024)"`.
- */
 export const buildSourcesLineFromColumns = (columns: CoreColumn[]): string => {
     const columnsWithSources = columns.filter(
         (column) => !!column.source.name || !_.isEmpty(column.def.origins)

--- a/packages/@ourworldindata/grapher/src/core/sourcesLine.ts
+++ b/packages/@ourworldindata/grapher/src/core/sourcesLine.ts
@@ -1,6 +1,7 @@
 import * as _ from "lodash-es"
 import {
     ColumnSlug,
+    formatAttributionsShortened,
     getAttributionFragmentsFromVariable,
 } from "@ourworldindata/utils"
 import {
@@ -116,10 +117,5 @@ export const buildSourcesLineFromColumns = (columns: CoreColumn[]): string => {
         })
     )
 
-    const uniqueAttributions = _.uniq(attributions)
-
-    if (uniqueAttributions.length > 3)
-        return `${uniqueAttributions[0]} and other sources`
-
-    return uniqueAttributions.join("; ")
+    return formatAttributionsShortened(_.uniq(attributions))
 }

--- a/packages/@ourworldindata/grapher/src/core/sourcesLine.ts
+++ b/packages/@ourworldindata/grapher/src/core/sourcesLine.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash-es"
 import {
     ColumnSlug,
-    getOriginAttributionFragments,
+    getAttributionFragmentsFromVariable,
 } from "@ourworldindata/utils"
 import {
     ColumnTypeMap,
@@ -105,33 +105,22 @@ const getDimensionPropertiesForActiveTab = (
 }
 
 /**
- * Build a sources line from an array of columns.
- * Extracts attributions from column metadata and joins them into a single string.
+ * Who to credit for the columns a chart draws, e.g. `"World Bank; UN WPP
+ * (2024)"`.
  */
 export const buildSourcesLineFromColumns = (columns: CoreColumn[]): string => {
     const columnsWithSources = columns.filter(
         (column) => !!column.source.name || !_.isEmpty(column.def.origins)
     )
 
-    const attributions = columnsWithSources.flatMap((column) => {
-        const { presentation = {} } = column.def
-        // If the variable metadata specifies an attribution on the
-        // variable level then this is preferred over assembling it from
-        // the source and origins
-        if (
-            presentation.attribution !== undefined &&
-            presentation.attribution !== ""
-        )
-            return [presentation.attribution]
-        else {
-            const originFragments = getOriginAttributionFragments(
-                column.def.origins
-            )
-            return [column.source.name, ...originFragments]
-        }
-    })
+    const attributions = columnsWithSources.flatMap((column) =>
+        getAttributionFragmentsFromVariable({
+            ...column.def,
+            source: column.source,
+        })
+    )
 
-    const uniqueAttributions = _.uniq(_.compact(attributions))
+    const uniqueAttributions = _.uniq(attributions)
 
     if (uniqueAttributions.length > 3)
         return `${uniqueAttributions[0]} and other sources`

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -7,7 +7,7 @@ import {
     Bounds,
     canWriteToClipboard,
     fetchWithTimeout,
-    getOriginAttributionFragments,
+    getOriginAttributions,
     makeDownloadCodeExamples,
     getProcessingPhraseForAttribution,
     SERVER_SIDE_DOWNLOAD_HELP_TEXT,
@@ -55,7 +55,6 @@ import { Modal } from "./Modal"
 import { GrapherRasterizeFn } from "../captionedChart/StaticChartRasterizer.js"
 import { TabPanel } from "react-aria-components"
 import { TabItem, Tabs } from "../tabs/Tabs.js"
-import * as R from "remeda"
 import {
     DEFAULT_GRAPHER_BOUNDS,
     DEFAULT_GRAPHER_BOUNDS_SQUARE,
@@ -551,20 +550,16 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
         (o) => o.urlMain ?? o.datePublished
     )
 
-    const attributions = getOriginAttributionFragments(originsUniq)
+    const attributions = getOriginAttributions(originsUniq)
 
-    const sourceLinks = R.zip(attributions, originsUniq).map(
-        ([attribution, origin]) => {
-            const link = origin?.urlMain
-
-            if (link)
-                return (
-                    <li key={link}>
-                        <a href={link}>{attribution}</a>
-                    </li>
-                )
-            else return <li key={attribution}>{attribution}</li>
-        }
+    const sourceLinks = attributions.map(({ label, url }) =>
+        url ? (
+            <li key={url}>
+                <a href={url}>{label}</a>
+            </li>
+        ) : (
+            <li key={label}>{label}</li>
+        )
     )
 
     // Find the highest processing level of all columns
@@ -577,7 +572,7 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
         }, undefined)
 
     const processingLevelPhrase = getProcessingPhraseForAttribution(
-        attributions,
+        attributions.map(({ label }) => label),
         owidProcessingLevel
     )
     const fullProcessingPhrase = processingLevelPhrase ? (

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -9,7 +9,7 @@ import {
     fetchWithTimeout,
     getOriginAttributionFragments,
     makeDownloadCodeExamples,
-    getPhraseForProcessingLevel,
+    getProcessingPhraseForAttribution,
     SERVER_SIDE_DOWNLOAD_HELP_TEXT,
     triggerDownloadFromBlob,
     triggerDownloadFromUrl,
@@ -576,12 +576,10 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
             return undefined
         }, undefined)
 
-    const sourceIsOwid =
-        attributions.length === 1 &&
-        attributions[0].toLowerCase() === "our world in data"
-    const processingLevelPhrase = !sourceIsOwid
-        ? getPhraseForProcessingLevel(owidProcessingLevel)
-        : undefined
+    const processingLevelPhrase = getProcessingPhraseForAttribution(
+        attributions,
+        owidProcessingLevel
+    )
     const fullProcessingPhrase = processingLevelPhrase ? (
         <>
             {" "}

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -449,7 +449,7 @@ export class Source extends React.Component<SourceProps> {
         const attributionFragments =
             getAttributionFragmentsFromVariable(this.def) ?? this.producers
         if (attributionFragments.length === 0) return undefined
-        return attributionFragments.join(", ")
+        return attributionFragments.join("; ")
     }
 
     @computed get lastUpdated(): string | undefined {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -5,7 +5,6 @@ import {
     getAttributionFragmentsFromVariable,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
-    excludeUndefined,
     DisplaySource,
     prepareSourcesForDisplay,
     OwidSource,
@@ -440,14 +439,10 @@ export class Source extends React.Component<SourceProps> {
         return undefined
     }
 
-    @computed private get producers(): string[] {
-        if (!this.def.origins) return []
-        return _.uniq(excludeUndefined(this.def.origins.map((o) => o.producer)))
-    }
-
     @computed get attributions(): string | undefined {
-        const attributionFragments =
-            getAttributionFragmentsFromVariable(this.def) ?? this.producers
+        const attributionFragments = getAttributionFragmentsFromVariable(
+            this.def
+        )
         if (attributionFragments.length === 0) return undefined
         return attributionFragments.join("; ")
     }

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -402,14 +402,6 @@ export class Source extends React.Component<SourceProps> {
         })
     }
 
-    @computed get citationShort(): string {
-        return this.citations.short
-    }
-
-    @computed get citationLong(): string {
-        return this.citations.long
-    }
-
     @computed private get source(): OwidSource {
         return this.def.source ?? {}
     }
@@ -577,8 +569,8 @@ export class Source extends React.Component<SourceProps> {
                     How to cite this data:
                 </h3>
                 <DataCitation
-                    citationShort={this.citationShort}
-                    citationLong={this.citationLong}
+                    citationShort={this.citations.short}
+                    citationLong={this.citations.long}
                 />
             </div>
         )

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -2,6 +2,7 @@ import * as _ from "lodash-es"
 import * as R from "remeda"
 import {
     Bounds,
+    formatAttributions,
     getAttributionFragmentsFromVariable,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
@@ -436,7 +437,7 @@ export class Source extends React.Component<SourceProps> {
             this.def
         )
         if (attributionFragments.length === 0) return undefined
-        return attributionFragments.join("; ")
+        return formatAttributions(attributionFragments)
     }
 
     @computed get lastUpdated(): string | undefined {

--- a/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/SourcesModal.tsx
@@ -11,8 +11,7 @@ import {
     OwidSource,
     IndicatorTitleWithFragments,
     joinTitleFragments,
-    getCitationShort,
-    getCitationLong,
+    getIndicatorCitations,
 } from "@ourworldindata/utils"
 import {
     IndicatorSources,
@@ -392,26 +391,24 @@ export class Source extends React.Component<SourceProps> {
         return { ...this.column.def, source: this.column.source }
     }
 
+    @computed private get citations(): { short: string; long: string } {
+        return getIndicatorCitations({
+            indicatorTitle: this.titleWithFragments,
+            origins: this.def.origins ?? [],
+            source: this.source,
+            attributions: getAttributionFragmentsFromVariable(this.def),
+            attributionShort: this.def.presentation?.attributionShort,
+            titleVariant: this.def.presentation?.titleVariant,
+            owidProcessingLevel: this.def.owidProcessingLevel,
+        })
+    }
+
     @computed get citationShort(): string {
-        return getCitationShort(
-            this.def.origins ?? [],
-            getAttributionFragmentsFromVariable(this.def),
-            this.def.owidProcessingLevel
-        )
+        return this.citations.short
     }
 
     @computed get citationLong(): string {
-        return getCitationLong(
-            this.titleWithFragments,
-            this.def.origins ?? [],
-            this.source,
-            getAttributionFragmentsFromVariable(this.def),
-            this.def.presentation?.attributionShort,
-            this.def.presentation?.titleVariant,
-            this.def.owidProcessingLevel,
-            undefined,
-            undefined
-        )
+        return this.citations.long
     }
 
     @computed private get source(): OwidSource {

--- a/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
+++ b/packages/@ourworldindata/grapher/src/tooltip/TooltipContents.tsx
@@ -331,10 +331,9 @@ export function makeTooltipRoundingNotice(
     { plural }: { plural: boolean } = { plural: true }
 ): string {
     const uniqueNumSigFigs = _.uniq(numSignificantFigures)
-    const formattedNumSigFigs = formatInlineList(
-        _.sortBy(uniqueNumSigFigs),
-        "or"
-    )
+    const formattedNumSigFigs = formatInlineList(_.sortBy(uniqueNumSigFigs), {
+        connector: "or",
+    })
 
     const values = plural ? "Values" : "Value"
     const are = plural ? "are" : "is"

--- a/packages/@ourworldindata/utils/src/Util.test.ts
+++ b/packages/@ourworldindata/utils/src/Util.test.ts
@@ -30,6 +30,8 @@ import {
     traverseEnrichedBlock,
     cartesian,
     formatInlineList,
+    formatAuthors,
+    formatAuthorsForBibtex,
     flattenNonTopicNodes,
     imemo,
     normaliseToSingleDigitNumber,
@@ -1112,9 +1114,73 @@ describe(formatInlineList, () => {
     })
 
     it("formats four items correctly using 'or'", () => {
-        expect(formatInlineList(["a", "b", "c", "d"], "or")).toEqual(
-            "a, b, c or d"
+        expect(
+            formatInlineList(["a", "b", "c", "d"], { connector: "or" })
+        ).toEqual("a, b, c or d")
+    })
+
+    it("adds an oxford comma when asked", () => {
+        expect(
+            formatInlineList(["a", "b", "c"], { oxfordComma: true })
+        ).toEqual("a, b, and c")
+    })
+
+    it("does not add an oxford comma to two items", () => {
+        expect(formatInlineList(["a", "b"], { oxfordComma: true })).toEqual(
+            "a and b"
         )
+    })
+})
+
+describe(formatAuthors, () => {
+    it("formats zero authors", () => {
+        expect(formatAuthors([])).toEqual("")
+    })
+
+    it("formats one author", () => {
+        expect(formatAuthors(["Author 1"])).toEqual("Author 1")
+    })
+
+    it("formats two authors", () => {
+        expect(formatAuthors(["Author 1", "Author 2"])).toEqual(
+            "Author 1 and Author 2"
+        )
+    })
+
+    it("formats three authors", () => {
+        const authors = ["Author 1", "Author 2", "Author 3"]
+        expect(formatAuthors(authors)).toEqual(
+            "Author 1, Author 2, and Author 3"
+        )
+    })
+
+    it("formats four authors", () => {
+        const authors = ["Author 1", "Author 2", "Author 3", "Author 4"]
+        expect(formatAuthors(authors)).toEqual(
+            "Author 1, Author 2, Author 3, and Author 4"
+        )
+    })
+})
+
+describe(formatAuthorsForBibtex, () => {
+    it("formats zero authors for bibtex", () => {
+        expect(formatAuthorsForBibtex([])).toEqual("")
+    })
+
+    it("formats one author for bibtex", () => {
+        expect(formatAuthorsForBibtex(["Author 1"])).toEqual("Author 1")
+    })
+
+    it("formats two authors for bibtex", () => {
+        expect(formatAuthorsForBibtex(["Author 1", "Author 2"])).toEqual(
+            "Author 1 and Author 2"
+        )
+    })
+
+    it("formats three authors for bibtex", () => {
+        expect(
+            formatAuthorsForBibtex(["Author 1", "Author 2", "Author 3"])
+        ).toEqual("Author 1 and Author 2 and Author 3")
     })
 })
 

--- a/packages/@ourworldindata/utils/src/Util.ts
+++ b/packages/@ourworldindata/utils/src/Util.ts
@@ -2405,11 +2405,23 @@ export function flattenNonTopicNodes(tagGraph: TagGraphRoot): TagGraphRoot {
 
 export function formatInlineList(
     array: unknown[],
-    connector: "and" | "or" = "and"
+    {
+        connector = "and",
+        oxfordComma = false,
+    }: { connector?: "and" | "or"; oxfordComma?: boolean } = {}
 ): string {
     if (array.length === 0) return ""
     if (array.length === 1) return `${array[0]}`
-    return `${array.slice(0, -1).join(", ")} ${connector} ${R.last(array)}`
+    const comma = oxfordComma && array.length > 2 ? "," : ""
+    return `${array.slice(0, -1).join(", ")}${comma} ${connector} ${R.last(array)}`
+}
+
+export function formatAuthors(authors: string[]): string {
+    return formatInlineList(authors, { oxfordComma: true })
+}
+
+export function formatAuthorsForBibtex(authors: string[]): string {
+    return authors.join(" and ")
 }
 
 // The below comment marks this function as side-effect free, meaning that the bundler

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.test.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.test.ts
@@ -80,11 +80,7 @@ describe(getPhraseForArchivalDate, () => {
         )
     })
 
-    // TODO: return undefined when the date cannot be parsed, rather than
-    // putting "Invalid Date" into a citation.
-    it("renders an invalid date for an unparseable archival date", () => {
-        expect(getPhraseForArchivalDate("nope")).toEqual(
-            "(archived on Invalid Date)."
-        )
+    it("has no phrase for an unparseable archival date", () => {
+        expect(getPhraseForArchivalDate("nope")).toBeUndefined()
     })
 })

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.test.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
-import { formatAsArchivalDate, parseArchivalDate } from "./archivalDate.js"
+import {
+    formatAsArchivalDate,
+    getPhraseForArchivalDate,
+    parseArchivalDate,
+} from "./archivalDate.js"
 import dayjs from "../dayjs.js"
 import timezoneMock from "timezone-mock"
 
@@ -56,5 +60,31 @@ describe(formatAsArchivalDate, () => {
         const date = dayjs("2020-01-21T12:34:56Z")
         const formattedDate = formatAsArchivalDate(date)
         expect(formattedDate).toBe("20200121-123456")
+    })
+})
+
+describe(getPhraseForArchivalDate, () => {
+    it("returns undefined if there is no archival date", () => {
+        expect(getPhraseForArchivalDate(undefined)).toBeUndefined()
+    })
+
+    it("formats an archival timestamp", () => {
+        expect(getPhraseForArchivalDate("20250414-074331")).toEqual(
+            "(archived on April 14, 2025)."
+        )
+    })
+
+    it("formats an ISO date", () => {
+        expect(getPhraseForArchivalDate("2025-04-14")).toEqual(
+            "(archived on April 14, 2025)."
+        )
+    })
+
+    // TODO: return undefined when the date cannot be parsed, rather than
+    // putting "Invalid Date" into a citation.
+    it("renders an invalid date for an unparseable archival date", () => {
+        expect(getPhraseForArchivalDate("nope")).toEqual(
+            "(archived on Invalid Date)."
+        )
     })
 })

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.test.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.test.ts
@@ -80,7 +80,7 @@ describe(getPhraseForArchivalDate, () => {
         )
     })
 
-    it("has no phrase for an unparseable archival date", () => {
-        expect(getPhraseForArchivalDate("nope")).toBeUndefined()
+    it("omits the date if the archival date is unparseable", () => {
+        expect(getPhraseForArchivalDate("nope")).toEqual("(archived).")
     })
 })

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.ts
@@ -57,6 +57,8 @@ export const getPhraseForArchivalDate = (
     if (!archivalDate) return undefined
 
     const parsedDate = parseArchivalDate(archivalDate)
+    if (!parsedDate.isValid()) return undefined
+
     const formatted = formatDateForCitation(parsedDate)
     return `(archived on ${formatted}).`
 }

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.ts
@@ -50,7 +50,6 @@ export const getDateForArchival = (): ArchivalTimestamp => {
 export const formatDateForCitation = (date: dayjs.Dayjs): string =>
     date.format("MMMM D, YYYY")
 
-/** Pins a citation to a snapshot: `"(archived on April 14, 2025)."` */
 export const getPhraseForArchivalDate = (
     archivalDate: string | undefined
 ): string | undefined => {

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.ts
@@ -56,7 +56,7 @@ export const getPhraseForArchivalDate = (
     if (!archivalDate) return undefined
 
     const parsedDate = parseArchivalDate(archivalDate)
-    if (!parsedDate.isValid()) return undefined
+    if (!parsedDate.isValid()) return "(archived)."
 
     const formatted = formatDateForCitation(parsedDate)
     return `(archived on ${formatted}).`

--- a/packages/@ourworldindata/utils/src/archival/archivalDate.ts
+++ b/packages/@ourworldindata/utils/src/archival/archivalDate.ts
@@ -46,3 +46,17 @@ export const getDateForArchival = (): ArchivalTimestamp => {
 
     return { date: date.toDate(), formattedDate }
 }
+
+export const formatDateForCitation = (date: dayjs.Dayjs): string =>
+    date.format("MMMM D, YYYY")
+
+/** Pins a citation to a snapshot: `"(archived on April 14, 2025)."` */
+export const getPhraseForArchivalDate = (
+    archivalDate: string | undefined
+): string | undefined => {
+    if (!archivalDate) return undefined
+
+    const parsedDate = parseArchivalDate(archivalDate)
+    const formatted = formatDateForCitation(parsedDate)
+    return `(archived on ${formatted}).`
+}

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -161,6 +161,8 @@ export {
 export {
     getOriginAttributions,
     getAttributionFragmentsFromVariable,
+    formatAttributions,
+    formatAttributionsShortened,
     getETLPathComponents,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -164,12 +164,12 @@ export {
     getETLPathComponents,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
-    getPhraseForProcessingLevel,
+    getProcessingPhraseForAttribution,
+    getYearSuffixFromOrigin,
     prepareSourcesForDisplay,
     formatSourceDate,
     getDateRange,
     getIndicatorCitations,
-    getYearSuffixFromOrigin,
 } from "./metadataHelpers.js"
 
 export { getAllVariableIds } from "./multiDim.js"

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -159,7 +159,7 @@ export {
 } from "./Util.js"
 
 export {
-    getOriginAttributionFragments,
+    getOriginAttributions,
     getAttributionFragmentsFromVariable,
     getETLPathComponents,
     getLastUpdatedFromVariable,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -124,6 +124,8 @@ export {
     getAllChildrenOfArea,
     flattenNonTopicNodes,
     formatInlineList,
+    formatAuthors,
+    formatAuthorsForBibtex,
     lazy,
     getParentIndicatorIdFromChartConfig,
     isArrayDifferentFromReference,
@@ -160,19 +162,15 @@ export {
     getOriginAttributionFragments,
     getAttributionFragmentsFromVariable,
     getETLPathComponents,
-    formatAuthors,
-    formatAuthorsForBibtex,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
     getPhraseForProcessingLevel,
-    splitSourceTextIntoFragments,
     prepareSourcesForDisplay,
     formatSourceDate,
     getDateRange,
     getCitationLong,
     getCitationShort,
     getCitationDatapage,
-    getPhraseForArchivalDate,
     getYearSuffixFromOrigin,
 } from "./metadataHelpers.js"
 
@@ -380,6 +378,7 @@ export {
     convertToArchivalDateStringIfNecessary,
     formatAsArchivalDate,
     getDateForArchival,
+    getPhraseForArchivalDate,
     parseArchivalDate,
 } from "./archival/archivalDate.js"
 

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -165,7 +165,6 @@ export {
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
     getProcessingPhraseForAttribution,
-    getYearSuffixFromOrigin,
     prepareSourcesForDisplay,
     formatSourceDate,
     getDateRange,

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -168,9 +168,7 @@ export {
     prepareSourcesForDisplay,
     formatSourceDate,
     getDateRange,
-    getCitationLong,
-    getCitationShort,
-    getCitationDatapage,
+    getIndicatorCitations,
     getYearSuffixFromOrigin,
 } from "./metadataHelpers.js"
 

--- a/packages/@ourworldindata/utils/src/index.ts
+++ b/packages/@ourworldindata/utils/src/index.ts
@@ -166,6 +166,7 @@ export {
     getETLPathComponents,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
+    getAttributionWithProcessing,
     getProcessingPhraseForAttribution,
     prepareSourcesForDisplay,
     formatSourceDate,

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -558,8 +558,17 @@ describe(getIndicatorCitations, () => {
 
         it("credits us when there is nothing else to credit", () => {
             expect(citations({ attributions: [] }).short).toEqual(
-                "Our World in Data – processed by Our World in Data"
+                "Our World in Data"
             )
+        })
+
+        it("does not say we processed data that is only ours", () => {
+            expect(
+                citations({
+                    attributions: ["Our World in Data"],
+                    owidProcessingLevel: "minor",
+                }).short
+            ).toEqual("Our World in Data")
         })
 
         it("ignores the origins when there are no attributions", () => {
@@ -570,7 +579,7 @@ describe(getIndicatorCitations, () => {
                     ],
                     attributions: [],
                 }).short
-            ).toEqual("Our World in Data – processed by Our World in Data")
+            ).toEqual("Our World in Data")
         })
     })
 
@@ -613,7 +622,7 @@ describe(getIndicatorCitations, () => {
                     attributions: [],
                 }).long
             ).toEqual(
-                "Our World in Data – processed by Our World in Data. " +
+                "Our World in Data. " +
                     "“Indicator” [dataset]. " +
                     "Producer, “Title” [original data]."
             )

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -545,9 +545,9 @@ describe(getIndicatorCitations, () => {
             )
         })
 
-        it("credits us when there is nothing else to credit", () => {
+        it("credits nobody when there is nothing to credit", () => {
             expect(citations({ attributions: [] }).short).toEqual(
-                "Our World in Data"
+                " – processed by Our World in Data"
             )
         })
 
@@ -568,7 +568,7 @@ describe(getIndicatorCitations, () => {
                     ],
                     attributions: [],
                 }).short
-            ).toEqual("Our World in Data")
+            ).toEqual(" – processed by Our World in Data")
         })
     })
 
@@ -598,7 +598,7 @@ describe(getIndicatorCitations, () => {
             )
         })
 
-        it("credits us when there is nothing else to credit", () => {
+        it("credits nobody when there is nothing to credit", () => {
             expect(
                 citations({
                     origins: [
@@ -611,7 +611,7 @@ describe(getIndicatorCitations, () => {
                     attributions: [],
                 }).long
             ).toEqual(
-                "Our World in Data. " +
+                " – processed by Our World in Data. " +
                     "“Indicator” [dataset]. " +
                     "Producer, “Title” [original data]."
             )

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -8,92 +8,118 @@ import {
     getETLPathComponents,
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
-    getOriginAttributionFragments,
+    getOriginAttributions,
     getProcessingPhraseForAttribution,
     getYearSuffixFromOrigin,
     prepareSourcesForDisplay,
 } from "./metadataHelpers.js"
 import dayjs from "./dayjs.js"
 
-describe(getOriginAttributionFragments, () => {
+describe(getOriginAttributions, () => {
     it("returns an empty array for undefined origins", () => {
-        expect(getOriginAttributionFragments(undefined)).toEqual([])
+        expect(getOriginAttributions(undefined)).toEqual([])
     })
 
     it("returns an empty array for no origins", () => {
-        expect(getOriginAttributionFragments([])).toEqual([])
+        expect(getOriginAttributions([])).toEqual([])
     })
 
     it("prefers an explicit attribution over producer and year", () => {
         expect(
-            getOriginAttributionFragments([
+            getOriginAttributions([
                 {
                     attribution: "Custom attribution",
                     producer: "Producer",
                     datePublished: "2019-01-01",
                 },
             ])
-        ).toEqual(["Custom attribution"])
+        ).toEqual([{ label: "Custom attribution", url: undefined }])
     })
 
     it("appends the publication year to the producer", () => {
         expect(
-            getOriginAttributionFragments([
+            getOriginAttributions([
                 { producer: "Producer", datePublished: "2019-01-01" },
             ])
-        ).toEqual(["Producer (2019)"])
+        ).toEqual([{ label: "Producer (2019)", url: undefined }])
     })
 
     it("accepts a year-only publication date", () => {
         expect(
-            getOriginAttributionFragments([
+            getOriginAttributions([
                 { producer: "Producer", datePublished: "2019" },
             ])
-        ).toEqual(["Producer (2019)"])
+        ).toEqual([{ label: "Producer (2019)", url: undefined }])
     })
 
     it("omits the year if there is no publication date", () => {
-        expect(
-            getOriginAttributionFragments([{ producer: "Producer" }])
-        ).toEqual(["Producer"])
+        expect(getOriginAttributions([{ producer: "Producer" }])).toEqual([
+            { label: "Producer", url: undefined },
+        ])
     })
 
     it("omits the year if the publication date is unparseable", () => {
         expect(
-            getOriginAttributionFragments([
+            getOriginAttributions([
                 { producer: "Producer", datePublished: "not a date" },
             ])
-        ).toEqual(["Producer"])
+        ).toEqual([{ label: "Producer", url: undefined }])
     })
 
-    // TODO: fall back to the origin's title, or drop the origin, instead of
-    // interpolating a missing producer. This reaches the sources line under a
-    // chart and the download modal's source list.
-    it("renders a literal undefined when an origin has no producer", () => {
+    it("carries the origin's url", () => {
         expect(
-            getOriginAttributionFragments([{ datePublished: "2019" }])
-        ).toEqual(["undefined (2019)"])
-    })
-
-    // TODO: treat an empty attribution like a missing one and fall through to
-    // the producer. `??` only catches null and undefined, so the origin
-    // contributes a blank label.
-    it("keeps an empty attribution instead of using the producer", () => {
-        expect(
-            getOriginAttributionFragments([
-                { attribution: "", producer: "Producer" },
+            getOriginAttributions([
+                { producer: "Producer", urlMain: "https://example.org" },
             ])
-        ).toEqual([""])
+        ).toEqual([{ label: "Producer", url: "https://example.org" }])
+    })
+
+    it("falls back to the title if there is no producer", () => {
+        expect(
+            getOriginAttributions([{ title: "Title", datePublished: "2019" }])
+        ).toEqual([{ label: "Title (2019)", url: undefined }])
+    })
+
+    it("falls back to the url if there is no producer or title", () => {
+        expect(
+            getOriginAttributions([
+                { urlMain: "https://example.org", datePublished: "2019" },
+            ])
+        ).toEqual([
+            {
+                label: "https://example.org (2019)",
+                url: "https://example.org",
+            },
+        ])
+    })
+
+    it("drops an origin with nothing to name it", () => {
+        expect(
+            getOriginAttributions([
+                { datePublished: "2019" },
+                { producer: "Producer" },
+            ])
+        ).toEqual([{ label: "Producer", url: undefined }])
+    })
+
+    it("ignores an empty attribution and uses the producer", () => {
+        expect(
+            getOriginAttributions([{ attribution: "", producer: "Producer" }])
+        ).toEqual([{ label: "Producer", url: undefined }])
     })
 
     it("keeps duplicates and preserves the order of origins", () => {
         expect(
-            getOriginAttributionFragments([
+            getOriginAttributions([
                 { producer: "B" },
                 { producer: "A" },
                 { producer: "B" },
             ])
-        ).toEqual(["B", "A", "B"])
+        ).toEqual([
+            { label: "B", url: undefined },
+            { label: "A", url: undefined },
+            { label: "B", url: undefined },
+        ])
     })
 })
 
@@ -452,12 +478,10 @@ describe(prepareSourcesForDisplay, () => {
         ).toEqual([{ label: "Producer" }])
     })
 
-    // TODO: omit the separator when there is no producer, so the label reads
-    // "Title" rather than opening with a dangling dash.
-    it("starts the label with a separator when an origin has no producer", () => {
+    it("omits the separator when an origin has no producer", () => {
         expect(
             prepareSourcesForDisplay({ origins: [{ title: "Title" }] })
-        ).toEqual([{ label: " – Title" }])
+        ).toEqual([{ label: "Title" }])
     })
 
     it("keeps the order of the origins", () => {
@@ -682,15 +706,21 @@ describe(getIndicatorCitations, () => {
             )
         })
 
-        // TODO: omit the quoted title when an origin has neither `title` nor
-        // `titleSnapshot`, instead of quoting the string "undefined".
-        it("renders a literal undefined when an origin has no title", () => {
+        it("omits the quoted title when an origin has none", () => {
             expect(
                 citations({ origins: [{ producer: "Producer" }] }).long
             ).toEqual(
                 "Attribution – processed by Our World in Data. " +
                     "“Indicator” [dataset]. " +
-                    "Producer, “undefined” [original data]."
+                    "Producer [original data]."
+            )
+        })
+
+        it("omits the producer when an origin has none", () => {
+            expect(citations({ origins: [{ title: "Title" }] }).long).toEqual(
+                "Attribution – processed by Our World in Data. " +
+                    "“Indicator” [dataset]. " +
+                    "“Title” [original data]."
             )
         })
 

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -221,10 +221,6 @@ describe(getLastUpdatedFromVariable, () => {
         ).toEqual("2020-01-01")
     })
 
-    // TODO: parse and format in UTC. `new Date("2022-05-05")` is UTC
-    // midnight but is formatted in local time, so this returns 2022-05-04 at
-    // negative UTC offsets. The assertion below only holds because CI and most
-    // of the team run at or ahead of UTC.
     it("picks the latest date accessed across origins", () => {
         expect(
             getLastUpdatedFromVariable({
@@ -246,6 +242,12 @@ describe(getLastUpdatedFromVariable, () => {
                 ],
             })
         ).toEqual("2020-01-01")
+    })
+
+    it("returns undefined if no origin has a date accessed", () => {
+        expect(
+            getLastUpdatedFromVariable({ origins: [{ producer: "Producer" }] })
+        ).toBeUndefined()
     })
 
     it("returns undefined if there is nothing to go on", () => {

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -10,7 +10,6 @@ import {
     getNextUpdateFromVariable,
     getOriginAttributions,
     getProcessingPhraseForAttribution,
-    getYearSuffixFromOrigin,
     prepareSourcesForDisplay,
 } from "./metadataHelpers.js"
 import dayjs from "./dayjs.js"
@@ -493,39 +492,6 @@ describe(prepareSourcesForDisplay, () => {
     })
 })
 
-describe(getYearSuffixFromOrigin, () => {
-    it("prefers the date accessed", () => {
-        expect(
-            getYearSuffixFromOrigin({
-                dateAccessed: "2024-03-07",
-                datePublished: "2019-01-01",
-            })
-        ).toEqual(" (2024)")
-    })
-
-    it("falls back to the date published", () => {
-        expect(
-            getYearSuffixFromOrigin({ datePublished: "2019-01-01" })
-        ).toEqual(" (2019)")
-    })
-
-    it("accepts year-only dates", () => {
-        expect(getYearSuffixFromOrigin({ datePublished: "2019" })).toEqual(
-            " (2019)"
-        )
-    })
-
-    it("returns an empty string if there is no date", () => {
-        expect(getYearSuffixFromOrigin({})).toEqual("")
-    })
-
-    it("returns an empty string if the date is unparseable", () => {
-        expect(getYearSuffixFromOrigin({ dateAccessed: "not a date" })).toEqual(
-            ""
-        )
-    })
-})
-
 describe(getIndicatorCitations, () => {
     const citations = (
         overrides: Partial<Parameters<typeof getIndicatorCitations>[0]> = {}
@@ -590,12 +556,13 @@ describe(getIndicatorCitations, () => {
             )
         })
 
-        // TODO: fire the intended fallback on an empty attributions array.
-        // `attributions ?? producersWithYear` only catches null and undefined,
-        // and every caller passes a non-optional string[], so
-        // `producersWithYear` is unreachable and the citation opens with a bare
-        // separator.
-        it("does not fall back to the origins if there are no attributions", () => {
+        it("credits us when there is nothing else to credit", () => {
+            expect(citations({ attributions: [] }).short).toEqual(
+                "Our World in Data – processed by Our World in Data"
+            )
+        })
+
+        it("ignores the origins when there are no attributions", () => {
             expect(
                 citations({
                     origins: [
@@ -603,16 +570,7 @@ describe(getIndicatorCitations, () => {
                     ],
                     attributions: [],
                 }).short
-            ).toEqual(" – processed by Our World in Data")
-        })
-
-        // TODO: return "Our World in Data" when there is no attribution at all,
-        // rather than a separator with nothing before it. Mirrors the rule that
-        // hides the processing phrase when the attribution is already us.
-        it("has nothing to attribute without attributions or origins", () => {
-            expect(citations({ attributions: [] }).short).toEqual(
-                " – processed by Our World in Data"
-            )
+            ).toEqual("Our World in Data – processed by Our World in Data")
         })
     })
 
@@ -642,10 +600,7 @@ describe(getIndicatorCitations, () => {
             )
         })
 
-        // TODO: fire the intended fallback on an empty attributions array, as
-        // in short above. The citation currently opens with a bare separator
-        // even though the origins name a producer.
-        it("does not fall back to the origins if there are no attributions", () => {
+        it("credits us when there is nothing else to credit", () => {
             expect(
                 citations({
                     origins: [
@@ -658,7 +613,7 @@ describe(getIndicatorCitations, () => {
                     attributions: [],
                 }).long
             ).toEqual(
-                " – processed by Our World in Data. " +
+                "Our World in Data – processed by Our World in Data. " +
                     "“Indicator” [dataset]. " +
                     "Producer, “Title” [original data]."
             )

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -509,13 +509,8 @@ describe(getIndicatorCitations, () => {
         expect(citations().datapage).toBeUndefined()
     })
 
-    it("still cites the page when the citation url is empty", () => {
-        // mdim pages baked without a slug have one (MultiDimBaker.tsx)
-        expect(citations({ citationUrl: "" }).datapage).toEqual(
-            "“Data Page: Indicator”. " +
-                `Our World in Data (${dayjs().year()}). ` +
-                "Retrieved from  [online resource]"
-        )
+    it("omits the datapage citation when the citation url is empty", () => {
+        expect(citations({ citationUrl: "" }).datapage).toBeUndefined()
     })
 
     describe("short", () => {

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -9,7 +9,7 @@ import {
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
     getOriginAttributionFragments,
-    getPhraseForProcessingLevel,
+    getProcessingPhraseForAttribution,
     getYearSuffixFromOrigin,
     prepareSourcesForDisplay,
 } from "./metadataHelpers.js"
@@ -322,21 +322,67 @@ describe(getNextUpdateFromVariable, () => {
     })
 })
 
-describe(getPhraseForProcessingLevel, () => {
+describe(getProcessingPhraseForAttribution, () => {
+    const attribution = "Producer"
+
     it("describes major processing", () => {
-        expect(getPhraseForProcessingLevel("major")).toEqual(
+        expect(getProcessingPhraseForAttribution(attribution, "major")).toEqual(
             "with major processing"
         )
     })
 
     it("describes minor processing", () => {
-        expect(getPhraseForProcessingLevel("minor")).toEqual(
+        expect(getProcessingPhraseForAttribution(attribution, "minor")).toEqual(
             "with minor processing"
         )
     })
 
     it("falls back to a generic phrase", () => {
-        expect(getPhraseForProcessingLevel(undefined)).toEqual("processed")
+        expect(
+            getProcessingPhraseForAttribution(attribution, undefined)
+        ).toEqual("processed")
+    })
+
+    it("says nothing when we are the only attribution", () => {
+        expect(
+            getProcessingPhraseForAttribution("Our World in Data", "major")
+        ).toBeUndefined()
+    })
+
+    it("ignores the case of our own name", () => {
+        expect(
+            getProcessingPhraseForAttribution("our world in data", "major")
+        ).toBeUndefined()
+    })
+
+    it("accepts the fragments as a list", () => {
+        expect(
+            getProcessingPhraseForAttribution(["Our World in Data"], "major")
+        ).toBeUndefined()
+    })
+
+    it("still describes processing when we are one of several attributions", () => {
+        expect(
+            getProcessingPhraseForAttribution(
+                ["Our World in Data", "Producer"],
+                "major"
+            )
+        ).toEqual("with major processing")
+    })
+
+    it("still describes processing when the joined attribution names others", () => {
+        expect(
+            getProcessingPhraseForAttribution(
+                "Our World in Data; Producer",
+                "major"
+            )
+        ).toEqual("with major processing")
+    })
+
+    it("describes processing when there is no attribution at all", () => {
+        expect(getProcessingPhraseForAttribution([], "major")).toEqual(
+            "with major processing"
+        )
     })
 })
 

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -1,8 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
-    formatAuthors,
-    formatAuthorsForBibtex,
     formatSourceDate,
     getAttributionFragmentsFromVariable,
     getCitationDatapage,
@@ -13,11 +11,9 @@ import {
     getLastUpdatedFromVariable,
     getNextUpdateFromVariable,
     getOriginAttributionFragments,
-    getPhraseForArchivalDate,
     getPhraseForProcessingLevel,
     getYearSuffixFromOrigin,
     prepareSourcesForDisplay,
-    splitSourceTextIntoFragments,
 } from "./metadataHelpers.js"
 import dayjs from "./dayjs.js"
 
@@ -100,38 +96,6 @@ describe(getOriginAttributionFragments, () => {
                 { producer: "B" },
             ])
         ).toEqual(["B", "A", "B"])
-    })
-})
-
-describe(splitSourceTextIntoFragments, () => {
-    it("returns an empty array for undefined text", () => {
-        expect(splitSourceTextIntoFragments(undefined)).toEqual([])
-    })
-
-    it("returns an empty array for empty text", () => {
-        expect(splitSourceTextIntoFragments("")).toEqual([])
-    })
-
-    it("returns a single fragment if there is no semicolon", () => {
-        expect(splitSourceTextIntoFragments("  one fragment  ")).toEqual([
-            "one fragment",
-        ])
-    })
-
-    it("splits on semicolons and trims each fragment", () => {
-        expect(splitSourceTextIntoFragments("one ;  two;three ")).toEqual([
-            "one",
-            "two",
-            "three",
-        ])
-    })
-
-    it("keeps empty fragments produced by consecutive semicolons", () => {
-        expect(splitSourceTextIntoFragments("one;;two")).toEqual([
-            "one",
-            "",
-            "two",
-        ])
     })
 })
 
@@ -247,58 +211,6 @@ describe(getETLPathComponents, () => {
             table: "e",
             indicator: "f",
         })
-    })
-})
-
-describe(formatAuthors, () => {
-    it("formats zero authors", () => {
-        expect(formatAuthors([])).toEqual("")
-    })
-
-    it("formats one author", () => {
-        expect(formatAuthors(["Author 1"])).toEqual("Author 1")
-    })
-
-    it("formats two authors", () => {
-        expect(formatAuthors(["Author 1", "Author 2"])).toEqual(
-            "Author 1 and Author 2"
-        )
-    })
-
-    it("formats three authors", () => {
-        const authors = ["Author 1", "Author 2", "Author 3"]
-        expect(formatAuthors(authors)).toEqual(
-            "Author 1, Author 2, and Author 3"
-        )
-    })
-
-    it("formats four authors", () => {
-        const authors = ["Author 1", "Author 2", "Author 3", "Author 4"]
-        expect(formatAuthors(authors)).toEqual(
-            "Author 1, Author 2, Author 3, and Author 4"
-        )
-    })
-})
-
-describe(formatAuthorsForBibtex, () => {
-    it("formats zero authors for bibtex", () => {
-        expect(formatAuthorsForBibtex([])).toEqual("")
-    })
-
-    it("formats one author for bibtex", () => {
-        expect(formatAuthorsForBibtex(["Author 1"])).toEqual("Author 1")
-    })
-
-    it("formats two authors for bibtex", () => {
-        expect(formatAuthorsForBibtex(["Author 1", "Author 2"])).toEqual(
-            "Author 1 and Author 2"
-        )
-    })
-
-    it("formats three authors for bibtex", () => {
-        expect(
-            formatAuthorsForBibtex(["Author 1", "Author 2", "Author 3"])
-        ).toEqual("Author 1 and Author 2 and Author 3")
     })
 })
 
@@ -610,32 +522,6 @@ describe(getCitationShort, () => {
     it("has nothing to attribute without attributions or origins", () => {
         expect(getCitationShort([], [], undefined)).toEqual(
             " – processed by Our World in Data"
-        )
-    })
-})
-
-describe(getPhraseForArchivalDate, () => {
-    it("returns undefined if there is no archival date", () => {
-        expect(getPhraseForArchivalDate(undefined)).toBeUndefined()
-    })
-
-    it("formats an archival timestamp", () => {
-        expect(getPhraseForArchivalDate("20250414-074331")).toEqual(
-            "(archived on April 14, 2025)."
-        )
-    })
-
-    it("formats an ISO date", () => {
-        expect(getPhraseForArchivalDate("2025-04-14")).toEqual(
-            "(archived on April 14, 2025)."
-        )
-    })
-
-    // TODO: return undefined when the date cannot be parsed, rather than
-    // putting "Invalid Date" into a citation.
-    it("renders an invalid date for an unparseable archival date", () => {
-        expect(getPhraseForArchivalDate("nope")).toEqual(
-            "(archived on Invalid Date)."
         )
     })
 })

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -278,12 +278,6 @@ describe(getLastUpdatedFromVariable, () => {
     it("returns undefined if there is nothing to go on", () => {
         expect(getLastUpdatedFromVariable({})).toBeUndefined()
     })
-
-    it("returns undefined if no origin has a date accessed", () => {
-        expect(
-            getLastUpdatedFromVariable({ origins: [{ producer: "Producer" }] })
-        ).toBeUndefined()
-    })
 })
 
 describe(getNextUpdateFromVariable, () => {

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -757,18 +757,6 @@ describe(getIndicatorCitations, () => {
             )
         })
 
-        it("adds a period after a closing quotation mark", () => {
-            expect(
-                citations({
-                    primaryTopic: {
-                        topicTag: "Topic",
-                        citation: "Author (2023) – “Topic”",
-                    },
-                    citationUrl,
-                }).datapage
-            ).toContain("publication: Author (2023) – “Topic”. Retrieved")
-        })
-
         it("does not add a second period", () => {
             expect(
                 citations({

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -1,6 +1,254 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { formatAuthors, formatAuthorsForBibtex } from "./metadataHelpers.js"
+import {
+    formatAuthors,
+    formatAuthorsForBibtex,
+    formatSourceDate,
+    getAttributionFragmentsFromVariable,
+    getCitationDatapage,
+    getCitationLong,
+    getCitationShort,
+    getDateRange,
+    getETLPathComponents,
+    getLastUpdatedFromVariable,
+    getNextUpdateFromVariable,
+    getOriginAttributionFragments,
+    getPhraseForArchivalDate,
+    getPhraseForProcessingLevel,
+    getYearSuffixFromOrigin,
+    prepareSourcesForDisplay,
+    splitSourceTextIntoFragments,
+} from "./metadataHelpers.js"
+import dayjs from "./dayjs.js"
+
+describe(getOriginAttributionFragments, () => {
+    it("returns an empty array for undefined origins", () => {
+        expect(getOriginAttributionFragments(undefined)).toEqual([])
+    })
+
+    it("returns an empty array for no origins", () => {
+        expect(getOriginAttributionFragments([])).toEqual([])
+    })
+
+    it("prefers an explicit attribution over producer and year", () => {
+        expect(
+            getOriginAttributionFragments([
+                {
+                    attribution: "Custom attribution",
+                    producer: "Producer",
+                    datePublished: "2019-01-01",
+                },
+            ])
+        ).toEqual(["Custom attribution"])
+    })
+
+    it("appends the publication year to the producer", () => {
+        expect(
+            getOriginAttributionFragments([
+                { producer: "Producer", datePublished: "2019-01-01" },
+            ])
+        ).toEqual(["Producer (2019)"])
+    })
+
+    it("accepts a year-only publication date", () => {
+        expect(
+            getOriginAttributionFragments([
+                { producer: "Producer", datePublished: "2019" },
+            ])
+        ).toEqual(["Producer (2019)"])
+    })
+
+    it("omits the year if there is no publication date", () => {
+        expect(
+            getOriginAttributionFragments([{ producer: "Producer" }])
+        ).toEqual(["Producer"])
+    })
+
+    it("omits the year if the publication date is unparseable", () => {
+        expect(
+            getOriginAttributionFragments([
+                { producer: "Producer", datePublished: "not a date" },
+            ])
+        ).toEqual(["Producer"])
+    })
+
+    // TODO: fall back to the origin's title, or drop the origin, instead of
+    // interpolating a missing producer. This reaches the sources line under a
+    // chart and the download modal's source list.
+    it("renders a literal undefined when an origin has no producer", () => {
+        expect(
+            getOriginAttributionFragments([{ datePublished: "2019" }])
+        ).toEqual(["undefined (2019)"])
+    })
+
+    // TODO: treat an empty attribution like a missing one and fall through to
+    // the producer. `??` only catches null and undefined, so the origin
+    // contributes a blank label.
+    it("keeps an empty attribution instead of using the producer", () => {
+        expect(
+            getOriginAttributionFragments([
+                { attribution: "", producer: "Producer" },
+            ])
+        ).toEqual([""])
+    })
+
+    it("keeps duplicates and preserves the order of origins", () => {
+        expect(
+            getOriginAttributionFragments([
+                { producer: "B" },
+                { producer: "A" },
+                { producer: "B" },
+            ])
+        ).toEqual(["B", "A", "B"])
+    })
+})
+
+describe(splitSourceTextIntoFragments, () => {
+    it("returns an empty array for undefined text", () => {
+        expect(splitSourceTextIntoFragments(undefined)).toEqual([])
+    })
+
+    it("returns an empty array for empty text", () => {
+        expect(splitSourceTextIntoFragments("")).toEqual([])
+    })
+
+    it("returns a single fragment if there is no semicolon", () => {
+        expect(splitSourceTextIntoFragments("  one fragment  ")).toEqual([
+            "one fragment",
+        ])
+    })
+
+    it("splits on semicolons and trims each fragment", () => {
+        expect(splitSourceTextIntoFragments("one ;  two;three ")).toEqual([
+            "one",
+            "two",
+            "three",
+        ])
+    })
+
+    it("keeps empty fragments produced by consecutive semicolons", () => {
+        expect(splitSourceTextIntoFragments("one;;two")).toEqual([
+            "one",
+            "",
+            "two",
+        ])
+    })
+})
+
+describe(getAttributionFragmentsFromVariable, () => {
+    it("uses the presentation attribution if there is one", () => {
+        expect(
+            getAttributionFragmentsFromVariable({
+                presentation: { attribution: "Custom attribution" },
+                origins: [{ producer: "Producer" }],
+                source: { name: "Source" },
+            })
+        ).toEqual(["Custom attribution"])
+    })
+
+    it("ignores an empty presentation attribution", () => {
+        expect(
+            getAttributionFragmentsFromVariable({
+                presentation: { attribution: "" },
+                source: { name: "Source" },
+            })
+        ).toEqual(["Source"])
+    })
+
+    it("lists the source name before the origin attributions", () => {
+        expect(
+            getAttributionFragmentsFromVariable({
+                origins: [
+                    { producer: "Producer", datePublished: "2019" },
+                    { attribution: "Other" },
+                ],
+                source: { name: "Source" },
+            })
+        ).toEqual(["Source", "Producer (2019)", "Other"])
+    })
+
+    it("deduplicates fragments", () => {
+        expect(
+            getAttributionFragmentsFromVariable({
+                origins: [{ producer: "Source" }, { producer: "Source" }],
+                source: { name: "Source" },
+            })
+        ).toEqual(["Source"])
+    })
+
+    it("returns an empty array if there is nothing to attribute", () => {
+        expect(getAttributionFragmentsFromVariable({})).toEqual([])
+    })
+})
+
+describe(getETLPathComponents, () => {
+    it("splits a full catalog path into its components", () => {
+        expect(
+            getETLPathComponents(
+                "grapher/un/2024-07-12/world_population_prospects/population/population"
+            )
+        ).toEqual({
+            channel: "grapher",
+            producer: "un",
+            version: "2024-07-12",
+            dataset: "world_population_prospects",
+            table: "population",
+            indicator: "population",
+        })
+    })
+
+    // TODO: split on "#" as well as "/", so `indicator` is populated and
+    // `table` is usable. Every real catalog path hits this, which is why the
+    // ETL links in adminSiteClient/VariableEditPage.tsx point at
+    // `population#population.meta.yml`.
+    it("leaves a hash-separated indicator attached to the table", () => {
+        expect(
+            getETLPathComponents(
+                "grapher/un/2024-07-12/world_population_prospects/population#population"
+            )
+        ).toEqual({
+            channel: "grapher",
+            producer: "un",
+            version: "2024-07-12",
+            dataset: "world_population_prospects",
+            table: "population#population",
+            indicator: undefined,
+        })
+    })
+
+    it("leaves trailing components undefined for a short path", () => {
+        expect(getETLPathComponents("grapher/un")).toEqual({
+            channel: "grapher",
+            producer: "un",
+            version: undefined,
+            dataset: undefined,
+            table: undefined,
+            indicator: undefined,
+        })
+    })
+
+    it("handles an empty path", () => {
+        expect(getETLPathComponents("")).toEqual({
+            channel: "",
+            producer: undefined,
+            version: undefined,
+            dataset: undefined,
+            table: undefined,
+            indicator: undefined,
+        })
+    })
+
+    it("ignores components beyond the indicator", () => {
+        expect(getETLPathComponents("a/b/c/d/e/f/g")).toEqual({
+            channel: "a",
+            producer: "b",
+            version: "c",
+            dataset: "d",
+            table: "e",
+            indicator: "f",
+        })
+    })
+})
 
 describe(formatAuthors, () => {
     it("formats zero authors", () => {
@@ -21,6 +269,13 @@ describe(formatAuthors, () => {
         const authors = ["Author 1", "Author 2", "Author 3"]
         expect(formatAuthors(authors)).toEqual(
             "Author 1, Author 2, and Author 3"
+        )
+    })
+
+    it("formats four authors", () => {
+        const authors = ["Author 1", "Author 2", "Author 3", "Author 4"]
+        expect(formatAuthors(authors)).toEqual(
+            "Author 1, Author 2, Author 3, and Author 4"
         )
     })
 })
@@ -44,5 +299,834 @@ describe(formatAuthorsForBibtex, () => {
         expect(
             formatAuthorsForBibtex(["Author 1", "Author 2", "Author 3"])
         ).toEqual("Author 1 and Author 2 and Author 3")
+    })
+})
+
+describe(getLastUpdatedFromVariable, () => {
+    it("extracts the date from the catalog path version", () => {
+        expect(
+            getLastUpdatedFromVariable({
+                catalogPath: "grapher/un/2024-07-12/dataset/table",
+                origins: [{ dateAccessed: "2020-01-01" }],
+            })
+        ).toEqual("2024-07-12")
+    })
+
+    it("falls back to the origins if the version is not a full date", () => {
+        expect(
+            getLastUpdatedFromVariable({
+                catalogPath: "grapher/un/2024/dataset/table",
+                origins: [{ dateAccessed: "2020-01-01" }],
+            })
+        ).toEqual("2020-01-01")
+    })
+
+    it("falls back to the origins if the version is not zero-padded", () => {
+        expect(
+            getLastUpdatedFromVariable({
+                catalogPath: "grapher/un/2024-7-1/dataset/table",
+                origins: [{ dateAccessed: "2020-01-01" }],
+            })
+        ).toEqual("2020-01-01")
+    })
+
+    // TODO: parse and format in UTC. `new Date("2022-05-05")` is UTC
+    // midnight but is formatted in local time, so this returns 2022-05-04 at
+    // negative UTC offsets. The assertion below only holds because CI and most
+    // of the team run at or ahead of UTC.
+    it("picks the latest date accessed across origins", () => {
+        expect(
+            getLastUpdatedFromVariable({
+                origins: [
+                    { dateAccessed: "2020-01-01" },
+                    { dateAccessed: "2022-05-05" },
+                    { dateAccessed: "2021-12-31" },
+                ],
+            })
+        ).toEqual("2022-05-05")
+    })
+
+    it("ignores origins without a date accessed", () => {
+        expect(
+            getLastUpdatedFromVariable({
+                origins: [
+                    { producer: "Producer" },
+                    { dateAccessed: "2020-01-01" },
+                ],
+            })
+        ).toEqual("2020-01-01")
+    })
+
+    it("returns undefined if there is nothing to go on", () => {
+        expect(getLastUpdatedFromVariable({})).toBeUndefined()
+    })
+
+    it("returns undefined if no origin has a date accessed", () => {
+        expect(
+            getLastUpdatedFromVariable({ origins: [{ producer: "Producer" }] })
+        ).toBeUndefined()
+    })
+})
+
+describe(getNextUpdateFromVariable, () => {
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it("returns undefined if there is no update period", () => {
+        expect(
+            getNextUpdateFromVariable({
+                catalogPath: "grapher/un/2024-07-12/dataset/table",
+            })
+        ).toBeUndefined()
+    })
+
+    it("adds the update period to the last update", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date("2024-08-01T12:00:00Z"))
+        expect(
+            getNextUpdateFromVariable({
+                catalogPath: "grapher/un/2024-07-12/dataset/table",
+                updatePeriodDays: 365,
+            })
+        ).toEqual("2025-07-12")
+    })
+
+    it("falls back to a month from now if the next update is overdue", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date("2024-08-01T12:00:00Z"))
+        expect(
+            getNextUpdateFromVariable({
+                catalogPath: "grapher/un/2024-07-12/dataset/table",
+                updatePeriodDays: 7,
+            })
+        ).toEqual(dayjs().add(1, "month").format("YYYY-MM-DD"))
+    })
+
+    it("counts from today if the last update is unknown", () => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date("2024-08-01T12:00:00Z"))
+        expect(getNextUpdateFromVariable({ updatePeriodDays: 30 })).toEqual(
+            dayjs().add(30, "day").format("YYYY-MM-DD")
+        )
+    })
+})
+
+describe(getPhraseForProcessingLevel, () => {
+    it("describes major processing", () => {
+        expect(getPhraseForProcessingLevel("major")).toEqual(
+            "with major processing"
+        )
+    })
+
+    it("describes minor processing", () => {
+        expect(getPhraseForProcessingLevel("minor")).toEqual(
+            "with minor processing"
+        )
+    })
+
+    it("falls back to a generic phrase", () => {
+        expect(getPhraseForProcessingLevel(undefined)).toEqual("processed")
+    })
+})
+
+describe(prepareSourcesForDisplay, () => {
+    it("returns an empty array if there is nothing to display", () => {
+        expect(prepareSourcesForDisplay({})).toEqual([])
+    })
+
+    it("includes the source if it has a name and any provenance field", () => {
+        expect(
+            prepareSourcesForDisplay({
+                source: {
+                    name: "Source",
+                    dataPublishedBy: "Publisher",
+                    retrievedDate: "2024-01-01",
+                    link: "https://example.com",
+                },
+            })
+        ).toEqual([
+            {
+                label: "Source",
+                dataPublishedBy: "Publisher",
+                retrievedOn: "2024-01-01",
+                retrievedFrom: "https://example.com",
+            },
+        ])
+    })
+
+    it("omits a source that only has a name", () => {
+        expect(
+            prepareSourcesForDisplay({ source: { name: "Source" } })
+        ).toEqual([])
+    })
+
+    it("omits a source without a name", () => {
+        expect(
+            prepareSourcesForDisplay({
+                source: { link: "https://example.com" },
+            })
+        ).toEqual([])
+    })
+
+    it("maps origins to display sources after the source", () => {
+        expect(
+            prepareSourcesForDisplay({
+                source: { name: "Source", link: "https://example.com" },
+                origins: [
+                    {
+                        producer: "Producer",
+                        title: "Title",
+                        description: "Description",
+                        dateAccessed: "2024-02-02",
+                        urlMain: "https://origin.example.com",
+                        citationFull: "Citation",
+                    },
+                ],
+            })
+        ).toEqual([
+            {
+                label: "Source",
+                retrievedFrom: "https://example.com",
+            },
+            {
+                label: "Producer – Title",
+                description: "Description",
+                retrievedOn: "2024-02-02",
+                retrievedFrom: "https://origin.example.com",
+                citation: "Citation",
+            },
+        ])
+    })
+
+    it("labels an origin with its producer only", () => {
+        expect(
+            prepareSourcesForDisplay({ origins: [{ producer: "Producer" }] })
+        ).toEqual([{ label: "Producer" }])
+    })
+
+    it("does not repeat the producer if the title matches it", () => {
+        expect(
+            prepareSourcesForDisplay({
+                origins: [{ producer: "Producer", title: "Producer" }],
+            })
+        ).toEqual([{ label: "Producer" }])
+    })
+
+    // TODO: omit the separator when there is no producer, so the label reads
+    // "Title" rather than opening with a dangling dash.
+    it("starts the label with a separator when an origin has no producer", () => {
+        expect(
+            prepareSourcesForDisplay({ origins: [{ title: "Title" }] })
+        ).toEqual([{ label: " – Title" }])
+    })
+
+    it("keeps the order of the origins", () => {
+        expect(
+            prepareSourcesForDisplay({
+                origins: [{ producer: "B" }, { producer: "A" }],
+            })
+        ).toEqual([{ label: "B" }, { label: "A" }])
+    })
+})
+
+describe(getYearSuffixFromOrigin, () => {
+    it("prefers the date accessed", () => {
+        expect(
+            getYearSuffixFromOrigin({
+                dateAccessed: "2024-03-07",
+                datePublished: "2019-01-01",
+            })
+        ).toEqual(" (2024)")
+    })
+
+    it("falls back to the date published", () => {
+        expect(
+            getYearSuffixFromOrigin({ datePublished: "2019-01-01" })
+        ).toEqual(" (2019)")
+    })
+
+    it("accepts year-only dates", () => {
+        expect(getYearSuffixFromOrigin({ datePublished: "2019" })).toEqual(
+            " (2019)"
+        )
+    })
+
+    it("returns an empty string if there is no date", () => {
+        expect(getYearSuffixFromOrigin({})).toEqual("")
+    })
+
+    it("returns an empty string if the date is unparseable", () => {
+        expect(getYearSuffixFromOrigin({ dateAccessed: "not a date" })).toEqual(
+            ""
+        )
+    })
+})
+
+describe(getCitationShort, () => {
+    it("joins the attributions with the processing phrase", () => {
+        expect(
+            getCitationShort([], ["Producer A (2024)", "Producer B"], "major")
+        ).toEqual(
+            "Producer A (2024); Producer B – with major processing by Our World in Data"
+        )
+    })
+
+    it("uses the generic processing phrase if the level is unknown", () => {
+        expect(getCitationShort([], ["Producer A"], undefined)).toEqual(
+            "Producer A – processed by Our World in Data"
+        )
+    })
+
+    it("keeps three attributions", () => {
+        expect(getCitationShort([], ["A", "B", "C"], "minor")).toEqual(
+            "A; B; C – with minor processing by Our World in Data"
+        )
+    })
+
+    it("shortens more than three attributions", () => {
+        expect(getCitationShort([], ["A", "B", "C", "D"], "minor")).toEqual(
+            "A and other sources – with minor processing by Our World in Data"
+        )
+    })
+
+    // TODO: fire the intended fallback on an empty attributions array.
+    // `attributions ?? producersWithYear` only catches null and undefined, and
+    // every caller passes a non-optional string[], so `producersWithYear` is
+    // unreachable and the citation opens with a bare separator.
+    it("does not fall back to the origins if there are no attributions", () => {
+        expect(
+            getCitationShort(
+                [{ producer: "Producer", dateAccessed: "2024-07-11" }],
+                [],
+                undefined
+            )
+        ).toEqual(" – processed by Our World in Data")
+    })
+
+    // TODO: return "Our World in Data" when there is no attribution at all,
+    // rather than a separator with nothing before it. Mirrors the rule that
+    // hides the processing phrase when the attribution is already us.
+    it("has nothing to attribute without attributions or origins", () => {
+        expect(getCitationShort([], [], undefined)).toEqual(
+            " – processed by Our World in Data"
+        )
+    })
+})
+
+describe(getPhraseForArchivalDate, () => {
+    it("returns undefined if there is no archival date", () => {
+        expect(getPhraseForArchivalDate(undefined)).toBeUndefined()
+    })
+
+    it("formats an archival timestamp", () => {
+        expect(getPhraseForArchivalDate("20250414-074331")).toEqual(
+            "(archived on April 14, 2025)."
+        )
+    })
+
+    it("formats an ISO date", () => {
+        expect(getPhraseForArchivalDate("2025-04-14")).toEqual(
+            "(archived on April 14, 2025)."
+        )
+    })
+
+    // TODO: return undefined when the date cannot be parsed, rather than
+    // putting "Invalid Date" into a citation.
+    it("renders an invalid date for an unparseable archival date", () => {
+        expect(getPhraseForArchivalDate("nope")).toEqual(
+            "(archived on Invalid Date)."
+        )
+    })
+})
+
+describe(getCitationLong, () => {
+    const origins = [
+        {
+            producer: "Producer",
+            title: "Title",
+            versionProducer: "v2",
+            dateAccessed: "2024-03-07",
+        },
+    ]
+
+    it("assembles a full citation", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                origins,
+                undefined,
+                ["Producer (2024)"],
+                "Short",
+                "Variant",
+                "minor",
+                "https://ourworldindata.org/grapher/indicator",
+                undefined
+            )
+        ).toEqual(
+            "Producer (2024) – with minor processing by Our World in Data. " +
+                "“Indicator – Short – Variant” [dataset]. " +
+                "Producer, “Title v2” [original data]. " +
+                `Retrieved ${dayjs().format("MMMM D, YYYY")} from https://ourworldindata.org/grapher/indicator`
+        )
+    })
+
+    // TODO: fire the intended fallback on an empty attributions array, as in
+    // getCitationShort above. The citation currently opens with a bare
+    // separator even though the origins name a producer.
+    it("does not fall back to the origins if there are no attributions", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [
+                    {
+                        producer: "Producer",
+                        title: "Title",
+                        dateAccessed: "2024-07-11",
+                    },
+                ],
+                undefined,
+                [],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            " – processed by Our World in Data. " +
+                "“Indicator” [dataset]. " +
+                "Producer, “Title” [original data]."
+        )
+    })
+
+    it("uses only the attribution short if there is no title variant", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                undefined,
+                ["Attribution"],
+                "Short",
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. “Indicator – Short” [dataset]."
+        )
+    })
+
+    it("uses only the title variant if there is no attribution short", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                undefined,
+                ["Attribution"],
+                undefined,
+                "Variant",
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. “Indicator – Variant” [dataset]."
+        )
+    })
+
+    it("uses the bare title if there is neither", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                undefined,
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. “Indicator” [dataset]."
+        )
+    })
+
+    it("joins multiple attributions", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                undefined,
+                ["A", "B", "C", "D"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "A; B; C; D – processed by Our World in Data. “Indicator” [dataset]."
+        )
+    })
+
+    it("deduplicates identical origins and joins the rest", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [
+                    { producer: "A", title: "One" },
+                    { producer: "B", title: "Two" },
+                    { producer: "A", title: "One" },
+                ],
+                undefined,
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. " +
+                "“Indicator” [dataset]. " +
+                "A, “One”; B, “Two” [original data]."
+        )
+    })
+
+    // TODO: omit the quoted title when an origin has neither `title` nor
+    // `titleSnapshot`, instead of quoting the string "undefined".
+    it("renders a literal undefined when an origin has no title", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [{ producer: "Producer" }],
+                undefined,
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. " +
+                "“Indicator” [dataset]. " +
+                "Producer, “undefined” [original data]."
+        )
+    })
+
+    it("falls back to the title snapshot of an origin", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [{ producer: "Producer", titleSnapshot: "Snapshot" }],
+                undefined,
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. " +
+                "“Indicator” [dataset]. " +
+                "Producer, “Snapshot” [original data]."
+        )
+    })
+
+    it("falls back to the source name if there are no origins", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                { name: "Source" },
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. " +
+                "“Indicator” [dataset]. " +
+                "Source [original data]."
+        )
+    })
+
+    it("omits the original data sentence if there is neither", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                {},
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. “Indicator” [dataset]."
+        )
+    })
+
+    it("appends the archival date to the retrieval sentence", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                undefined,
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                "https://ourworldindata.org/grapher/indicator",
+                "20250414-074331"
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. " +
+                "“Indicator” [dataset]. " +
+                `Retrieved ${dayjs().format("MMMM D, YYYY")} from https://ourworldindata.org/grapher/indicator (archived on April 14, 2025).`
+        )
+    })
+
+    it("ignores the archival date if there is no citation url", () => {
+        expect(
+            getCitationLong(
+                { title: "Indicator" },
+                [],
+                undefined,
+                ["Attribution"],
+                undefined,
+                undefined,
+                undefined,
+                undefined,
+                "20250414-074331"
+            )
+        ).toEqual(
+            "Attribution – processed by Our World in Data. “Indicator” [dataset]."
+        )
+    })
+})
+
+describe(getCitationDatapage, () => {
+    const citationUrl = "https://ourworldindata.org/grapher/indicator"
+
+    it("cites the primary topic publication", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [{ producer: "Producer" }],
+                undefined,
+                { topicTag: "Topic", citation: "Author (2023) – “Topic”" },
+                citationUrl,
+                undefined
+            )
+        ).toEqual(
+            "“Data Page: Indicator”, part of the following publication: " +
+                "Author (2023) – “Topic”. " +
+                "Data adapted from Producer. " +
+                `Retrieved from ${citationUrl} [online resource]`
+        )
+    })
+
+    it("does not add a period after a question mark", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [],
+                undefined,
+                { topicTag: "Topic", citation: "Author (2023) – Why?" },
+                citationUrl,
+                undefined
+            )
+        ).toEqual(
+            "“Data Page: Indicator”, part of the following publication: " +
+                "Author (2023) – Why? " +
+                `Retrieved from ${citationUrl} [online resource]`
+        )
+    })
+
+    it("adds a period after a closing quotation mark", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [],
+                undefined,
+                { topicTag: "Topic", citation: "Author (2023) – “Topic”" },
+                citationUrl,
+                undefined
+            )
+        ).toContain("publication: Author (2023) – “Topic”. Retrieved")
+    })
+
+    it("does not add a second period", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [],
+                undefined,
+                { topicTag: "Topic", citation: "Author (2023)." },
+                citationUrl,
+                undefined
+            )
+        ).toEqual(
+            "“Data Page: Indicator”, part of the following publication: " +
+                "Author (2023). " +
+                `Retrieved from ${citationUrl} [online resource]`
+        )
+    })
+
+    it("credits Our World in Data if there is no primary topic", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [],
+                undefined,
+                undefined,
+                citationUrl,
+                undefined
+            )
+        ).toEqual(
+            `“Data Page: Indicator”. Our World in Data (${dayjs().year()}). ` +
+                `Retrieved from ${citationUrl} [online resource]`
+        )
+    })
+
+    it("lists the deduplicated producers", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [{ producer: "A" }, { producer: "B" }, { producer: "A" }],
+                { name: "Source" },
+                undefined,
+                citationUrl,
+                undefined
+            )
+        ).toContain("Data adapted from A, B.")
+    })
+
+    it("falls back to the source name if there are no origins", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [],
+                { name: "Source" },
+                undefined,
+                citationUrl,
+                undefined
+            )
+        ).toContain("Data adapted from Source.")
+    })
+
+    it("omits the adapted-from sentence if there is neither", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [],
+                {},
+                undefined,
+                citationUrl,
+                undefined
+            )
+        ).not.toContain("Data adapted from")
+    })
+
+    it("appends the archival date", () => {
+        expect(
+            getCitationDatapage(
+                { title: "Indicator" },
+                [],
+                undefined,
+                undefined,
+                citationUrl,
+                "20250414-074331"
+            )
+        ).toEqual(
+            `“Data Page: Indicator”. Our World in Data (${dayjs().year()}). ` +
+                `Retrieved from ${citationUrl} [online resource] (archived on April 14, 2025).`
+        )
+    })
+})
+
+describe(formatSourceDate, () => {
+    it("returns null for an undefined date", () => {
+        expect(formatSourceDate(undefined, "MMMM D, YYYY")).toBeNull()
+    })
+
+    it("returns null for an empty date", () => {
+        expect(formatSourceDate("", "MMMM D, YYYY")).toBeNull()
+    })
+
+    it("formats an ISO date", () => {
+        expect(formatSourceDate("2024-03-07", "MMMM D, YYYY")).toEqual(
+            "March 7, 2024"
+        )
+    })
+
+    it("formats a day-first date", () => {
+        expect(formatSourceDate("07/03/2024", "MMMM D, YYYY")).toEqual(
+            "March 7, 2024"
+        )
+    })
+
+    it("honours the requested format", () => {
+        expect(formatSourceDate("2024-03-07", "MMMM YYYY")).toEqual(
+            "March 2024"
+        )
+    })
+
+    it("returns the input unchanged if it cannot be parsed", () => {
+        expect(formatSourceDate("not a date", "MMMM D, YYYY")).toEqual(
+            "not a date"
+        )
+    })
+
+    it("returns a year-only date unchanged", () => {
+        expect(formatSourceDate("2024", "MMMM D, YYYY")).toEqual("2024")
+    })
+})
+
+describe(getDateRange, () => {
+    it("joins two CE years with an en dash", () => {
+        expect(getDateRange("1990-2020")).toEqual("1990–2020")
+    })
+
+    it("accepts an en dash separator and surrounding whitespace", () => {
+        expect(getDateRange("  1990 – 2020  ")).toEqual("1990–2020")
+    })
+
+    it("marks both years as BCE", () => {
+        expect(getDateRange("-5000--200")).toEqual("5000 BCE – 200 BCE")
+    })
+
+    it("marks a BCE start and a CE end", () => {
+        expect(getDateRange("-5000-2020")).toEqual("5000 BCE – 2020 CE")
+    })
+
+    it("returns null for a single year", () => {
+        expect(getDateRange("1990")).toBeNull()
+    })
+
+    it("returns null for an unrecognised separator", () => {
+        expect(getDateRange("1990 to 2020")).toBeNull()
+    })
+
+    it("returns null for non-numeric years", () => {
+        expect(getDateRange("nineteen-ninety")).toBeNull()
+    })
+
+    it("returns null for trailing junk", () => {
+        expect(getDateRange("1990-2020 (approx)")).toBeNull()
+    })
+
+    it("returns null for an empty string", () => {
+        expect(getDateRange("")).toBeNull()
     })
 })

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -147,7 +147,7 @@ describe(getETLPathComponents, () => {
     it("splits a full catalog path into its components", () => {
         expect(
             getETLPathComponents(
-                "grapher/un/2024-07-12/world_population_prospects/population/population"
+                "grapher/un/2024-07-12/world_population_prospects/population#population"
             )
         ).toEqual({
             channel: "grapher",
@@ -156,25 +156,6 @@ describe(getETLPathComponents, () => {
             dataset: "world_population_prospects",
             table: "population",
             indicator: "population",
-        })
-    })
-
-    // TODO: split on "#" as well as "/", so `indicator` is populated and
-    // `table` is usable. Every real catalog path hits this, which is why the
-    // ETL links in adminSiteClient/VariableEditPage.tsx point at
-    // `population#population.meta.yml`.
-    it("leaves a hash-separated indicator attached to the table", () => {
-        expect(
-            getETLPathComponents(
-                "grapher/un/2024-07-12/world_population_prospects/population#population"
-            )
-        ).toEqual({
-            channel: "grapher",
-            producer: "un",
-            version: "2024-07-12",
-            dataset: "world_population_prospects",
-            table: "population#population",
-            indicator: undefined,
         })
     })
 

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -3,9 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import {
     formatSourceDate,
     getAttributionFragmentsFromVariable,
-    getCitationDatapage,
-    getCitationLong,
-    getCitationShort,
+    getIndicatorCitations,
     getDateRange,
     getETLPathComponents,
     getLastUpdatedFromVariable,
@@ -475,469 +473,348 @@ describe(getYearSuffixFromOrigin, () => {
     })
 })
 
-describe(getCitationShort, () => {
-    it("joins the attributions with the processing phrase", () => {
-        expect(
-            getCitationShort([], ["Producer A (2024)", "Producer B"], "major")
-        ).toEqual(
-            "Producer A (2024); Producer B – with major processing by Our World in Data"
-        )
-    })
+describe(getIndicatorCitations, () => {
+    const citations = (
+        overrides: Partial<Parameters<typeof getIndicatorCitations>[0]> = {}
+    ): ReturnType<typeof getIndicatorCitations> =>
+        getIndicatorCitations({
+            indicatorTitle: { title: "Indicator" },
+            origins: [],
+            attributions: ["Attribution"],
+            ...overrides,
+        })
 
-    it("uses the generic processing phrase if the level is unknown", () => {
-        expect(getCitationShort([], ["Producer A"], undefined)).toEqual(
-            "Producer A – processed by Our World in Data"
-        )
-    })
-
-    it("keeps three attributions", () => {
-        expect(getCitationShort([], ["A", "B", "C"], "minor")).toEqual(
-            "A; B; C – with minor processing by Our World in Data"
-        )
-    })
-
-    it("shortens more than three attributions", () => {
-        expect(getCitationShort([], ["A", "B", "C", "D"], "minor")).toEqual(
-            "A and other sources – with minor processing by Our World in Data"
-        )
-    })
-
-    // TODO: fire the intended fallback on an empty attributions array.
-    // `attributions ?? producersWithYear` only catches null and undefined, and
-    // every caller passes a non-optional string[], so `producersWithYear` is
-    // unreachable and the citation opens with a bare separator.
-    it("does not fall back to the origins if there are no attributions", () => {
-        expect(
-            getCitationShort(
-                [{ producer: "Producer", dateAccessed: "2024-07-11" }],
-                [],
-                undefined
-            )
-        ).toEqual(" – processed by Our World in Data")
-    })
-
-    // TODO: return "Our World in Data" when there is no attribution at all,
-    // rather than a separator with nothing before it. Mirrors the rule that
-    // hides the processing phrase when the attribution is already us.
-    it("has nothing to attribute without attributions or origins", () => {
-        expect(getCitationShort([], [], undefined)).toEqual(
-            " – processed by Our World in Data"
-        )
-    })
-})
-
-describe(getCitationLong, () => {
-    const origins = [
-        {
-            producer: "Producer",
-            title: "Title",
-            versionProducer: "v2",
-            dateAccessed: "2024-03-07",
-        },
-    ]
-
-    it("assembles a full citation", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                origins,
-                undefined,
-                ["Producer (2024)"],
-                "Short",
-                "Variant",
-                "minor",
-                "https://ourworldindata.org/grapher/indicator",
-                undefined
-            )
-        ).toEqual(
-            "Producer (2024) – with minor processing by Our World in Data. " +
-                "“Indicator – Short – Variant” [dataset]. " +
-                "Producer, “Title v2” [original data]. " +
-                `Retrieved ${dayjs().format("MMMM D, YYYY")} from https://ourworldindata.org/grapher/indicator`
-        )
-    })
-
-    // TODO: fire the intended fallback on an empty attributions array, as in
-    // getCitationShort above. The citation currently opens with a bare
-    // separator even though the origins name a producer.
-    it("does not fall back to the origins if there are no attributions", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [
-                    {
-                        producer: "Producer",
-                        title: "Title",
-                        dateAccessed: "2024-07-11",
-                    },
-                ],
-                undefined,
-                [],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            " – processed by Our World in Data. " +
-                "“Indicator” [dataset]. " +
-                "Producer, “Title” [original data]."
-        )
-    })
-
-    it("uses only the attribution short if there is no title variant", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                undefined,
-                ["Attribution"],
-                "Short",
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. “Indicator – Short” [dataset]."
-        )
-    })
-
-    it("uses only the title variant if there is no attribution short", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                undefined,
-                ["Attribution"],
-                undefined,
-                "Variant",
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. “Indicator – Variant” [dataset]."
-        )
-    })
-
-    it("uses the bare title if there is neither", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                undefined,
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. “Indicator” [dataset]."
-        )
-    })
-
-    it("joins multiple attributions", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                undefined,
-                ["A", "B", "C", "D"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "A; B; C; D – processed by Our World in Data. “Indicator” [dataset]."
-        )
-    })
-
-    it("deduplicates identical origins and joins the rest", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [
-                    { producer: "A", title: "One" },
-                    { producer: "B", title: "Two" },
-                    { producer: "A", title: "One" },
-                ],
-                undefined,
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. " +
-                "“Indicator” [dataset]. " +
-                "A, “One”; B, “Two” [original data]."
-        )
-    })
-
-    // TODO: omit the quoted title when an origin has neither `title` nor
-    // `titleSnapshot`, instead of quoting the string "undefined".
-    it("renders a literal undefined when an origin has no title", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [{ producer: "Producer" }],
-                undefined,
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. " +
-                "“Indicator” [dataset]. " +
-                "Producer, “undefined” [original data]."
-        )
-    })
-
-    it("falls back to the title snapshot of an origin", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [{ producer: "Producer", titleSnapshot: "Snapshot" }],
-                undefined,
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. " +
-                "“Indicator” [dataset]. " +
-                "Producer, “Snapshot” [original data]."
-        )
-    })
-
-    it("falls back to the source name if there are no origins", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                { name: "Source" },
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. " +
-                "“Indicator” [dataset]. " +
-                "Source [original data]."
-        )
-    })
-
-    it("omits the original data sentence if there is neither", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                {},
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                undefined
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. “Indicator” [dataset]."
-        )
-    })
-
-    it("appends the archival date to the retrieval sentence", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                undefined,
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                "https://ourworldindata.org/grapher/indicator",
-                "20250414-074331"
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. " +
-                "“Indicator” [dataset]. " +
-                `Retrieved ${dayjs().format("MMMM D, YYYY")} from https://ourworldindata.org/grapher/indicator (archived on April 14, 2025).`
-        )
-    })
-
-    it("ignores the archival date if there is no citation url", () => {
-        expect(
-            getCitationLong(
-                { title: "Indicator" },
-                [],
-                undefined,
-                ["Attribution"],
-                undefined,
-                undefined,
-                undefined,
-                undefined,
-                "20250414-074331"
-            )
-        ).toEqual(
-            "Attribution – processed by Our World in Data. “Indicator” [dataset]."
-        )
-    })
-})
-
-describe(getCitationDatapage, () => {
     const citationUrl = "https://ourworldindata.org/grapher/indicator"
 
-    it("cites the primary topic publication", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [{ producer: "Producer" }],
-                undefined,
-                { topicTag: "Topic", citation: "Author (2023) – “Topic”" },
-                citationUrl,
-                undefined
-            )
-        ).toEqual(
-            "“Data Page: Indicator”, part of the following publication: " +
-                "Author (2023) – “Topic”. " +
-                "Data adapted from Producer. " +
-                `Retrieved from ${citationUrl} [online resource]`
+    it("omits the datapage citation without a citation url", () => {
+        expect(citations().datapage).toBeUndefined()
+    })
+
+    it("still cites the page when the citation url is empty", () => {
+        // mdim pages baked without a slug have one (MultiDimBaker.tsx)
+        expect(citations({ citationUrl: "" }).datapage).toEqual(
+            "“Data Page: Indicator”. " +
+                `Our World in Data (${dayjs().year()}). ` +
+                "Retrieved from  [online resource]"
         )
     })
 
-    it("does not add a period after a question mark", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [],
-                undefined,
-                { topicTag: "Topic", citation: "Author (2023) – Why?" },
-                citationUrl,
-                undefined
+    describe("short", () => {
+        it("joins the attributions with the processing phrase", () => {
+            expect(
+                citations({
+                    attributions: ["Producer A (2024)", "Producer B"],
+                    owidProcessingLevel: "major",
+                }).short
+            ).toEqual(
+                "Producer A (2024); Producer B – with major processing by Our World in Data"
             )
-        ).toEqual(
-            "“Data Page: Indicator”, part of the following publication: " +
-                "Author (2023) – Why? " +
-                `Retrieved from ${citationUrl} [online resource]`
-        )
+        })
+
+        it("uses the generic processing phrase if the level is unknown", () => {
+            expect(citations({ attributions: ["Producer A"] }).short).toEqual(
+                "Producer A – processed by Our World in Data"
+            )
+        })
+
+        it("keeps three attributions", () => {
+            expect(
+                citations({
+                    attributions: ["A", "B", "C"],
+                    owidProcessingLevel: "minor",
+                }).short
+            ).toEqual("A; B; C – with minor processing by Our World in Data")
+        })
+
+        it("shortens more than three attributions", () => {
+            expect(
+                citations({
+                    attributions: ["A", "B", "C", "D"],
+                    owidProcessingLevel: "minor",
+                }).short
+            ).toEqual(
+                "A and other sources – with minor processing by Our World in Data"
+            )
+        })
+
+        // TODO: fire the intended fallback on an empty attributions array.
+        // `attributions ?? producersWithYear` only catches null and undefined,
+        // and every caller passes a non-optional string[], so
+        // `producersWithYear` is unreachable and the citation opens with a bare
+        // separator.
+        it("does not fall back to the origins if there are no attributions", () => {
+            expect(
+                citations({
+                    origins: [
+                        { producer: "Producer", dateAccessed: "2024-07-11" },
+                    ],
+                    attributions: [],
+                }).short
+            ).toEqual(" – processed by Our World in Data")
+        })
+
+        // TODO: return "Our World in Data" when there is no attribution at all,
+        // rather than a separator with nothing before it. Mirrors the rule that
+        // hides the processing phrase when the attribution is already us.
+        it("has nothing to attribute without attributions or origins", () => {
+            expect(citations({ attributions: [] }).short).toEqual(
+                " – processed by Our World in Data"
+            )
+        })
     })
 
-    it("adds a period after a closing quotation mark", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [],
-                undefined,
-                { topicTag: "Topic", citation: "Author (2023) – “Topic”" },
-                citationUrl,
-                undefined
+    describe("long", () => {
+        it("assembles a full citation", () => {
+            expect(
+                citations({
+                    origins: [
+                        {
+                            producer: "Producer",
+                            title: "Title",
+                            versionProducer: "v2",
+                            dateAccessed: "2024-03-07",
+                        },
+                    ],
+                    attributions: ["Producer (2024)"],
+                    attributionShort: "Short",
+                    titleVariant: "Variant",
+                    owidProcessingLevel: "minor",
+                    citationUrl,
+                }).long
+            ).toEqual(
+                "Producer (2024) – with minor processing by Our World in Data. " +
+                    "“Indicator – Short – Variant” [dataset]. " +
+                    "Producer, “Title v2” [original data]. " +
+                    `Retrieved ${dayjs().format("MMMM D, YYYY")} from ${citationUrl}`
             )
-        ).toContain("publication: Author (2023) – “Topic”. Retrieved")
+        })
+
+        // TODO: fire the intended fallback on an empty attributions array, as
+        // in short above. The citation currently opens with a bare separator
+        // even though the origins name a producer.
+        it("does not fall back to the origins if there are no attributions", () => {
+            expect(
+                citations({
+                    origins: [
+                        {
+                            producer: "Producer",
+                            title: "Title",
+                            dateAccessed: "2024-07-11",
+                        },
+                    ],
+                    attributions: [],
+                }).long
+            ).toEqual(
+                " – processed by Our World in Data. " +
+                    "“Indicator” [dataset]. " +
+                    "Producer, “Title” [original data]."
+            )
+        })
+
+        it("uses only the attribution short if there is no title variant", () => {
+            expect(citations({ attributionShort: "Short" }).long).toEqual(
+                "Attribution – processed by Our World in Data. “Indicator – Short” [dataset]."
+            )
+        })
+
+        it("uses only the title variant if there is no attribution short", () => {
+            expect(citations({ titleVariant: "Variant" }).long).toEqual(
+                "Attribution – processed by Our World in Data. “Indicator – Variant” [dataset]."
+            )
+        })
+
+        it("uses the bare title if there is neither", () => {
+            expect(citations().long).toEqual(
+                "Attribution – processed by Our World in Data. “Indicator” [dataset]."
+            )
+        })
+
+        it("joins multiple attributions", () => {
+            expect(
+                citations({ attributions: ["A", "B", "C", "D"] }).long
+            ).toEqual(
+                "A; B; C; D – processed by Our World in Data. “Indicator” [dataset]."
+            )
+        })
+
+        it("deduplicates identical origins and joins the rest", () => {
+            expect(
+                citations({
+                    origins: [
+                        { producer: "A", title: "One" },
+                        { producer: "B", title: "Two" },
+                        { producer: "A", title: "One" },
+                    ],
+                }).long
+            ).toEqual(
+                "Attribution – processed by Our World in Data. " +
+                    "“Indicator” [dataset]. " +
+                    "A, “One”; B, “Two” [original data]."
+            )
+        })
+
+        // TODO: omit the quoted title when an origin has neither `title` nor
+        // `titleSnapshot`, instead of quoting the string "undefined".
+        it("renders a literal undefined when an origin has no title", () => {
+            expect(
+                citations({ origins: [{ producer: "Producer" }] }).long
+            ).toEqual(
+                "Attribution – processed by Our World in Data. " +
+                    "“Indicator” [dataset]. " +
+                    "Producer, “undefined” [original data]."
+            )
+        })
+
+        it("falls back to the title snapshot of an origin", () => {
+            expect(
+                citations({
+                    origins: [
+                        { producer: "Producer", titleSnapshot: "Snapshot" },
+                    ],
+                }).long
+            ).toEqual(
+                "Attribution – processed by Our World in Data. " +
+                    "“Indicator” [dataset]. " +
+                    "Producer, “Snapshot” [original data]."
+            )
+        })
+
+        it("falls back to the source name if there are no origins", () => {
+            expect(citations({ source: { name: "Source" } }).long).toEqual(
+                "Attribution – processed by Our World in Data. " +
+                    "“Indicator” [dataset]. " +
+                    "Source [original data]."
+            )
+        })
+
+        it("omits the original data sentence if there is neither", () => {
+            expect(citations({ source: {} }).long).toEqual(
+                "Attribution – processed by Our World in Data. “Indicator” [dataset]."
+            )
+        })
+
+        it("appends the archival date to the retrieval sentence", () => {
+            expect(
+                citations({ citationUrl, archivalDate: "20250414-074331" }).long
+            ).toEqual(
+                "Attribution – processed by Our World in Data. " +
+                    "“Indicator” [dataset]. " +
+                    `Retrieved ${dayjs().format("MMMM D, YYYY")} from ${citationUrl} (archived on April 14, 2025).`
+            )
+        })
+
+        it("ignores the archival date if there is no citation url", () => {
+            expect(citations({ archivalDate: "20250414-074331" }).long).toEqual(
+                "Attribution – processed by Our World in Data. “Indicator” [dataset]."
+            )
+        })
     })
 
-    it("does not add a second period", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [],
-                undefined,
-                { topicTag: "Topic", citation: "Author (2023)." },
-                citationUrl,
-                undefined
+    describe("datapage", () => {
+        it("cites the primary topic publication", () => {
+            expect(
+                citations({
+                    origins: [{ producer: "Producer" }],
+                    primaryTopic: {
+                        topicTag: "Topic",
+                        citation: "Author (2023) – “Topic”",
+                    },
+                    citationUrl,
+                }).datapage
+            ).toEqual(
+                "“Data Page: Indicator”, part of the following publication: " +
+                    "Author (2023) – “Topic”. " +
+                    "Data adapted from Producer. " +
+                    `Retrieved from ${citationUrl} [online resource]`
             )
-        ).toEqual(
-            "“Data Page: Indicator”, part of the following publication: " +
-                "Author (2023). " +
-                `Retrieved from ${citationUrl} [online resource]`
-        )
-    })
+        })
 
-    it("credits Our World in Data if there is no primary topic", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [],
-                undefined,
-                undefined,
-                citationUrl,
-                undefined
+        it("does not add a period after a question mark", () => {
+            expect(
+                citations({
+                    primaryTopic: {
+                        topicTag: "Topic",
+                        citation: "Author (2023) – Why?",
+                    },
+                    citationUrl,
+                }).datapage
+            ).toEqual(
+                "“Data Page: Indicator”, part of the following publication: " +
+                    "Author (2023) – Why? " +
+                    `Retrieved from ${citationUrl} [online resource]`
             )
-        ).toEqual(
-            `“Data Page: Indicator”. Our World in Data (${dayjs().year()}). ` +
-                `Retrieved from ${citationUrl} [online resource]`
-        )
-    })
+        })
 
-    it("lists the deduplicated producers", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [{ producer: "A" }, { producer: "B" }, { producer: "A" }],
-                { name: "Source" },
-                undefined,
-                citationUrl,
-                undefined
-            )
-        ).toContain("Data adapted from A, B.")
-    })
+        it("adds a period after a closing quotation mark", () => {
+            expect(
+                citations({
+                    primaryTopic: {
+                        topicTag: "Topic",
+                        citation: "Author (2023) – “Topic”",
+                    },
+                    citationUrl,
+                }).datapage
+            ).toContain("publication: Author (2023) – “Topic”. Retrieved")
+        })
 
-    it("falls back to the source name if there are no origins", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [],
-                { name: "Source" },
-                undefined,
-                citationUrl,
-                undefined
+        it("does not add a second period", () => {
+            expect(
+                citations({
+                    primaryTopic: {
+                        topicTag: "Topic",
+                        citation: "Author (2023).",
+                    },
+                    citationUrl,
+                }).datapage
+            ).toEqual(
+                "“Data Page: Indicator”, part of the following publication: " +
+                    "Author (2023). " +
+                    `Retrieved from ${citationUrl} [online resource]`
             )
-        ).toContain("Data adapted from Source.")
-    })
+        })
 
-    it("omits the adapted-from sentence if there is neither", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [],
-                {},
-                undefined,
-                citationUrl,
-                undefined
+        it("credits Our World in Data if there is no primary topic", () => {
+            expect(citations({ citationUrl }).datapage).toEqual(
+                `“Data Page: Indicator”. Our World in Data (${dayjs().year()}). ` +
+                    `Retrieved from ${citationUrl} [online resource]`
             )
-        ).not.toContain("Data adapted from")
-    })
+        })
 
-    it("appends the archival date", () => {
-        expect(
-            getCitationDatapage(
-                { title: "Indicator" },
-                [],
-                undefined,
-                undefined,
-                citationUrl,
-                "20250414-074331"
+        it("lists the deduplicated producers", () => {
+            expect(
+                citations({
+                    origins: [
+                        { producer: "A" },
+                        { producer: "B" },
+                        { producer: "A" },
+                    ],
+                    source: { name: "Source" },
+                    citationUrl,
+                }).datapage
+            ).toContain("Data adapted from A, B.")
+        })
+
+        it("falls back to the source name if there are no origins", () => {
+            expect(
+                citations({ source: { name: "Source" }, citationUrl }).datapage
+            ).toContain("Data adapted from Source.")
+        })
+
+        it("omits the adapted-from sentence if there is neither", () => {
+            expect(
+                citations({ source: {}, citationUrl }).datapage
+            ).not.toContain("Data adapted from")
+        })
+
+        it("appends the archival date", () => {
+            expect(
+                citations({ citationUrl, archivalDate: "20250414-074331" })
+                    .datapage
+            ).toEqual(
+                `“Data Page: Indicator”. Our World in Data (${dayjs().year()}). ` +
+                    `Retrieved from ${citationUrl} [online resource] (archived on April 14, 2025).`
             )
-        ).toEqual(
-            `“Data Page: Indicator”. Our World in Data (${dayjs().year()}). ` +
-                `Retrieved from ${citationUrl} [online resource] (archived on April 14, 2025).`
-        )
+        })
     })
 })
 

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -1,4 +1,3 @@
-import * as R from "remeda"
 import {
     OwidOrigin,
     OwidVariableWithSource,
@@ -11,7 +10,10 @@ import {
 import * as _ from "lodash-es"
 import { excludeUndefined } from "./Util"
 import dayjs from "./dayjs.js"
-import { parseArchivalDate } from "./archival/archivalDate.js"
+import {
+    formatDateForCitation,
+    getPhraseForArchivalDate,
+} from "./archival/archivalDate.js"
 
 /**
  * One label per origin: its explicit attribution, or its producer plus
@@ -35,17 +37,6 @@ export function getOriginAttributionFragments(
               )
           })
         : []
-}
-
-/**
- * Splits a semicolon-separated metadata field into trimmed fragments, e.g.
- * `["https://a.example", "https://b.example"]`. Renders as the individual links
- * in the "Links" row of the key-data table.
- */
-export const splitSourceTextIntoFragments = (
-    text: string | undefined
-): string[] => {
-    return text ? text.split(";").map((fragment) => fragment.trim()) : []
 }
 
 /**
@@ -90,26 +81,6 @@ export const getETLPathComponents = (path: string): ETLPathComponents => {
     const [channel, producer, version, dataset, table, indicator] =
         path.split("/")
     return { channel, producer, version, dataset, table, indicator }
-}
-
-/**
- * Author names as a prose list, e.g. `"Hannah Ritchie, Pablo Rosado, and Max
- * Roser"`. Renders as an article's byline and in homepage, latest and search
- * cards.
- */
-export function formatAuthors(authors: string[]): string {
-    if (authors.length === 0) return ""
-    if (authors.length === 1) return authors[0]
-    if (authors.length === 2) return authors.join(" and ")
-    return authors.slice(0, -1).join(", ") + `, and ${R.last(authors)}`
-}
-
-/**
- * Author names as BibTeX expects them, e.g. `"Hannah Ritchie and Max Roser"`.
- * Renders in the BibTeX entry of "Cite this work".
- */
-export function formatAuthorsForBibtex(authors: string[]): string {
-    return authors.join(" and ")
 }
 
 const isFullDate = (date: string): boolean => {
@@ -275,23 +246,6 @@ export const getCitationShort = (
     return `${attributionShortened} – ${processingLevelPhrase} by Our World in Data`
 }
 
-const getDateForCitation = (date: dayjs.Dayjs): string =>
-    date.format("MMMM D, YYYY")
-
-/**
- * Pins a citation to a snapshot: `"(archived on April 14, 2025)."`. Renders at
- * the end of the citations on archived pages only.
- */
-export const getPhraseForArchivalDate = (
-    archivalDate: string | undefined
-): string | undefined => {
-    if (!archivalDate) return undefined
-
-    const parsedDate = parseArchivalDate(archivalDate)
-    const formatted = getDateForCitation(parsedDate)
-    return `(archived on ${formatted}).`
-}
-
 /**
  * The full indicator citation. The attribution unshortened, then the dataset
  * title, the original data and the retrieval date, dropping any part with nothing
@@ -335,7 +289,7 @@ export const getCitationLong = (
                 }”`
         )
     ).join("; ")
-    const today = getDateForCitation(dayjs())
+    const today = formatDateForCitation(dayjs())
     const archivalPhrase = getPhraseForArchivalDate(archivalDate)
     return excludeUndefined([
         `${attributionWithProcessing}.`,

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -20,7 +20,6 @@ export interface OriginAttribution {
     url?: string
 }
 
-/** How to credit one origin: its explicit attribution, or whatever names it */
 const getOriginAttributionLabel = (origin: OwidOrigin): string | undefined => {
     if (origin.attribution) return origin.attribution
 
@@ -34,12 +33,6 @@ const getOriginAttributionLabel = (origin: OwidOrigin): string | undefined => {
     return yearPublished ? `${name} (${yearPublished})` : name
 }
 
-/**
- * One credit per origin that can be named, e.g.
- * `[{ label: "UN WPP (2024)", url: "https://population.un.org" }]`. Renders as
- * the download modal's list of linked data sources, and unlinked in a chart's
- * sources line.
- */
 export function getOriginAttributions(
     origins: OwidOrigin[] | undefined
 ): OriginAttribution[] {
@@ -53,11 +46,6 @@ export function getOriginAttributions(
     )
 }
 
-/**
- * Who to credit for an indicator. A hand-set attribution wins; otherwise the
- * source name and the origins, deduplicated. E.g. `["World Bank", "UN WPP
- * (2024)"]`. Feeds the "Source" row of the key-data table and both citations.
- */
 export function getAttributionFragmentsFromVariable(
     variable: Pick<
         OwidVariableWithSource,
@@ -86,11 +74,6 @@ interface ETLPathComponents {
     indicator: string
 }
 
-/**
- * Splits an ETL catalog path into its parts, e.g.
- * `"grapher/un/2024-07-12/world_population_prospects/population#population"`.
- * The indicator is separated with "#", everything before it with "/".
- */
 export const getETLPathComponents = (path: string): ETLPathComponents => {
     const [channel, producer, version, dataset, table, indicator] =
         path.split(/[/#]/)
@@ -102,11 +85,6 @@ const isFullDate = (date: string): boolean => {
     return !!date.match(fullDateRegex)
 }
 
-/**
- * When the data was last refreshed. Takes the catalog path version if that's a
- * full date, otherwise the latest `dateAccessed` of the origins, e.g.
- * `"2024-07-11"`. Renders as the "Last updated" row of the key-data table.
- */
 export const getLastUpdatedFromVariable = (
     variable: Pick<OwidVariableWithSource, "catalogPath" | "origins">
 ): string | undefined => {
@@ -115,20 +93,13 @@ export const getLastUpdatedFromVariable = (
     if (version && isFullDate(version)) return version
 
     const { origins = [] } = variable
-    const originDates = excludeUndefined(
+    const isoDatesAccessed = excludeUndefined(
         origins.map((origin) => origin.dateAccessed)
     )
 
-    // Alternatively, pick the latest dateAccessed from the origins. These are
-    // zero-padded YYYY-MM-DD, so the largest string is the latest date
-    return _.max(originDates)
+    return _.max(isoDatesAccessed)
 }
 
-/**
- * The last update plus the update period, e.g. `"2025-07-11"`, or a month from
- * today if that date has already passed. Renders as the "Next expected update"
- * row of the key-data table.
- */
 export const getNextUpdateFromVariable = (
     variable: Pick<OwidVariableWithSource, "catalogPath" | "updatePeriodDays">
 ): string | undefined => {
@@ -150,7 +121,6 @@ export const getNextUpdateFromVariable = (
 
 const OWID_ATTRIBUTION = "Our World in Data"
 
-/** How much we reshaped the data, e.g. `"with minor processing"` */
 const getPhraseForProcessingLevel = (
     processingLevel: OwidProcessingLevel | undefined
 ): string => {
@@ -164,12 +134,6 @@ const getPhraseForProcessingLevel = (
     }
 }
 
-/**
- * Whether we are the only party being credited, in which case saying we also
- * processed the data adds nothing. Takes the fragments either as a list or
- * already joined, since the surfaces that render prose have joined them by the
- * time they ask.
- */
 const isOwidTheSoleAttribution = (attribution: string | string[]): boolean => {
     const fragments = Array.isArray(attribution) ? attribution : [attribution]
     return (
@@ -178,10 +142,6 @@ const isOwidTheSoleAttribution = (attribution: string | string[]): boolean => {
     )
 }
 
-/**
- * The processing phrase to show after an attribution, e.g. `"with minor
- * processing"`, or nothing when we are the only party credited.
- */
 export const getProcessingPhraseForAttribution = (
     attribution: string | string[],
     owidProcessingLevel: OwidProcessingLevel | undefined
@@ -203,11 +163,6 @@ const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
     }
 }
 
-/**
- * An indicator's origins, plus its legacy source if that has provenance of its
- * own, as one displayable list. Labels read `"UN WPP – World Population
- * Prospects"`. Renders as the per-source blocks of "Sources and processing".
- */
 export const prepareSourcesForDisplay = (
     variable: Pick<OwidVariableWithSource, "origins" | "source">
 ): DisplaySource[] => {
@@ -236,11 +191,6 @@ export const prepareSourcesForDisplay = (
     return sourcesForDisplay
 }
 
-/**
- * The line both citations open with, e.g. `"UN WPP (2024) – with minor
- * processing by Our World in Data"`. An indicator with nothing else to credit is
- * credited to us.
- */
 const getAttributionWithProcessing = (
     attributionText: string,
     owidProcessingLevel: OwidProcessingLevel | undefined
@@ -256,12 +206,6 @@ const getAttributionWithProcessing = (
         : attribution
 }
 
-/**
- * The abbreviated indicator citation, e.g. `"UN WPP (2024); HYDE (2023) – with
- * minor processing by Our World in Data"`. More than three attributions collapse
- * to "UN WPP (2024) and other sources". Renders as the "In-line citation" under
- * "How to cite this data".
- */
 const getCitationShort = ({
     attributions,
     owidProcessingLevel,
@@ -280,11 +224,6 @@ const getCitationShort = ({
     )
 }
 
-/**
- * The full indicator citation. The attribution unshortened, then the dataset
- * title, the original data and the retrieval date, dropping any part with nothing
- * to say. Renders as the "Full citation" under "How to cite this data".
- */
 const getCitationLong = ({
     indicatorTitle,
     origins,
@@ -346,12 +285,6 @@ const getCitationLong = ({
     ]).join(" ")
 }
 
-/**
- * The "How to cite this page" citation, covering the OWID-authored data page as a
- * whole (descriptions, FAQs, etc.) rather than just the data. Credits the topic
- * page it belongs to where there is one, Our World in Data otherwise. Renders
- * below the indicator citations.
- */
 const getCitationDatapage = ({
     indicatorTitle,
     origins,
@@ -389,15 +322,6 @@ const getCitationDatapage = ({
     ]).join(" ")
 }
 
-/**
- * Every citation an indicator needs, built from one set of values rather than
- * three overlapping argument lists. `datapage` is omitted when no `citationUrl`
- * is given, which is how the callers that want only the indicator citations opt
- * out of it.
- *
- * Renders as the "How to cite this data" section of a data page, and as the same
- * section of Grapher's sources modal, which shows only `short` and `long`.
- */
 export const getIndicatorCitations = ({
     indicatorTitle,
     origins,
@@ -445,11 +369,6 @@ export const getIndicatorCitations = ({
         : undefined,
 })
 
-/**
- * Reformats an ETL date for display, e.g. `"July 11, 2024"`. Reads ISO and
- * day-first spellings; a date it can't parse passes through untouched. Renders in
- * the "Last updated" and "Retrieved on" rows.
- */
 export const formatSourceDate = (
     date: string | undefined,
     format: string
@@ -459,11 +378,6 @@ export const formatSourceDate = (
     return parsedDate.format(format)
 }
 
-/**
- * An indicator's timespan as a year range, e.g. `"1990–2020"` or `"5000 BCE –
- * 2020 CE"`. Null for anything that isn't two dash-separated years, since the
- * field is free text. Renders as the "Date range" row of the key-data table.
- */
 export const getDateRange = (timespan: string): string | null => {
     // This regex matches:
     //   Beginning of string

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -433,20 +433,16 @@ export const getIndicatorCitations = ({
         citationUrl,
         archivalDate,
     }),
-    // An empty citationUrl is not the same as none: mdim pages baked without a
-    // slug have one (MultiDimBaker.tsx), and cited the page anyway before this
-    // was one entry point
-    datapage:
-        citationUrl !== undefined
-            ? getCitationDatapage({
-                  indicatorTitle,
-                  origins,
-                  source,
-                  primaryTopic,
-                  citationUrl,
-                  archivalDate,
-              })
-            : undefined,
+    datapage: citationUrl
+        ? getCitationDatapage({
+              indicatorTitle,
+              origins,
+              source,
+              primaryTopic,
+              citationUrl,
+              archivalDate,
+          })
+        : undefined,
 })
 
 /**

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -246,9 +246,14 @@ const getAttributionWithProcessing = (
     owidProcessingLevel: OwidProcessingLevel | undefined
 ): string => {
     const attribution = attributionText || OWID_ATTRIBUTION
-    const processingPhrase = getPhraseForProcessingLevel(owidProcessingLevel)
+    const processingPhrase = getProcessingPhraseForAttribution(
+        attribution,
+        owidProcessingLevel
+    )
 
-    return `${attribution} – ${processingPhrase} by Our World in Data`
+    return processingPhrase
+        ? `${attribution} – ${processingPhrase} by ${OWID_ATTRIBUTION}`
+        : attribution
 }
 
 /**

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -148,6 +148,8 @@ export const getNextUpdateFromVariable = (
     return nextUpdate?.format("YYYY-MM-DD")
 }
 
+const OWID_ATTRIBUTION = "Our World in Data"
+
 /** How much we reshaped the data, e.g. `"with minor processing"` */
 const getPhraseForProcessingLevel = (
     processingLevel: OwidProcessingLevel | undefined
@@ -172,7 +174,7 @@ const isOwidTheSoleAttribution = (attribution: string | string[]): boolean => {
     const fragments = Array.isArray(attribution) ? attribution : [attribution]
     return (
         fragments.length === 1 &&
-        fragments[0].toLowerCase() === "our world in data"
+        fragments[0].toLowerCase() === OWID_ATTRIBUTION.toLowerCase()
     )
 }
 
@@ -235,50 +237,42 @@ export const prepareSourcesForDisplay = (
 }
 
 /**
- * The year to append to a producer's name, from `dateAccessed` or else
- * `datePublished`, e.g. `" (2024)"`. Renders inside the producer labels of the
- * citations.
+ * The line both citations open with, e.g. `"UN WPP (2024) – with minor
+ * processing by Our World in Data"`. An indicator with nothing else to credit is
+ * credited to us.
  */
-export const getYearSuffixFromOrigin = (origin: OwidOrigin): string => {
-    const year = origin.dateAccessed
-        ? dayjs(origin.dateAccessed, ["YYYY-MM-DD", "YYYY"]).year()
-        : origin.datePublished
-          ? dayjs(origin.datePublished, ["YYYY-MM-DD", "YYYY"]).year()
-          : undefined
-    if (year) return ` (${year})`
-    else return ""
+const getAttributionWithProcessing = (
+    attributionText: string,
+    owidProcessingLevel: OwidProcessingLevel | undefined
+): string => {
+    const attribution = attributionText || OWID_ATTRIBUTION
+    const processingPhrase = getPhraseForProcessingLevel(owidProcessingLevel)
+
+    return `${attribution} – ${processingPhrase} by Our World in Data`
 }
 
 /**
  * The abbreviated indicator citation, e.g. `"UN WPP (2024); HYDE (2023) – with
  * minor processing by Our World in Data"`. More than three attributions collapse
- * to "UN WPP (2024) and other sources". `origins` is dead code. Renders as the
- * "In-line citation" under "How to cite this data".
+ * to "UN WPP (2024) and other sources". Renders as the "In-line citation" under
+ * "How to cite this data".
  */
 const getCitationShort = ({
-    origins,
     attributions,
     owidProcessingLevel,
 }: {
-    origins: OwidOrigin[]
     attributions: string[]
     owidProcessingLevel?: OwidProcessingLevel
 }): string => {
-    const producersWithYear = _.uniq(
-        origins.map(
-            (origin) => `${origin.producer}${getYearSuffixFromOrigin(origin)}`
-        )
-    )
-    const processingLevelPhrase =
-        getPhraseForProcessingLevel(owidProcessingLevel)
-
-    const attributionFragments = attributions ?? producersWithYear
     const attributionShortened =
-        attributionFragments.length > 3
-            ? `${attributionFragments[0]} and other sources`
-            : attributionFragments.join("; ")
+        attributions.length > 3
+            ? `${attributions[0]} and other sources`
+            : attributions.join("; ")
 
-    return `${attributionShortened} – ${processingLevelPhrase} by Our World in Data`
+    return getAttributionWithProcessing(
+        attributionShortened,
+        owidProcessingLevel
+    )
 }
 
 /**
@@ -311,17 +305,10 @@ const getCitationLong = ({
         attributionShort && titleVariant
             ? `${attributionShort} – ${titleVariant}`
             : attributionShort || titleVariant
-    const producersWithYear = _.uniq(
-        origins.map(
-            (origin) => `${origin.producer}${getYearSuffixFromOrigin(origin)}`
-        )
+    const attributionWithProcessing = getAttributionWithProcessing(
+        attributions.join("; "),
+        owidProcessingLevel
     )
-    const processingLevelPhrase =
-        getPhraseForProcessingLevel(owidProcessingLevel)
-
-    const attributionFragments = attributions ?? producersWithYear
-    const attributionUnshortened = attributionFragments.join("; ")
-    const attributionWithProcessing = `${attributionUnshortened} – ${processingLevelPhrase} by Our World in Data`
     const titleWithFragments = excludeUndefined([
         indicatorTitle.title,
         titleFragments,
@@ -429,7 +416,7 @@ export const getIndicatorCitations = ({
     archivalDate?: string
     primaryTopic?: PrimaryTopic
 }): { short: string; long: string; datapage?: string } => ({
-    short: getCitationShort({ origins, attributions, owidProcessingLevel }),
+    short: getCitationShort({ attributions, owidProcessingLevel }),
     long: getCitationLong({
         indicatorTitle,
         origins,

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -224,11 +224,15 @@ export const getYearSuffixFromOrigin = (origin: OwidOrigin): string => {
  * to "UN WPP (2024) and other sources". `origins` is dead code. Renders as the
  * "In-line citation" under "How to cite this data".
  */
-export const getCitationShort = (
-    origins: OwidOrigin[],
-    attributions: string[],
-    owidProcessingLevel: OwidProcessingLevel | undefined
-): string => {
+const getCitationShort = ({
+    origins,
+    attributions,
+    owidProcessingLevel,
+}: {
+    origins: OwidOrigin[]
+    attributions: string[]
+    owidProcessingLevel?: OwidProcessingLevel
+}): string => {
     const producersWithYear = _.uniq(
         origins.map(
             (origin) => `${origin.producer}${getYearSuffixFromOrigin(origin)}`
@@ -251,17 +255,27 @@ export const getCitationShort = (
  * title, the original data and the retrieval date, dropping any part with nothing
  * to say. Renders as the "Full citation" under "How to cite this data".
  */
-export const getCitationLong = (
-    indicatorTitle: IndicatorTitleWithFragments,
-    origins: OwidOrigin[],
-    source: OwidSource | undefined,
-    attributions: string[],
-    attributionShort: string | undefined,
-    titleVariant: string | undefined,
-    owidProcessingLevel: OwidProcessingLevel | undefined,
-    citationUrl: string | undefined,
-    archivalDate: string | undefined
-): string => {
+const getCitationLong = ({
+    indicatorTitle,
+    origins,
+    source,
+    attributions,
+    attributionShort,
+    titleVariant,
+    owidProcessingLevel,
+    citationUrl,
+    archivalDate,
+}: {
+    indicatorTitle: IndicatorTitleWithFragments
+    origins: OwidOrigin[]
+    source?: OwidSource
+    attributions: string[]
+    attributionShort?: string
+    titleVariant?: string
+    owidProcessingLevel?: OwidProcessingLevel
+    citationUrl?: string
+    archivalDate?: string
+}): string => {
     const titleFragments =
         attributionShort && titleVariant
             ? `${attributionShort} – ${titleVariant}`
@@ -311,14 +325,21 @@ export const getCitationLong = (
  * page it belongs to where there is one, Our World in Data otherwise. Renders
  * below the indicator citations.
  */
-export const getCitationDatapage = (
-    indicatorTitle: IndicatorTitleWithFragments,
-    origins: OwidOrigin[],
-    source: OwidSource | undefined,
-    primaryTopic: PrimaryTopic | undefined,
-    citationUrl: string | undefined,
-    archivalDate: string | undefined
-): string => {
+const getCitationDatapage = ({
+    indicatorTitle,
+    origins,
+    source,
+    primaryTopic,
+    citationUrl,
+    archivalDate,
+}: {
+    indicatorTitle: IndicatorTitleWithFragments
+    origins: OwidOrigin[]
+    source?: OwidSource
+    primaryTopic?: PrimaryTopic
+    citationUrl: string
+    archivalDate?: string
+}): string => {
     const currentYear = dayjs().year()
     const producers = _.uniq(origins.map((origin) => `${origin.producer}`))
     const adaptedFrom =
@@ -340,6 +361,66 @@ export const getCitationDatapage = (
         }`,
     ]).join(" ")
 }
+
+/**
+ * Every citation an indicator needs, built from one set of values rather than
+ * three overlapping argument lists. `datapage` is omitted when no `citationUrl`
+ * is given, which is how the callers that want only the indicator citations opt
+ * out of it.
+ *
+ * Renders as the "How to cite this data" section of a data page, and as the same
+ * section of Grapher's sources modal, which shows only `short` and `long`.
+ */
+export const getIndicatorCitations = ({
+    indicatorTitle,
+    origins,
+    source,
+    attributions,
+    attributionShort,
+    titleVariant,
+    owidProcessingLevel,
+    citationUrl,
+    archivalDate,
+    primaryTopic,
+}: {
+    indicatorTitle: IndicatorTitleWithFragments
+    origins: OwidOrigin[]
+    source?: OwidSource
+    attributions: string[]
+    attributionShort?: string
+    titleVariant?: string
+    owidProcessingLevel?: OwidProcessingLevel
+    citationUrl?: string
+    archivalDate?: string
+    primaryTopic?: PrimaryTopic
+}): { short: string; long: string; datapage?: string } => ({
+    short: getCitationShort({ origins, attributions, owidProcessingLevel }),
+    long: getCitationLong({
+        indicatorTitle,
+        origins,
+        source,
+        attributions,
+        attributionShort,
+        titleVariant,
+        owidProcessingLevel,
+        citationUrl,
+        archivalDate,
+    }),
+    // An empty citationUrl is not the same as none: mdim pages baked without a
+    // slug have one (MultiDimBaker.tsx), and cited the page anyway before this
+    // was one entry point
+    datapage:
+        citationUrl !== undefined
+            ? getCitationDatapage({
+                  indicatorTitle,
+                  origins,
+                  source,
+                  primaryTopic,
+                  citationUrl,
+                  archivalDate,
+              })
+            : undefined,
+})
 
 /**
  * Reformats an ETL date for display, e.g. `"July 11, 2024"`. Reads ISO and

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -200,10 +200,9 @@ export const prepareSourcesForDisplay = (
 }
 
 export const getAttributionWithProcessing = (
-    attributionText: string,
+    attribution: string,
     owidProcessingLevel: OwidProcessingLevel | undefined
 ): string => {
-    const attribution = attributionText || OWID_ATTRIBUTION
     const processingPhrase = getProcessingPhraseForAttribution(
         attribution,
         owidProcessingLevel

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -58,8 +58,8 @@ export function getAttributionFragmentsFromVariable(
     )
         return [variable.presentation?.attribution]
 
-    const originAttributions = getOriginAttributions(variable.origins).map(
-        (attribution) => attribution.label
+    const originAttributions = excludeUndefined(
+        (variable.origins ?? []).map(getOriginAttributionLabel)
     )
     const name = variable.source?.name
     return _.uniq(_.compact([name, ...originAttributions]))

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -65,6 +65,14 @@ export function getAttributionFragmentsFromVariable(
     return _.uniq(_.compact([name, ...originAttributions]))
 }
 
+export const formatAttributions = (attributions: string[]): string =>
+    attributions.join("; ")
+
+export const formatAttributionsShortened = (attributions: string[]): string =>
+    attributions.length > 3
+        ? `${attributions[0]} and other sources`
+        : formatAttributions(attributions)
+
 interface ETLPathComponents {
     channel: string
     producer: string
@@ -213,13 +221,8 @@ const getCitationShort = ({
     attributions: string[]
     owidProcessingLevel?: OwidProcessingLevel
 }): string => {
-    const attributionShortened =
-        attributions.length > 3
-            ? `${attributions[0]} and other sources`
-            : attributions.join("; ")
-
     return getAttributionWithProcessing(
-        attributionShortened,
+        formatAttributionsShortened(attributions),
         owidProcessingLevel
     )
 }
@@ -250,7 +253,7 @@ const getCitationLong = ({
             ? `${attributionShort} – ${titleVariant}`
             : attributionShort || titleVariant
     const attributionWithProcessing = getAttributionWithProcessing(
-        attributions.join("; "),
+        formatAttributions(attributions),
         owidProcessingLevel
     )
     const titleWithFragments = excludeUndefined([

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -13,6 +13,11 @@ import { excludeUndefined } from "./Util"
 import dayjs from "./dayjs.js"
 import { parseArchivalDate } from "./archival/archivalDate.js"
 
+/**
+ * One label per origin: its explicit attribution, or its producer plus
+ * publication year, e.g. `["UN WPP (2024)", "HYDE"]`. Renders in a chart's
+ * sources line and in the download modal's list of data sources.
+ */
 export function getOriginAttributionFragments(
     origins: OwidOrigin[] | undefined
 ): string[] {
@@ -32,12 +37,22 @@ export function getOriginAttributionFragments(
         : []
 }
 
+/**
+ * Splits a semicolon-separated metadata field into trimmed fragments, e.g.
+ * `["https://a.example", "https://b.example"]`. Renders as the individual links
+ * in the "Links" row of the key-data table.
+ */
 export const splitSourceTextIntoFragments = (
     text: string | undefined
 ): string[] => {
     return text ? text.split(";").map((fragment) => fragment.trim()) : []
 }
 
+/**
+ * Who to credit for an indicator. A hand-set attribution wins; otherwise the
+ * source name and the origins, deduplicated. E.g. `["World Bank", "UN WPP
+ * (2024)"]`. Feeds the "Source" row of the key-data table and both citations.
+ */
 export function getAttributionFragmentsFromVariable(
     variable: Pick<
         OwidVariableWithSource,
@@ -66,12 +81,22 @@ interface ETLPathComponents {
     indicator: string
 }
 
+/**
+ * Splits an ETL catalog path into its parts. Real paths separate the indicator
+ * with "#" rather than "/", so it arrives glued to `table` and `indicator` stays
+ * undefined. Used in the admin to link to an indicator's ETL steps on GitHub.
+ */
 export const getETLPathComponents = (path: string): ETLPathComponents => {
     const [channel, producer, version, dataset, table, indicator] =
         path.split("/")
     return { channel, producer, version, dataset, table, indicator }
 }
 
+/**
+ * Author names as a prose list, e.g. `"Hannah Ritchie, Pablo Rosado, and Max
+ * Roser"`. Renders as an article's byline and in homepage, latest and search
+ * cards.
+ */
 export function formatAuthors(authors: string[]): string {
     if (authors.length === 0) return ""
     if (authors.length === 1) return authors[0]
@@ -79,21 +104,30 @@ export function formatAuthors(authors: string[]): string {
     return authors.slice(0, -1).join(", ") + `, and ${R.last(authors)}`
 }
 
+/**
+ * Author names as BibTeX expects them, e.g. `"Hannah Ritchie and Max Roser"`.
+ * Renders in the BibTeX entry of "Cite this work".
+ */
 export function formatAuthorsForBibtex(authors: string[]): string {
     return authors.join(" and ")
 }
 
-const isDate = (date: string): boolean => {
-    const dateRegex = /^\d{4}-\d{2}-\d{2}$/
-    return !!date.match(dateRegex)
+const isFullDate = (date: string): boolean => {
+    const fullDateRegex = /^\d{4}-\d{2}-\d{2}$/
+    return !!date.match(fullDateRegex)
 }
 
+/**
+ * When the data was last refreshed. Takes the catalog path version if that's a
+ * full date, otherwise the latest `dateAccessed` of the origins, e.g.
+ * `"2024-07-11"`. Renders as the "Last updated" row of the key-data table.
+ */
 export const getLastUpdatedFromVariable = (
     variable: Pick<OwidVariableWithSource, "catalogPath" | "origins">
 ): string | undefined => {
     // if possible, extract date from the catalog path
     const version = getETLPathComponents(variable.catalogPath ?? "")?.version
-    if (version && isDate(version)) return version
+    if (version && isFullDate(version)) return version
 
     const { origins = [] } = variable
     const originDates = excludeUndefined(
@@ -109,22 +143,34 @@ export const getLastUpdatedFromVariable = (
     return dayjs(latestDate).format("YYYY-MM-DD")
 }
 
+/**
+ * The last update plus the update period, e.g. `"2025-07-11"`, or a month from
+ * today if that date has already passed. Renders as the "Next expected update"
+ * row of the key-data table.
+ */
 export const getNextUpdateFromVariable = (
     variable: Pick<OwidVariableWithSource, "catalogPath" | "updatePeriodDays">
 ): string | undefined => {
     const lastUpdated = getLastUpdatedFromVariable(variable)
     let nextUpdate = undefined
     if (variable.updatePeriodDays) {
-        const date = dayjs(lastUpdated)
-        const nextUpdateDate = date.add(variable.updatePeriodDays, "day")
+        const lastUpdatedDate = dayjs(lastUpdated)
+        const scheduledUpdate = lastUpdatedDate.add(
+            variable.updatePeriodDays,
+            "day"
+        )
         // If the next update date is in the past, we set it to the next month
-        if (nextUpdateDate.isBefore(dayjs()))
+        if (scheduledUpdate.isBefore(dayjs()))
             nextUpdate = dayjs().add(1, "month")
-        else nextUpdate = nextUpdateDate
+        else nextUpdate = scheduledUpdate
     }
     return nextUpdate?.format("YYYY-MM-DD")
 }
 
+/**
+ * How much we reshaped the data, e.g. `"with minor processing"`. Renders after
+ * the attribution in the "Source" row and in the citations.
+ */
 export const getPhraseForProcessingLevel = (
     processingLevel: OwidProcessingLevel | undefined
 ): string => {
@@ -153,6 +199,11 @@ const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
     }
 }
 
+/**
+ * An indicator's origins, plus its legacy source if that has provenance of its
+ * own, as one displayable list. Labels read `"UN WPP – World Population
+ * Prospects"`. Renders as the per-source blocks of "Sources and processing".
+ */
 export const prepareSourcesForDisplay = (
     variable: Pick<OwidVariableWithSource, "origins" | "source">
 ): DisplaySource[] => {
@@ -181,39 +232,56 @@ export const prepareSourcesForDisplay = (
     return sourcesForDisplay
 }
 
-export const getYearSuffixFromOrigin = (o: OwidOrigin): string => {
-    const year = o.dateAccessed
-        ? dayjs(o.dateAccessed, ["YYYY-MM-DD", "YYYY"]).year()
-        : o.datePublished
-          ? dayjs(o.datePublished, ["YYYY-MM-DD", "YYYY"]).year()
+/**
+ * The year to append to a producer's name, from `dateAccessed` or else
+ * `datePublished`, e.g. `" (2024)"`. Renders inside the producer labels of the
+ * citations.
+ */
+export const getYearSuffixFromOrigin = (origin: OwidOrigin): string => {
+    const year = origin.dateAccessed
+        ? dayjs(origin.dateAccessed, ["YYYY-MM-DD", "YYYY"]).year()
+        : origin.datePublished
+          ? dayjs(origin.datePublished, ["YYYY-MM-DD", "YYYY"]).year()
           : undefined
     if (year) return ` (${year})`
     else return ""
 }
 
+/**
+ * The abbreviated indicator citation, e.g. `"UN WPP (2024); HYDE (2023) – with
+ * minor processing by Our World in Data"`. More than three attributions collapse
+ * to "UN WPP (2024) and other sources". `origins` is dead code. Renders as the
+ * "In-line citation" under "How to cite this data".
+ */
 export const getCitationShort = (
     origins: OwidOrigin[],
     attributions: string[],
     owidProcessingLevel: OwidProcessingLevel | undefined
 ): string => {
     const producersWithYear = _.uniq(
-        origins.map((o) => `${o.producer}${getYearSuffixFromOrigin(o)}`)
+        origins.map(
+            (origin) => `${origin.producer}${getYearSuffixFromOrigin(origin)}`
+        )
     )
     const processingLevelPhrase =
         getPhraseForProcessingLevel(owidProcessingLevel)
 
     const attributionFragments = attributions ?? producersWithYear
-    const attributionPotentiallyShortened =
+    const attributionShortened =
         attributionFragments.length > 3
             ? `${attributionFragments[0]} and other sources`
             : attributionFragments.join("; ")
 
-    return `${attributionPotentiallyShortened} – ${processingLevelPhrase} by Our World in Data`
+    return `${attributionShortened} – ${processingLevelPhrase} by Our World in Data`
 }
 
 const getDateForCitation = (date: dayjs.Dayjs): string =>
     date.format("MMMM D, YYYY")
 
+/**
+ * Pins a citation to a snapshot: `"(archived on April 14, 2025)."`. Renders at
+ * the end of the citations on archived pages only.
+ */
 export const getPhraseForArchivalDate = (
     archivalDate: string | undefined
 ): string | undefined => {
@@ -224,6 +292,11 @@ export const getPhraseForArchivalDate = (
     return `(archived on ${formatted}).`
 }
 
+/**
+ * The full indicator citation. The attribution unshortened, then the dataset
+ * title, the original data and the retrieval date, dropping any part with nothing
+ * to say. Renders as the "Full citation" under "How to cite this data".
+ */
 export const getCitationLong = (
     indicatorTitle: IndicatorTitleWithFragments,
     origins: OwidOrigin[],
@@ -235,49 +308,55 @@ export const getCitationLong = (
     citationUrl: string | undefined,
     archivalDate: string | undefined
 ): string => {
-    const sourceShortName =
+    const titleFragments =
         attributionShort && titleVariant
             ? `${attributionShort} – ${titleVariant}`
             : attributionShort || titleVariant
     const producersWithYear = _.uniq(
-        origins.map((o) => `${o.producer}${getYearSuffixFromOrigin(o)}`)
+        origins.map(
+            (origin) => `${origin.producer}${getYearSuffixFromOrigin(origin)}`
+        )
     )
     const processingLevelPhrase =
         getPhraseForProcessingLevel(owidProcessingLevel)
 
     const attributionFragments = attributions ?? producersWithYear
     const attributionUnshortened = attributionFragments.join("; ")
-    const citationLonger = `${attributionUnshortened} – ${processingLevelPhrase} by Our World in Data`
-    const titleWithOptionalFragments = excludeUndefined([
+    const attributionWithProcessing = `${attributionUnshortened} – ${processingLevelPhrase} by Our World in Data`
+    const titleWithFragments = excludeUndefined([
         indicatorTitle.title,
-        sourceShortName,
+        titleFragments,
     ]).join(" – ")
-    const originsLong = _.uniq(
+    const originCitations = _.uniq(
         origins.map(
-            (o) =>
-                `${o.producer}, “${o.title ?? o.titleSnapshot}${
-                    o.versionProducer ? " " + o.versionProducer : ""
+            (origin) =>
+                `${origin.producer}, “${origin.title ?? origin.titleSnapshot}${
+                    origin.versionProducer ? " " + origin.versionProducer : ""
                 }”`
         )
     ).join("; ")
     const today = getDateForCitation(dayjs())
-    const archivalString = getPhraseForArchivalDate(archivalDate)
+    const archivalPhrase = getPhraseForArchivalDate(archivalDate)
     return excludeUndefined([
-        `${citationLonger}.`,
-        `“${titleWithOptionalFragments}” [dataset].`,
-        originsLong
-            ? `${originsLong} [original data].`
+        `${attributionWithProcessing}.`,
+        `“${titleWithFragments}” [dataset].`,
+        originCitations
+            ? `${originCitations} [original data].`
             : source?.name
               ? `${source?.name} [original data].`
               : undefined,
         citationUrl
-            ? `Retrieved ${today} from ${citationUrl}${archivalString ? ` ${archivalString}` : ""}`
+            ? `Retrieved ${today} from ${citationUrl}${archivalPhrase ? ` ${archivalPhrase}` : ""}`
             : undefined,
     ]).join(" ")
 }
 
-// The "How to cite this page" citation, covering the OWID-authored data page as
-// a whole (descriptions, FAQs, etc.) rather than just the underlying data.
+/**
+ * The "How to cite this page" citation, covering the OWID-authored data page as a
+ * whole (descriptions, FAQs, etc.) rather than just the data. Credits the topic
+ * page it belongs to where there is one, Our World in Data otherwise. Renders
+ * below the indicator citations.
+ */
 export const getCitationDatapage = (
     indicatorTitle: IndicatorTitleWithFragments,
     origins: OwidOrigin[],
@@ -287,7 +366,7 @@ export const getCitationDatapage = (
     archivalDate: string | undefined
 ): string => {
     const currentYear = dayjs().year()
-    const producers = _.uniq(origins.map((o) => `${o.producer}`))
+    const producers = _.uniq(origins.map((origin) => `${origin.producer}`))
     const adaptedFrom =
         producers.length > 0 ? producers.join(", ") : source?.name
 
@@ -296,18 +375,23 @@ export const getCitationDatapage = (
     const maybeAddPeriod = (s: string): string =>
         s.endsWith("?") || s.endsWith(".") ? s : `${s}.`
     const primaryTopicCitation = maybeAddPeriod(primaryTopic?.citation ?? "")
-    const archivalString = getPhraseForArchivalDate(archivalDate)
+    const archivalPhrase = getPhraseForArchivalDate(archivalDate)
     return excludeUndefined([
         primaryTopic
             ? `“Data Page: ${indicatorTitle.title}”, part of the following publication: ${primaryTopicCitation}`
             : `“Data Page: ${indicatorTitle.title}”. Our World in Data (${currentYear}).`,
         adaptedFrom ? `Data adapted from ${adaptedFrom}.` : undefined,
         `Retrieved from ${citationUrl} [online resource]${
-            archivalString ? ` ${archivalString}` : ""
+            archivalPhrase ? ` ${archivalPhrase}` : ""
         }`,
     ]).join(" ")
 }
 
+/**
+ * Reformats an ETL date for display, e.g. `"July 11, 2024"`. Reads ISO and
+ * day-first spellings; a date it can't parse passes through untouched. Renders in
+ * the "Last updated" and "Retrieved on" rows.
+ */
 export const formatSourceDate = (
     date: string | undefined,
     format: string
@@ -317,7 +401,12 @@ export const formatSourceDate = (
     return parsedDate.format(format)
 }
 
-export const getDateRange = (dateRange: string): string | null => {
+/**
+ * An indicator's timespan as a year range, e.g. `"1990–2020"` or `"5000 BCE –
+ * 2020 CE"`. Null for anything that isn't two dash-separated years, since the
+ * field is free text. Renders as the "Date range" row of the key-data table.
+ */
+export const getDateRange = (timespan: string): string | null => {
     // This regex matches:
     //   Beginning of string
     //   Ignore whitespace
@@ -332,8 +421,8 @@ export const getDateRange = (dateRange: string): string | null => {
     //     1 or more digits
     //   Ignore whitespace
     //   End of string
-    const dateRangeRegex = /^\s*(?<start>(-)?\d+)\s*(-|–)\s*(?<end>(-)?\d+)\s*$/
-    const match = dateRange.match(dateRangeRegex)
+    const timespanRegex = /^\s*(?<start>(-)?\d+)\s*(-|–)\s*(?<end>(-)?\d+)\s*$/
+    const match = timespan.match(timespanRegex)
     if (match) {
         const firstYearString = match.groups?.start
         const lastYearString = match.groups?.end

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -105,13 +105,9 @@ export const getLastUpdatedFromVariable = (
         origins.map((origin) => origin.dateAccessed)
     )
 
-    if (originDates.length === 0) return undefined
-
-    // alternatively, pick the latest dateAccessed from the origins
-    const latestDate = new Date(
-        Math.max(...originDates.map((date) => new Date(date).getTime()))
-    )
-    return dayjs(latestDate).format("YYYY-MM-DD")
+    // Alternatively, pick the latest dateAccessed from the origins. These are
+    // zero-padded YYYY-MM-DD, so the largest string is the latest date
+    return _.max(originDates)
 }
 
 /**

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -248,7 +248,7 @@ const getCitationLong = ({
     citationUrl?: string
     archivalDate?: string
 }): string => {
-    const titleFragments =
+    const citationTitleFragments =
         attributionShort && titleVariant
             ? `${attributionShort} – ${titleVariant}`
             : attributionShort || titleVariant
@@ -258,7 +258,7 @@ const getCitationLong = ({
     )
     const titleWithFragments = excludeUndefined([
         indicatorTitle.title,
-        titleFragments,
+        citationTitleFragments,
     ]).join(" – ")
     const originCitations = _.uniq(
         origins.map((origin) => {

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -15,28 +15,42 @@ import {
     getPhraseForArchivalDate,
 } from "./archival/archivalDate.js"
 
+export interface OriginAttribution {
+    label: string
+    url?: string
+}
+
+/** How to credit one origin: its explicit attribution, or whatever names it */
+const getOriginAttributionLabel = (origin: OwidOrigin): string | undefined => {
+    if (origin.attribution) return origin.attribution
+
+    const name = origin.producer ?? origin.title ?? origin.urlMain
+    if (!name) return undefined
+
+    const yearPublished = origin.datePublished
+        ? dayjs(origin.datePublished, ["YYYY-MM-DD", "YYYY"]).year()
+        : undefined
+
+    return yearPublished ? `${name} (${yearPublished})` : name
+}
+
 /**
- * One label per origin: its explicit attribution, or its producer plus
- * publication year, e.g. `["UN WPP (2024)", "HYDE"]`. Renders in a chart's
- * sources line and in the download modal's list of data sources.
+ * One credit per origin that can be named, e.g.
+ * `[{ label: "UN WPP (2024)", url: "https://population.un.org" }]`. Renders as
+ * the download modal's list of linked data sources, and unlinked in a chart's
+ * sources line.
  */
-export function getOriginAttributionFragments(
+export function getOriginAttributions(
     origins: OwidOrigin[] | undefined
-): string[] {
-    return origins
-        ? origins.map((origin) => {
-              const yearPublished = origin.datePublished
-                  ? dayjs(origin.datePublished, ["YYYY-MM-DD", "YYYY"]).year()
-                  : undefined
-              const yearPublishedString = yearPublished
-                  ? ` (${yearPublished})`
-                  : ""
-              return (
-                  origin.attribution ??
-                  `${origin.producer}${yearPublishedString}`
-              )
-          })
-        : []
+): OriginAttribution[] {
+    if (!origins) return []
+
+    return excludeUndefined(
+        origins.map((origin) => {
+            const label = getOriginAttributionLabel(origin)
+            return label ? { label, url: origin.urlMain } : undefined
+        })
+    )
 }
 
 /**
@@ -56,11 +70,11 @@ export function getAttributionFragmentsFromVariable(
     )
         return [variable.presentation?.attribution]
 
-    const originAttributionFragments = getOriginAttributionFragments(
-        variable.origins
+    const originAttributions = getOriginAttributions(variable.origins).map(
+        (attribution) => attribution.label
     )
     const name = variable.source?.name
-    return _.uniq(_.compact([name, ...originAttributionFragments]))
+    return _.uniq(_.compact([name, ...originAttributions]))
 }
 
 interface ETLPathComponents {
@@ -175,10 +189,8 @@ export const getProcessingPhraseForAttribution = (
         : getPhraseForProcessingLevel(owidProcessingLevel)
 
 const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
-    let label = origin.producer ?? ""
-    if (origin.title && origin.title !== label) {
-        label += " – " + origin.title
-    }
+    const title = origin.title !== origin.producer ? origin.title : undefined
+    const label = excludeUndefined([origin.producer, title]).join(" – ")
 
     return {
         label,
@@ -315,12 +327,16 @@ const getCitationLong = ({
         titleFragments,
     ]).join(" – ")
     const originCitations = _.uniq(
-        origins.map(
-            (origin) =>
-                `${origin.producer}, “${origin.title ?? origin.titleSnapshot}${
-                    origin.versionProducer ? " " + origin.versionProducer : ""
-                }”`
-        )
+        origins.map((origin) => {
+            const title = origin.title ?? origin.titleSnapshot
+            const versionProducer = origin.versionProducer
+                ? " " + origin.versionProducer
+                : ""
+            return excludeUndefined([
+                origin.producer,
+                title ? `“${title}${versionProducer}”` : undefined,
+            ]).join(", ")
+        })
     ).join("; ")
     const today = formatDateForCitation(dayjs())
     const archivalPhrase = getPhraseForArchivalDate(archivalDate)

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -138,11 +138,8 @@ export const getNextUpdateFromVariable = (
     return nextUpdate?.format("YYYY-MM-DD")
 }
 
-/**
- * How much we reshaped the data, e.g. `"with minor processing"`. Renders after
- * the attribution in the "Source" row and in the citations.
- */
-export const getPhraseForProcessingLevel = (
+/** How much we reshaped the data, e.g. `"with minor processing"` */
+const getPhraseForProcessingLevel = (
     processingLevel: OwidProcessingLevel | undefined
 ): string => {
     switch (processingLevel) {
@@ -154,6 +151,32 @@ export const getPhraseForProcessingLevel = (
             return "processed"
     }
 }
+
+/**
+ * Whether we are the only party being credited, in which case saying we also
+ * processed the data adds nothing. Takes the fragments either as a list or
+ * already joined, since the surfaces that render prose have joined them by the
+ * time they ask.
+ */
+const isOwidTheSoleAttribution = (attribution: string | string[]): boolean => {
+    const fragments = Array.isArray(attribution) ? attribution : [attribution]
+    return (
+        fragments.length === 1 &&
+        fragments[0].toLowerCase() === "our world in data"
+    )
+}
+
+/**
+ * The processing phrase to show after an attribution, e.g. `"with minor
+ * processing"`, or nothing when we are the only party credited.
+ */
+export const getProcessingPhraseForAttribution = (
+    attribution: string | string[],
+    owidProcessingLevel: OwidProcessingLevel | undefined
+): string | undefined =>
+    isOwidTheSoleAttribution(attribution)
+        ? undefined
+        : getPhraseForProcessingLevel(owidProcessingLevel)
 
 const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
     let label = origin.producer ?? ""

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -199,7 +199,7 @@ export const prepareSourcesForDisplay = (
     return sourcesForDisplay
 }
 
-const getAttributionWithProcessing = (
+export const getAttributionWithProcessing = (
     attributionText: string,
     owidProcessingLevel: OwidProcessingLevel | undefined
 ): string => {

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -73,13 +73,13 @@ interface ETLPathComponents {
 }
 
 /**
- * Splits an ETL catalog path into its parts. Real paths separate the indicator
- * with "#" rather than "/", so it arrives glued to `table` and `indicator` stays
- * undefined. Used in the admin to link to an indicator's ETL steps on GitHub.
+ * Splits an ETL catalog path into its parts, e.g.
+ * `"grapher/un/2024-07-12/world_population_prospects/population#population"`.
+ * The indicator is separated with "#", everything before it with "/".
  */
 export const getETLPathComponents = (path: string): ETLPathComponents => {
     const [channel, producer, version, dataset, table, indicator] =
-        path.split("/")
+        path.split(/[/#]/)
     return { channel, producer, version, dataset, table, indicator }
 }
 

--- a/site/AboutThisData.tsx
+++ b/site/AboutThisData.tsx
@@ -10,8 +10,8 @@ import {
     Button,
 } from "@ourworldindata/components"
 import { DataPageDataV2 } from "@ourworldindata/types"
+import { formatAttributions } from "@ourworldindata/utils"
 import KeyDataTable from "./KeyDataTable.js"
-import { getAttributionUnshortened } from "./datapageUtils.js"
 
 export default function AboutThisData({
     datapageData,
@@ -25,7 +25,7 @@ export default function AboutThisData({
     id?: string
 }) {
     const hasDescriptionKey = !!datapageData.descriptionKey
-    const attributionUnshortened = getAttributionUnshortened(datapageData)
+    const attribution = formatAttributions(datapageData.attributions ?? [])
     const id_ = id ?? DATAPAGE_ABOUT_THIS_DATA_SECTION_ID
 
     return (
@@ -102,7 +102,7 @@ export default function AboutThisData({
                     <div className="key-info__right span-cols-4 span-lg-cols-5 span-sm-cols-12">
                         <KeyDataTable
                             datapageData={datapageData}
-                            attribution={attributionUnshortened}
+                            attribution={attribution}
                         />
                     </div>
                 </>
@@ -117,7 +117,7 @@ export default function AboutThisData({
                     <div className="col-start-4 span-cols-10 col-lg-start-5 span-lg-cols-8 col-md-start-2 span-md-cols-10 col-sm-start-1 span-sm-cols-12">
                         <KeyDataTable
                             datapageData={datapageData}
-                            attribution={attributionUnshortened}
+                            attribution={attribution}
                         />
                     </div>
                 </>

--- a/site/IndicatorMetadataBox.tsx
+++ b/site/IndicatorMetadataBox.tsx
@@ -20,6 +20,7 @@ import {
 } from "@ourworldindata/types"
 import { useRef } from "react"
 import {
+    formatAttributions,
     prepareSourcesForDisplay,
     getIndicatorCitations,
     spansToUnformattedPlainText,
@@ -28,10 +29,7 @@ import { Byline } from "./gdocs/components/Byline.js"
 import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { faChevronDown, faChevronUp } from "@fortawesome/free-solid-svg-icons"
-import {
-    getAttributionUnshortened,
-    splitDescriptionKey,
-} from "./datapageUtils.js"
+import { splitDescriptionKey } from "./datapageUtils.js"
 import { SiteAnalytics } from "./SiteAnalytics.js"
 import { ChartLicenseNotice } from "./ChartLicenseNotice.js"
 
@@ -416,9 +414,9 @@ export default function IndicatorMetadataBox({
     // expander per indicator, so we don't merge owners across datasets here.
     const owners = datapageData.owners?.[0]?.owners ?? []
 
-    const attributionUnshortened = getAttributionUnshortened(datapageData)
+    const attribution = formatAttributions(datapageData.attributions ?? [])
     const sourceString = makeSource({
-        attribution: attributionUnshortened,
+        attribution,
         owidProcessingLevel: datapageData.owidProcessingLevel,
         processingId: INDICATOR_PROCESSING_SECTION_ID,
     })

--- a/site/IndicatorMetadataBox.tsx
+++ b/site/IndicatorMetadataBox.tsx
@@ -21,9 +21,7 @@ import {
 import { useRef } from "react"
 import {
     prepareSourcesForDisplay,
-    getCitationShort,
-    getCitationLong,
-    getCitationDatapage,
+    getIndicatorCitations,
     spansToUnformattedPlainText,
 } from "@ourworldindata/utils"
 import { Byline } from "./gdocs/components/Byline.js"
@@ -109,30 +107,22 @@ function ExpandableSection({
     })
 
     const citationUrl = archiveContext?.archiveUrl ?? canonicalUrl
-    const citationShort = getCitationShort(
-        origins,
-        datapageData.attributions,
-        datapageData.owidProcessingLevel
-    )
-    const citationLong = getCitationLong(
-        datapageData.title,
+    const {
+        short: citationShort,
+        long: citationLong,
+        datapage: citationDatapage,
+    } = getIndicatorCitations({
+        indicatorTitle: title,
         origins,
         source,
-        datapageData.attributions,
-        datapageData.attributionShort,
-        datapageData.titleVariant,
-        datapageData.owidProcessingLevel,
+        attributions: datapageData.attributions,
+        attributionShort: datapageData.attributionShort,
+        titleVariant: datapageData.titleVariant,
+        owidProcessingLevel: datapageData.owidProcessingLevel,
         citationUrl,
-        archiveContext?.archivalDate
-    )
-    const citationDatapage = getCitationDatapage(
-        title,
-        origins,
-        source,
+        archivalDate: archiveContext?.archivalDate,
         primaryTopic,
-        citationUrl,
-        archiveContext?.archivalDate
-    )
+    })
 
     const faqQuestions = groupFaqsByQuestion(faqEntries?.faqs ?? [])
 

--- a/site/MetadataSection.tsx
+++ b/site/MetadataSection.tsx
@@ -19,9 +19,7 @@ import {
 } from "@ourworldindata/types"
 import {
     prepareSourcesForDisplay,
-    getCitationShort,
-    getCitationLong,
-    getCitationDatapage,
+    getIndicatorCitations,
 } from "@ourworldindata/utils"
 import { ArticleBlocks } from "./gdocs/components/ArticleBlocks.js"
 import { ChartLicenseNotice } from "./ChartLicenseNotice.js"
@@ -59,13 +57,12 @@ export default function MetadataSection({
 }) {
     const sourcesForDisplay = prepareSourcesForDisplay({ origins, source })
     const citationUrl = archiveContext?.archiveUrl ?? canonicalUrl
-    const citationShort = getCitationShort(
-        origins,
-        attributions,
-        owidProcessingLevel
-    )
-    const citationLong = getCitationLong(
-        title,
+    const {
+        short: citationShort,
+        long: citationLong,
+        datapage: citationDatapage,
+    } = getIndicatorCitations({
+        indicatorTitle: title,
         origins,
         source,
         attributions,
@@ -73,16 +70,9 @@ export default function MetadataSection({
         titleVariant,
         owidProcessingLevel,
         citationUrl,
-        archiveContext?.archivalDate
-    )
-    const citationDatapage = getCitationDatapage(
-        title,
-        origins,
-        source,
+        archivalDate: archiveContext?.archivalDate,
         primaryTopic,
-        citationUrl,
-        archiveContext?.archivalDate
-    )
+    })
     return (
         <div className="MetadataSection span-cols-14 grid grid-cols-12-full-width">
             <div className="col-start-2 span-cols-12">

--- a/site/datapageUtils.ts
+++ b/site/datapageUtils.ts
@@ -1,20 +1,7 @@
-import * as _ from "lodash-es"
-import { OwidOrigin } from "@ourworldindata/types"
-import { getYearSuffixFromOrigin } from "@ourworldindata/utils"
-
-export function getProducersFromYears(origins: OwidOrigin[]) {
-    return _.uniq(
-        origins.map((o) => `${o.producer}${getYearSuffixFromOrigin(o)}`)
-    )
-}
-
 export function getAttributionUnshortened(datapageData: {
     attributions?: string[]
-    origins: OwidOrigin[]
 }) {
-    const producersWithYear = getProducersFromYears(datapageData.origins)
-    const attributionFragments = datapageData.attributions ?? producersWithYear
-    return attributionFragments.join("; ")
+    return datapageData.attributions?.join("; ") ?? ""
 }
 
 interface MarkdownBlock {

--- a/site/datapageUtils.ts
+++ b/site/datapageUtils.ts
@@ -1,9 +1,3 @@
-export function getAttributionUnshortened(datapageData: {
-    attributions?: string[]
-}) {
-    return datapageData.attributions?.join("; ") ?? ""
-}
-
 interface MarkdownBlock {
     type: "heading" | "listItem" | "paragraph"
     lines: string[]

--- a/site/gdocs/pages/Announcement.tsx
+++ b/site/gdocs/pages/Announcement.tsx
@@ -3,7 +3,7 @@ import {
     LATEST_TYPE_LABELS,
     OwidGdocAnnouncementInterface,
 } from "@ourworldindata/types"
-import { formatInlineList } from "@ourworldindata/utils"
+import { formatAuthors } from "@ourworldindata/utils"
 import { useContext } from "react"
 import * as React from "react"
 import { AnnouncementContent } from "../../latest/AnnouncementContent.js"
@@ -33,7 +33,7 @@ function buildAuthorsNote(
 ): string | undefined {
     if (authors.length === 0) return undefined
     const kicker = LATEST_TYPE_LABELS[latestType].toLowerCase()
-    return `This ${kicker} was led by ${formatInlineList(authors)}.`
+    return `This ${kicker} was led by ${formatAuthors(authors)}.`
 }
 
 export const AnnouncementPage = ({

--- a/site/gdocs/pages/Announcement.tsx
+++ b/site/gdocs/pages/Announcement.tsx
@@ -33,7 +33,7 @@ function buildAuthorsNote(
 ): string | undefined {
     if (authors.length === 0) return undefined
     const kicker = LATEST_TYPE_LABELS[latestType].toLowerCase()
-    return `This ${kicker} was led by ${formatInlineList(authors, "and")}.`
+    return `This ${kicker} was led by ${formatInlineList(authors)}.`
 }
 
 export const AnnouncementPage = ({

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -3,7 +3,7 @@ import {
     LatestDataInsight,
     OwidGdocDataInsightInterface,
     copyToClipboard,
-    formatInlineList,
+    formatAuthors,
     MinimalTag,
 } from "@ourworldindata/utils"
 import { useContext, useState } from "react"
@@ -104,7 +104,7 @@ function CopyLinkButton(props: { slug: string }) {
 
 function buildAuthorsNote(authors: string[]): string | undefined {
     if (authors.length === 0) return undefined
-    return `(This Data Insight was written by ${formatInlineList(authors)}.)`
+    return `(This Data Insight was written by ${formatAuthors(authors)}.)`
 }
 
 export const DataInsightBody = (

--- a/site/gdocs/pages/DataInsight.tsx
+++ b/site/gdocs/pages/DataInsight.tsx
@@ -104,7 +104,7 @@ function CopyLinkButton(props: { slug: string }) {
 
 function buildAuthorsNote(authors: string[]): string | undefined {
     if (authors.length === 0) return undefined
-    return `(This Data Insight was written by ${formatInlineList(authors, "and")}.)`
+    return `(This Data Insight was written by ${formatInlineList(authors)}.)`
 }
 
 export const DataInsightBody = (


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

> [!NOTE]
> Waiting on Pablo's feedback 

Report: https://claude.ai/code/artifact/acb80de5-cc1d-48df-87f8-9ac2bd61ee62

`metadataHelpers` builds the attribution and citation text on every data page, chart sources modal and data download, and had no test coverage. Writing it (98 cases across the module's 17 exports) turned up a row of wrong strings readers have been seeing, so this fixes those and puts the duplicated citation and attribution logic behind single entry points. The module is down to 13 exports, the three citation builders are private behind `getIndicatorCitations`, and the rule that hides our processing phrase lives in one function rather than three.

The fixes, roughly by how many readers saw them:

- **Fix.** A chart's sources modal and the download readme separated credits with ", " while citations and a data page's Source row used "; ". Producer names routinely contain commas and never semicolons, so the comma form hid where one credit ended: of the fourteen behind `forest-area-as-share-of-land-area`, "Kleinn, C., Corrales, L., & Morales, D. (2002)" read as three sources. All four surfaces now use "; ".
- **Fix.** 78 indicators cited themselves as "Our World in Data – with minor processing by Our World in Data", across 851 chart-variable pairs, almost all of them the region colour dimension of our scatter plots. The Source row above the citation already dropped that phrase, so the same page contradicted itself.
- **Fix.** "Last updated" in the sources modal was a day early for readers west of UTC, because the date was parsed as UTC midnight and then formatted in local time. Baked pages and the Cloudflare functions run at UTC, so it only ever hit the browser, on the 868 chart variables whose catalog version is not a full date.
- **Fix.** The admin's three "Open the metadata.yaml file" links were broken for every indicator: `getETLPathComponents` split the catalog path only on "/", leaving the indicator glued to the table name.
- **Fix.** An unparseable archival date reached the reader as "(archived on Invalid Date)." at the end of a citation. It now says "(archived)." and leaves out the date.
- **Fix.** The download package credited two different source sets in the same zip: the readme's Source row and metadata.json's citations named only the origin producers, while the readme's own in-line citation named the source too. `getAttributionFragmentsFromVariable` reads `variable.source`, which a column def flattens into `sourceName`, so the call sites that handed it the def unchanged never saw it. 70 indicators carry both — though none of them is used by a chart, explorer or mdim, so no reader can currently download a zip that shows the mismatch.
- **Fix.** The download readme's Source row spelled our name "Our World In Data". Routing it through the same composer as the citations fixes the casing.
- **Fix.** A string no current indicator produces, but one bad ETL record would: an origin with no producer printing the literal "undefined", as in "undefined (2019)" in a chart's sources line.
- **Fix.** An mdim previewed without a slug cited itself as "Retrieved from  [online resource]". Those cannot be published, so it is admin-preview only.
- **Fix.** Announcement and data insight bylines lost the Oxford comma that the site's eight other author lists carry, so three or more authors read "A, B and C" in those two places and "A, B, and C" everywhere else.
- The download modal now leaves out origins it cannot name at all. They rendered as empty, unlinkable list items, two of which collided on React's `key=""`.

An indicator with nothing to credit at all still opens its Source row and citations with a dash and nothing in front of it, as it does today. Nothing reaches that case — it needs no attribution, no legacy source and no origins at once, and none of the 788,530 variables qualifies.

<details><summary>Details</summary>

### How the strings were checked

Master's helpers, and the call-site logic that lived in each surface, were copied verbatim and run beside this branch's over the real indicator metadata for the 210 indicators behind the 100 most-viewed charts. Both implementations saw identical inputs in one process, so every difference is the code rather than the data. "Last updated" was compared with the clock set to `America/Los_Angeles`, since that change is only observable west of UTC.

What changes for those 100 charts:

| Fix | Indicators | Charts |
| --- | --- | --- |
| `; ` instead of `, ` between credits | 66 / 210 | 28 |
| No processing phrase when we are the sole credit | 1 | 17 |
| "Last updated" west of UTC | 17 | 8 |
| "Our World in Data" casing in the readme | 209 | 100 |
| Admin `metadata.yaml` link | 210 | 100 |

Byte-identical across all 210 indicators: the sources line under every chart, the data page's Source row and its "How to cite this page" citation, the labels in "Sources and processing", and the download modal's source links. Two-author bylines and the eight author lists that already went through `formatAuthors` are unchanged too.

### What is only reachable in principle

- Every origin in the snapshot has a producer, and none carries an empty attribution string, so the `undefined` credit needs a bad ETL record.
- No variable has an empty attribution list — that needs no attribution, no legacy source and no origins at once — so the dangling dash cannot be reached.
- None of the 70 indicators carrying both a legacy source and origins is used by a chart, explorer or mdim.

### Checks

`yarn test run` passes (2,478 unit tests), `yarn typecheck` is clean, and lint and format pass on the changed files.

</details>
