### PR TITLE
Keep the Subscribe and Feedback buttons permanently visible

### DIFF
--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -10,6 +10,7 @@ import { observable, action, toJS, computed, makeObservable } from "mobx"
 import classnames from "clsx"
 import { BAKED_BASE_URL } from "../settings/clientSettings.mjs"
 import { stringifyUnknownError } from "@ourworldindata/utils"
+import { SiteToolsButton } from "./SiteToolsButton.js"
 
 const sendFeedback = async (feedback: Feedback) => {
     const json = {
@@ -446,22 +447,18 @@ export class FeedbackPrompt extends React.Component {
                     </div>
                 </div>
                 {this.isOpen ? (
-                    <button
-                        aria-label="Close feedback form"
-                        className="prompt"
+                    <SiteToolsButton
+                        icon={faTimes}
+                        label="Close feedback form"
                         onClick={this.toggleOpen}
-                    >
-                        <FontAwesomeIcon icon={faTimes} /> Close
-                    </button>
+                    />
                 ) : (
-                    <button
-                        aria-label="Open feedback form"
-                        className="prompt"
-                        data-track-note="page_open_feedback"
+                    <SiteToolsButton
+                        icon={faCommentAlt}
+                        label="Feedback"
+                        dataTrackNote="page_open_feedback"
                         onClick={this.toggleOpen}
-                    >
-                        <FontAwesomeIcon icon={faCommentAlt} /> Feedback
-                    </button>
+                    />
                 )}
             </div>
         )

--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -450,6 +450,7 @@ export class FeedbackPrompt extends React.Component {
                     <SiteToolsButton
                         icon={faTimes}
                         label="Close feedback form"
+                        tooltip={false}
                         onClick={this.toggleOpen}
                     />
                 ) : (

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -2,11 +2,11 @@ import { useState } from "react"
 import * as React from "react"
 import cx from "clsx"
 import { faTimes, faEnvelopeOpenText } from "@fortawesome/free-solid-svg-icons"
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { SiteAnalytics } from "./SiteAnalytics.js"
 import { TextInput } from "@ourworldindata/components"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { NewsletterIcon } from "./gdocs/components/NewsletterIcon.js"
+import { SiteToolsButton } from "./SiteToolsButton.js"
 
 const analytics = new SiteAnalytics()
 
@@ -38,25 +38,18 @@ export const NewsletterSubscription = ({
                 </>
             )}
             {isOpen ? (
-                <button
-                    aria-label="Close subscription form"
-                    className="prompt"
+                <SiteToolsButton
+                    icon={faTimes}
+                    label="Close subscription form"
                     onClick={() => setIsOpen(false)}
-                >
-                    <FontAwesomeIcon icon={faTimes} /> Close
-                </button>
+                />
             ) : (
-                <button
-                    aria-label={subscribeText}
-                    className="prompt"
-                    data-track-note="dialog_open_newsletter"
-                    onClick={() => {
-                        setIsOpen(!isOpen)
-                    }}
-                >
-                    <FontAwesomeIcon icon={faEnvelopeOpenText} />
-                    {subscribeText}
-                </button>
+                <SiteToolsButton
+                    icon={faEnvelopeOpenText}
+                    label={subscribeText}
+                    dataTrackNote="dialog_open_newsletter"
+                    onClick={() => setIsOpen(true)}
+                />
             )}
         </div>
     )

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -41,6 +41,7 @@ export const NewsletterSubscription = ({
                 <SiteToolsButton
                     icon={faTimes}
                     label="Close subscription form"
+                    tooltip={false}
                     onClick={() => setIsOpen(false)}
                 />
             ) : (

--- a/site/SiteFooter.tsx
+++ b/site/SiteFooter.tsx
@@ -6,7 +6,7 @@ import { viteAssetsForSite } from "./viteUtils.js"
 import { ScriptLoadErrorDetector } from "./NoJSDetector.js"
 import { ABOUT_LINKS, PROD_URL, RSS_FEEDS, SOCIALS } from "./SiteConstants.js"
 import { Button } from "@ourworldindata/components"
-import { SITE_TOOLS_CLASS } from "./SiteTools.js"
+import { SITE_TOOLS_ROOT_CLASS } from "./SiteTools.js"
 import { OxfordAndGcdlLogos } from "./SiteLogos.js"
 import { IS_ARCHIVE } from "../settings/clientSettings.mjs"
 import { SEARCH_BASE_PATH } from "./search/searchUtils.js"
@@ -134,6 +134,7 @@ export const SiteFooter = (props: SiteFooterProps) => {
 
     return (
         <>
+            <div className={SITE_TOOLS_ROOT_CLASS} />
             {!props.hideDonate && (
                 <section className="donate-footer grid grid-cols-12-full-width">
                     <div className="donate-footer-inner span-cols-12 col-start-2">
@@ -225,7 +226,6 @@ export const SiteFooter = (props: SiteFooterProps) => {
                     </div>
                 </div>
 
-                <div className={SITE_TOOLS_CLASS} />
                 {viteAssetsForSite({ staticAssetMap }).forFooter}
                 <ScriptLoadErrorDetector />
                 <script

--- a/site/SiteTools.tsx
+++ b/site/SiteTools.tsx
@@ -1,41 +1,25 @@
-import cx from "clsx"
 import { FeedbackPrompt } from "./Feedback.js"
-import { ScrollDirection, useScrollDirection } from "./hooks.js"
-// import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-// import { faHeart } from "@fortawesome/free-solid-svg-icons"
-// import { faHandshake } from "@fortawesome/free-solid-svg-icons"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { NewsletterSubscription } from "./NewsletterSubscription.js"
+// Uncomment along with the Jobs button below when a job posting goes live.
+// import { faHandshake } from "@fortawesome/free-solid-svg-icons"
+// import { SiteToolsButton } from "./SiteToolsButton.js"
 
-export const SITE_TOOLS_CLASS = "site-tools"
+export const SITE_TOOLS_ROOT_CLASS = "site-tools-root"
 
 export default function SiteTools() {
-    const scrollDirection = useScrollDirection()
-    // const isDonatePage = window.location.pathname === "/donate"
-
     return (
-        <div
-            className={cx("hide-wrapper", {
-                hide: scrollDirection === ScrollDirection.Down,
-            })}
-        >
-            {/* {!isDonatePage && (
-                <a
-                    className="prompt prompt-donate"
-                    data-track-note="page_open_donate"
-                    href="/donate"
-                >
-                    <FontAwesomeIcon icon={faHeart} />
-                    Donate
-                </a>
-            )} */}
+        <div className="site-tools">
             <NewsletterSubscription
                 context={NewsletterSubscriptionContext.Floating}
             />
             <FeedbackPrompt />
-            {/* <a className="prompt" data-track-note="page_open_jobs" href="/jobs">
-                <FontAwesomeIcon icon={faHandshake} /> Jobs
-            </a> */}
+            {/* <SiteToolsButton
+                icon={faHandshake}
+                label="Jobs"
+                href="/jobs"
+                dataTrackNote="page_open_jobs"
+            /> */}
         </div>
     )
 }

--- a/site/SiteToolsButton.tsx
+++ b/site/SiteToolsButton.tsx
@@ -1,0 +1,59 @@
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { Tippy } from "@ourworldindata/utils"
+
+/**
+ * Icon-only button used by the floating site tools (newsletter subscription,
+ * feedback). The label is only shown in a tooltip on hover/focus, so that the
+ * buttons stay small enough to be permanently visible without covering the
+ * content underneath them.
+ *
+ * Pass `href` for a tool that navigates somewhere instead of opening a popover.
+ */
+export const SiteToolsButton = ({
+    icon,
+    label,
+    onClick,
+    href,
+    dataTrackNote,
+}: {
+    icon: IconDefinition
+    label: string
+    onClick?: () => void
+    href?: string
+    dataTrackNote?: string
+}) => {
+    const content = <FontAwesomeIcon icon={icon} />
+
+    return (
+        <Tippy
+            content={label}
+            theme="site-tools"
+            placement="top"
+            // Keeps the tooltip anchored to the button as it moves with the
+            // sticky container while scrolling.
+            appendTo="parent"
+            delay={[200, 0]}
+        >
+            {href !== undefined ? (
+                <a
+                    aria-label={label}
+                    className="site-tools__button"
+                    data-track-note={dataTrackNote}
+                    href={href}
+                >
+                    {content}
+                </a>
+            ) : (
+                <button
+                    aria-label={label}
+                    className="site-tools__button"
+                    data-track-note={dataTrackNote}
+                    onClick={onClick}
+                >
+                    {content}
+                </button>
+            )}
+        </Tippy>
+    )
+}

--- a/site/SiteToolsButton.tsx
+++ b/site/SiteToolsButton.tsx
@@ -3,27 +3,51 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Tippy } from "@ourworldindata/utils"
 
 /**
- * Icon-only button used by the floating site tools (newsletter subscription,
- * feedback). The label is only shown in a tooltip on hover/focus, so that the
- * buttons stay small enough to be permanently visible without covering the
- * content underneath them.
+ * Icon-only button used by the floating site tools.
+ * `label` provides both the accessible name and the tooltip text.
+ * Set `tooltip={false}` for close buttons, which only need the accessible name.
  *
  * Pass `href` for a tool that navigates somewhere instead of opening a popover.
  */
 export const SiteToolsButton = ({
     icon,
     label,
+    tooltip = true,
     onClick,
     href,
     dataTrackNote,
 }: {
     icon: IconDefinition
     label: string
+    tooltip?: boolean
     onClick?: () => void
     href?: string
     dataTrackNote?: string
 }) => {
     const content = <FontAwesomeIcon icon={icon} />
+
+    const button =
+        href !== undefined ? (
+            <a
+                aria-label={label}
+                className="site-tools__button"
+                data-track-note={dataTrackNote}
+                href={href}
+            >
+                {content}
+            </a>
+        ) : (
+            <button
+                aria-label={label}
+                className="site-tools__button"
+                data-track-note={dataTrackNote}
+                onClick={onClick}
+            >
+                {content}
+            </button>
+        )
+
+    if (!tooltip) return button
 
     return (
         <Tippy
@@ -35,25 +59,7 @@ export const SiteToolsButton = ({
             appendTo="parent"
             delay={[200, 0]}
         >
-            {href !== undefined ? (
-                <a
-                    aria-label={label}
-                    className="site-tools__button"
-                    data-track-note={dataTrackNote}
-                    href={href}
-                >
-                    {content}
-                </a>
-            ) : (
-                <button
-                    aria-label={label}
-                    className="site-tools__button"
-                    data-track-note={dataTrackNote}
-                    onClick={onClick}
-                >
-                    {content}
-                </button>
-            )}
+            {button}
         </Tippy>
     )
 }

--- a/site/css/site-tools.scss
+++ b/site/css/site-tools.scss
@@ -1,81 +1,102 @@
-.site-tools {
+$site-tools-button-size: 40px;
+$site-tools-button-gap: 8px;
+
+.site-tools-root {
     display: none;
 }
 
 @include md-up {
-    .site-tools {
-        position: fixed;
+    // A zero-height sticky ruler that travels with the viewport until it
+    // reaches its resting place at the end of the page content, just above the
+    // donate banner. The buttons are positioned against its bottom edge, so
+    // they are permanently visible while scrolling but never end up on top of
+    // the donate banner or the footer links.
+    .site-tools-root {
         display: block;
+        position: sticky;
+        bottom: 0;
+        height: 0;
         z-index: $zindex-popover;
+    }
+
+    .site-tools {
+        position: absolute;
         right: $vertical-spacing;
         bottom: $vertical-spacing;
-        border: none;
-        .hide-wrapper {
-            display: flex;
-            transition:
-                transform var(--duration-popover) var(--ease-out),
-                opacity var(--duration-popover) var(--ease-out);
-            &.hide {
-                transform: translateY(calc(100% + #{$vertical-spacing}));
-                opacity: 0;
-            }
+        display: flex;
+        gap: $site-tools-button-gap;
+    }
 
-            > .active {
-                z-index: $zindex-popover;
+    .site-tools > .active {
+        z-index: $zindex-popover;
+    }
+
+    .site-tools__button {
+        @include popover-box-button;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        position: relative;
+        width: $site-tools-button-size;
+        height: $site-tools-button-size;
+        padding: 0;
+        // For the link variant, which would otherwise pick up the site's
+        // underlined link styles.
+        text-decoration: none;
+
+        svg {
+            // The mixin adds a right margin to sit next to a text label; the
+            // icon is on its own here, so it needs to stay centered.
+            margin-right: 0;
+        }
+    }
+
+    .site-tools .overlay {
+        @include overlay;
+    }
+
+    .site-tools .box {
+        position: absolute;
+        right: 0;
+        bottom: 100%;
+        margin-bottom: $vertical-spacing;
+        // Keep the popover inside the viewport on short windows. This can't
+        // help once the buttons have come to rest above the donate banner at
+        // the end of the page: the popover opens upwards from wherever they
+        // are, so a tall one is clipped there until the reader scrolls up.
+        max-height: calc(
+            100vh - #{$vertical-spacing * 3 + $site-tools-button-size}
+        );
+        overflow-y: auto;
+        @include popover-box-styles;
+
+        .newsletter-subscription-header {
+            padding: 32px 40px 0 40px;
+            svg {
+                display: none;
+            }
+            h4 {
+                flex: unset;
             }
         }
 
-        .prompt {
-            position: relative;
-            margin-left: 0.75rem;
-        }
-
-        .overlay {
-            @include overlay;
-        }
-
-        .box {
-            position: absolute;
-            bottom: 100%;
-            margin-bottom: $vertical-spacing;
-            right: 0;
-            @include popover-box-styles;
-            .newsletter-subscription-header {
-                padding: 32px 40px 0 40px;
-                svg {
-                    display: none;
-                }
-                h4 {
-                    flex: unset;
-                }
-            }
-
-            .newsletter-subscription-form {
-                padding-top: 16px;
-            }
-        }
-        button,
-        a.prompt {
-            @include popover-box-button;
-        }
-
-        a.prompt-donate {
-            background-color: $vermillion;
-            text-decoration: none;
-
-            &:hover {
-                background-color: $accent-vermillion;
-            }
+        .newsletter-subscription-form {
+            padding-top: 16px;
         }
     }
 }
 
-@media (prefers-reduced-motion: reduce) {
-    .site-tools .hide-wrapper {
-        transition: opacity var(--duration-popover) linear;
+.tippy-box[data-theme~="site-tools"] {
+    background-color: $blue-90;
+    color: $white;
+    border-radius: 3px;
+    @include note-12-medium;
 
-        &.hide {
-            transform: none;
-        }
+    .tippy-content {
+        padding: 4px 8px;
+    }
+
+    .tippy-arrow {
+        color: $blue-90;
     }
 }

--- a/site/css/site-tools.scss
+++ b/site/css/site-tools.scss
@@ -1,5 +1,9 @@
 $site-tools-button-size: 40px;
 $site-tools-button-gap: 8px;
+// Space outside an open popover: the site header, the tool buttons, and the
+// margins above, between, and below them.
+$site-tools-popover-inset: $header-height-md + $vertical-spacing * 3 +
+    $site-tools-button-size;
 
 .site-tools-root {
     display: none;
@@ -55,18 +59,19 @@ $site-tools-button-gap: 8px;
         @include overlay;
     }
 
+    .site-tools .box .FeedbackForm {
+        max-height: min(
+            700px,
+            calc(var(--viewport-height) - #{$site-tools-popover-inset})
+        );
+    }
+
     .site-tools .box {
         position: absolute;
         right: 0;
         bottom: 100%;
         margin-bottom: $vertical-spacing;
-        // Keep the popover inside the viewport on short windows. This can't
-        // help once the buttons have come to rest above the donate banner at
-        // the end of the page: the popover opens upwards from wherever they
-        // are, so a tall one is clipped there until the reader scrolls up.
-        max-height: calc(
-            100vh - #{$vertical-spacing * 3 + $site-tools-button-size}
-        );
+        max-height: calc(var(--viewport-height) - #{$site-tools-popover-inset});
         overflow-y: auto;
         @include popover-box-styles;
 

--- a/site/hooks.ts
+++ b/site/hooks.ts
@@ -4,39 +4,6 @@ import { MultiEmbedderSingleton } from "./multiembedder/MultiEmbedder.js"
 import { getWindowQueryStr } from "@ourworldindata/utils"
 import { reaction } from "mobx"
 
-export enum ScrollDirection {
-    Up = "up",
-    Down = "down",
-}
-
-export const useScrollDirection = () => {
-    const [direction, setDirection] = useState<null | ScrollDirection>(null)
-
-    useEffect(() => {
-        let lastScrollY = window.pageYOffset
-        const updateDirection = () => {
-            const scrollY = window.pageYOffset
-            setDirection(
-                scrollY > lastScrollY
-                    ? ScrollDirection.Down
-                    : ScrollDirection.Up
-            )
-            lastScrollY = scrollY
-        }
-
-        const updateDirectionThrottled = _.throttle(() => {
-            updateDirection()
-        }, 500)
-
-        document.addEventListener("scroll", updateDirectionThrottled)
-        return () => {
-            document.removeEventListener("scroll", updateDirectionThrottled)
-        }
-    })
-
-    return direction
-}
-
 // True while the user is actively scrolling; flips back to false once
 // scrolling has paused for `idleMs`. Lets consumers react to "scrolling
 // settled" by watching for the transition back to false.

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -632,6 +632,7 @@ a.ref sup {
 @media print {
     .site-header,
     .site-footer,
+    .site-tools-root,
     .cookie-notice,
     address,
     #wpadminbar,

--- a/site/runSiteFooterScripts.tsx
+++ b/site/runSiteFooterScripts.tsx
@@ -17,7 +17,7 @@ import {
 import { Footnote } from "./Footnote.js"
 import { OwidGdoc } from "./gdocs/OwidGdoc.js"
 import { MultiEmbedderSingleton } from "./multiembedder/MultiEmbedder.js"
-import SiteTools, { SITE_TOOLS_CLASS } from "./SiteTools.js"
+import SiteTools, { SITE_TOOLS_ROOT_CLASS } from "./SiteTools.js"
 import { runDetailsOnDemand } from "./detailsOnDemand.js"
 import { hydrateCodeSnippets } from "@ourworldindata/components"
 import { hydrateDynamicCollectionPage } from "./collections/DynamicCollectionPageMain.js"
@@ -223,7 +223,7 @@ function runSiteNavigation({
 }
 
 function runSiteTools() {
-    const siteToolsElem = document.querySelector(`.${SITE_TOOLS_CLASS}`)
+    const siteToolsElem = document.querySelector(`.${SITE_TOOLS_ROOT_CLASS}`)
     if (siteToolsElem) {
         const root = createRoot(siteToolsElem)
         root.render(<SiteTools />)

--- a/site/slideshows/SlideshowPage.scss
+++ b/site/slideshows/SlideshowPage.scss
@@ -7,7 +7,8 @@
 
 #slideshow-page-body {
     .site-footer,
-    .donate-footer {
+    .donate-footer,
+    .site-tools-root {
         display: none;
     }
 }


### PR DESCRIPTION
> _Written by OpenAI GPT-5 — @mlbrgl at the wheel._

Closes #5011.

Keeps the floating Subscribe and Feedback controls visible while readers scroll. They are now compact icon buttons with accessible labels and tooltips, and come to rest above the donate banner or footer instead of overlapping it.

At the very bottom of a page, an open popover may require scrolling up to reveal it fully. This is an accepted compromise to keep the positioning logic simple.

<details><summary>Details</summary>

- Hidden on mobile, slideshows, and printed pages.
- Popover heights adapt to the viewport.
- Typecheck, lint, formatting, unit tests, and visual checks pass.

</details>
