### PR TITLE
🔨🤖 give three bespoke workspaces their own tsconfig

### DIFF
--- a/bespoke/components/Sankey/SplitFlowSankey.test.ts
+++ b/bespoke/components/Sankey/SplitFlowSankey.test.ts
@@ -49,7 +49,11 @@ function makeBuild({
     const nodes = isIncoming
         ? [...partners, centralNode]
         : [centralNode, ...partners]
-    return { nodes, links }
+    const totalFlowVolume = partnerValues.reduce(
+        (total, value) => total + value,
+        0
+    )
+    return { nodes, links, totalFlowVolume }
 }
 
 // Mirror Sankey.tsx layout options and read realized value-to-pixel scale (ky).

--- a/bespoke/components/tsconfig.json
+++ b/bespoke/components/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedLocals": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es2020",
+            "es2021",
+            "es2022.array", // Array `at`
+            "es2022.error", // Error `cause`
+            "es2022.object", // Object `hasOwn`
+            "es2023.array", // Array `findLast`, `findLastIndex`, `toReversed`, `toSorted`, etc.
+            "es2024.collection", // `Map.groupBy`
+            "es2024.object", // `Object.groupBy`
+            "es2025.collection", // Set `union`, `intersection`, `difference` etc.
+            "es2025.iterator" // Iterator helpers: `map`, `filter`, `reduce`, `some`, `every`, `find`, etc.
+        ]
+    },
+    "include": ["."]
+}

--- a/bespoke/helpers/tsconfig.json
+++ b/bespoke/helpers/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedLocals": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es2020",
+            "es2021",
+            "es2022.array", // Array `at`
+            "es2022.error", // Error `cause`
+            "es2022.object", // Object `hasOwn`
+            "es2023.array", // Array `findLast`, `findLastIndex`, `toReversed`, `toSorted`, etc.
+            "es2024.collection", // `Map.groupBy`
+            "es2024.object", // `Object.groupBy`
+            "es2025.collection", // Set `union`, `intersection`, `difference` etc.
+            "es2025.iterator" // Iterator helpers: `map`, `filter`, `reduce`, `some`, `every`, `find`, etc.
+        ]
+    },
+    "include": ["."]
+}

--- a/bespoke/hooks/tsconfig.json
+++ b/bespoke/hooks/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "jsx": "react-jsx",
+        "strict": true,
+        "noUnusedLocals": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "noEmit": true,
+        "lib": [
+            "dom",
+            "dom.iterable",
+            "es2020",
+            "es2021",
+            "es2022.array", // Array `at`
+            "es2022.error", // Error `cause`
+            "es2022.object", // Object `hasOwn`
+            "es2023.array", // Array `findLast`, `findLastIndex`, `toReversed`, `toSorted`, etc.
+            "es2024.collection", // `Map.groupBy`
+            "es2024.object", // `Object.groupBy`
+            "es2025.collection", // Set `union`, `intersection`, `difference` etc.
+            "es2025.iterator" // Iterator helpers: `map`, `filter`, `reduce`, `some`, `every`, `find`, etc.
+        ]
+    },
+    "include": ["."]
+}


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

`bespoke/components`, `bespoke/helpers` and `bespoke/hooks` each run `tsc --noEmit` with no tsconfig of their own, so tsc walked up to the repo's solution-style root config, found no `files` or `include`, and read nothing. Their typecheck was passing over zero files. Each now carries the same config as the bespoke projects, with `include` set to `.` because these keep their sources at the top level rather than under `src`.

- **Fix.** Making the check real surfaced one existing error: a Sankey test builder returned an object without the `totalFlowVolume` that its declared return type requires.