### PR TITLE
🐛 🤖 fix ArchieML emitters: callout icon, video shouldAutoplay, url-first arrays

### DIFF
--- a/db/model/Gdoc/enrichedToRaw.ts
+++ b/db/model/Gdoc/enrichedToRaw.ts
@@ -102,6 +102,7 @@ export function enrichedBlockToRawBlock(
         .with({ type: "callout" }, (b): RawBlockCallout => ({
             type: b.type,
             value: {
+                icon: b.icon,
                 title: b.title,
                 text: b.text.map(
                     (enriched) =>
@@ -194,6 +195,7 @@ export function enrichedBlockToRawBlock(
                 filename: b.filename,
                 caption: b.caption ? spansToHtmlText(b.caption) : undefined,
                 shouldLoop: String(b.shouldLoop),
+                shouldAutoplay: String(b.shouldAutoplay),
                 visibility: b.visibility ? b.visibility : undefined,
             },
         }))

--- a/db/model/Gdoc/exampleEnrichedBlocks.ts
+++ b/db/model/Gdoc/exampleEnrichedBlocks.ts
@@ -228,6 +228,7 @@ export const enrichedBlockExamples: Record<
     },
     callout: {
         type: "callout",
+        icon: "info",
         parseErrors: [],
         text: [
             {
@@ -296,7 +297,7 @@ export const enrichedBlockExamples: Record<
         filename: "https://ourworldindata.org/assets/images/example-poster.jpg",
         caption: boldLinkExampleText,
         shouldLoop: true,
-        shouldAutoplay: false,
+        shouldAutoplay: true,
         visibility: "mobile",
         parseErrors: [],
     },

--- a/db/model/Gdoc/rawToArchie.ts
+++ b/db/model/Gdoc/rawToArchie.ts
@@ -180,6 +180,7 @@ function* rawBlockCalloutToArchieMLString(
 ): Generator<string, void, undefined> {
     yield "{.callout}"
     if (typeof block.value !== "string") {
+        yield* propertyToArchieMLString("icon", block.value)
         yield* propertyToArchieMLString("title", block.value)
         yield "[.+text]"
         for (const rawBlock of block.value.text) {
@@ -213,6 +214,7 @@ function* rawBlockVideoToArchieMLString(
     yield* propertyToArchieMLString("url", block.value)
     yield* propertyToArchieMLString("filename", block.value)
     yield* propertyToArchieMLString("shouldLoop", block.value)
+    yield* propertyToArchieMLString("shouldAutoplay", block.value)
     yield* propertyToArchieMLString("caption", block.value)
     yield* propertyToArchieMLString("visibility", block.value)
     yield "{}"
@@ -691,8 +693,11 @@ function* rawBlockTopicPageIntroToArchieMLString(
     if (relatedTopics?.length) {
         yield "[.related-topics]"
         for (const relatedTopic of relatedTopics) {
-            yield* propertyToArchieMLString("text", relatedTopic)
+            // url first: it is the always-present key, and ArchieML delimits
+            // array items by key repetition — starting with an optional key
+            // (text) would merge a text-less topic into its predecessor.
             yield* propertyToArchieMLString("url", relatedTopic)
+            yield* propertyToArchieMLString("text", relatedTopic)
         }
         yield "[]"
     }
@@ -977,9 +982,12 @@ function* rawBlockHomepageIntroToArchieMLString(
     if (Array.isArray(featuredWork) && featuredWork.length) {
         yield "[.featured-work]"
         for (const post of featuredWork) {
+            // url first: it is the always-present key, and ArchieML delimits
+            // array items by key repetition — starting with an optional key
+            // (title) would merge a title-less post into its predecessor.
+            yield* propertyToArchieMLString("url", post)
             yield* propertyToArchieMLString("title", post)
             yield* propertyToArchieMLString("description", post)
-            yield* propertyToArchieMLString("url", post)
             yield* propertyToArchieMLString("filename", post)
             yield* propertyToArchieMLString("kicker", post)
             yield* propertyToArchieMLString("authors", post)

--- a/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
+++ b/packages/@ourworldindata/types/src/gdocTypes/raycastSnippets.json
@@ -26,7 +26,7 @@
     },
     {
         "name": "callout",
-        "text": "{.callout}\ntitle: \n[.+text]\n\n\n[.list]\n* \n[]\n{.heading}\ntext: \nlevel: \n{}\n[]\n{}",
+        "text": "{.callout}\nicon: \ntitle: \n[.+text]\n\n\n[.list]\n* \n[]\n{.heading}\ntext: \nlevel: \n{}\n[]\n{}",
         "keyword": "+callout"
     },
     {
@@ -191,12 +191,12 @@
     },
     {
         "name": "topic-page-intro",
-        "text": "{.topic-page-intro}\n[.+content]\n\n\n[]\n{.download-button}\ntext: \nurl: \n{}\n[.related-topics]\ntext: \nurl: \n[]\n{}",
+        "text": "{.topic-page-intro}\n[.+content]\n\n\n[]\n{.download-button}\ntext: \nurl: \n{}\n[.related-topics]\nurl: \ntext: \n[]\n{}",
         "keyword": "+topic-page-intro"
     },
     {
         "name": "video",
-        "text": "{.video}\nurl: \nfilename: \nshouldLoop: \ncaption: \nvisibility: \n{}",
+        "text": "{.video}\nurl: \nfilename: \nshouldLoop: \nshouldAutoplay: \ncaption: \nvisibility: \n{}",
         "keyword": "+video"
     },
     {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @mlbrgl at the wheel._

Three fields were lost or mangled on the enriched → raw → ArchieML leg (`enrichedToRaw` + `rawToArchie`). That leg is not part of ingestion — no baked content is affected. It runs when generating the Raycast authoring snippets, when `createGdocFromTemplate` writes a doc from a template (`archieToGdoc`), and in the writing-reference UI in #7024. The fields:

- callout `icon` and video `shouldAutoplay` were never emitted at all.
- In `topic-page-intro` related-topics and `homepage-intro` featured-work, the optional key (`text` / `title`) was emitted before the always-present `url`. ArchieML delimits array items by repetition of their first key, so an item missing that optional key merged into its predecessor — two related topics became one, with the second's url overwriting the first's. This is the normal gdoc-linked case, where metadata is resolved automatically and `url` is the only key.

The Raycast snippets are regenerated accordingly, which also makes `icon:` and `shouldAutoplay:` available to authors for the first time — that snippet change is the main user-visible effect of this PR.

Note that `gdocToArchie` also calls `rawToArchie`, but only for the native Google Docs constructs it re-emits (headings, horizontal rules, table rows). None of the emitters touched here are reachable from ingestion.

**On test coverage:** the callout and video drops are now caught by the existing round-trip test over `enrichedBlockExamples`. The two array-ordering bugs are not covered, deliberately: exercising item delimiting needs a second, deliberately sparse array item, and those same example objects double as the Raycast snippet templates — adding one puts a half-empty stray item into the snippet authors paste. I had a targeted test for these and removed it rather than keep a second test mechanism alongside the round-trip harness. If we want them covered, the clean fix is to decouple the two roles of `enrichedBlockExamples` first.

<details><summary>Details</summary>

Split out of #7023, which is where these fixes were originally committed. They are orthogonal to that PR's work — the reference generator only runs examples *forward* through `archieToEnriched` and never touches these converters — so this branches off master rather than stacking.

### Why the round-trip test missed all three

`db/gdocTests.test.ts:543` already round-trips every entry in `enrichedBlockExamples` (enriched → raw → ArchieML → `load()` → raw → enriched, asserting both ends). Each bug slipped through a gap in the *examples*, not the harness:

- **callout `icon`** — the callout example didn't set it. The one `icon: "chart"` in the examples belongs to `resource-panel`, a different block. With the field absent, dropping it round-trips cleanly.
- **video `shouldAutoplay`** — the example set it to `false`, and `parseVideo`'s default is `shouldAutoplay: boolean = false` (`rawToEnriched.ts:828`). Omitting the key reparsed to the same `false`. Flipping the example to `true` is what makes the assertion bite.
- **url-first ordering** — both the `relatedTopics` and `featuredWork` examples had every key populated on every item, so no item could merge into its predecessor.

Verified by reverting `rawToArchie.ts` to master with the new examples in place: `example type 'callout'` and `example type 'video'` fail, and pass again with the fix.

### Note on `parseTopicPageIntro`

A text-less related topic is only valid when the url is a Google Doc link (`rawToEnriched.ts:2256`) — worth knowing if anyone does add coverage here, since a bare `{ url }` with a non-gdoc url is a parse error, not the bug case.

### Test plan

- `yarn test run db/gdocTests.test.ts` — 81 passed.
- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` — clean.
- `yarn checkRaycastSnippets` — up to date.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
