### PR TITLE
🔨🤖 (marimekko) strip the redundant markup and anchor the internal labels

### DIFF
--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
@@ -33,7 +33,6 @@ export function MarimekkoBars({
         <>
             {noDataArea && (
                 <rect
-                    key="noDataArea"
                     x={noDataArea.x}
                     y={noDataArea.y}
                     width={noDataArea.width}
@@ -53,7 +52,6 @@ export function MarimekkoBars({
             ))}
             {!isFocusModeActive && noDataArea && (
                 <text
-                    key={`noDataArea-label`}
                     transform={`translate(${noDataArea.labelX}, ${noDataArea.labelY}) rotate(-90)`}
                     fontWeight={700}
                     fill="#666"

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
@@ -5,9 +5,10 @@ import {
 } from "./MarimekkoChartConstants"
 import { GRAPHER_FONT_SCALE_12, Patterns } from "../core/GrapherConstants"
 import { Emphasis, OPACITY_BY_EMPHASIS } from "../interaction/Emphasis.js"
+import { GRAY_30 } from "../color/ColorConstants.js"
 
 const PLACEHOLDER_COLOR = "#555"
-const BACKGROUNDED_COLOR = "#DADADA"
+const BACKGROUNDED_COLOR = GRAY_30
 
 interface MarimekkoBarsProps {
     series: RenderMarimekkoSeries[]

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
@@ -53,15 +53,9 @@ export function MarimekkoBars({
             {!isFocusModeActive && noDataArea && (
                 <text
                     key={`noDataArea-label`}
-                    x={0}
-                    transform={`rotate(-90, ${noDataArea.labelX}, ${noDataArea.labelY})
-                translate(${noDataArea.labelX}, ${noDataArea.labelY})`}
-                    y={0}
-                    width={noDataArea.width}
-                    height={noDataArea.height}
+                    transform={`translate(${noDataArea.labelX}, ${noDataArea.labelY}) rotate(-90)`}
                     fontWeight={700}
                     fill="#666"
-                    opacity={1}
                     fontSize={GRAPHER_FONT_SCALE_12 * fontSize}
                     textAnchor="middle"
                     dy={dyFromAlign(VerticalAlign.middle)}
@@ -122,22 +116,18 @@ function MarimekkoBar({
             onMouseLeave={(): void => onEntityMouseLeave?.()}
             onClick={(): void => onEntityClick?.(entityName)}
         >
-            <g>
-                <rect
-                    x={0}
-                    y={0}
-                    transform={`translate(0, ${barY - barHeight})`}
-                    width={barWidth}
-                    height={barHeight}
-                    fill={barColor}
-                    fillOpacity={fillOpacity}
-                    stroke={barColor}
-                    strokeWidth={isOutlined ? 1 : 0.5}
-                    strokeOpacity={isPlaceholder ? 0.8 : isMuted ? 0.2 : 1.0}
-                    opacity={isPlaceholder ? 0.2 : 1.0}
-                    style={{ transition: "translate 200ms ease" }}
-                />
-            </g>
+            <rect
+                x={0}
+                y={barY - barHeight}
+                width={barWidth}
+                height={barHeight}
+                fill={barColor}
+                fillOpacity={fillOpacity}
+                stroke={barColor}
+                strokeWidth={isOutlined ? 1 : 0.5}
+                strokeOpacity={isPlaceholder ? 0.8 : isMuted ? 0.2 : 1.0}
+                opacity={isPlaceholder ? 0.2 : 1.0}
+            />
         </g>
     )
 }

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
@@ -672,34 +672,29 @@ export class MarimekkoChart
     }
 
     private renderLabels(): React.ReactElement[] {
-        const labelsYPosition = this.dualAxis.verticalAxis.place(0)
+        const labelsY = MARKER_AREA_HEIGHT + this.dualAxis.verticalAxis.place(0)
         return this.placedLabels.map((label) => (
             <g
                 key={`label-${label.entityName}`}
                 id={makeFigmaId("label", label.entityName)}
-                transform={`translate(${label.correctedX}, ${MARKER_AREA_HEIGHT})`}
+                transform={`translate(${label.correctedX}, ${labelsY})`}
             >
-                <g transform={`translate(0, ${labelsYPosition})`}>
-                    <text
-                        y={0}
-                        fontWeight={label.isSelected ? 700 : 400}
-                        fill={label.color}
-                        transform={`rotate(${LABEL_ANGLE_IN_DEGREES}, 0, 0)`}
-                        opacity={1}
-                        fontSize={this.entityLabelFontSize}
-                        textAnchor="end"
-                        dy={dyFromAlign(VerticalAlign.middle)}
-                        onMouseOver={(): void =>
-                            this.onEntityMouseOver(label.entityName)
-                        }
-                        onMouseLeave={(): void => this.dismissTooltip()}
-                        onClick={(): void =>
-                            this.onEntityClick(label.entityName)
-                        }
-                    >
-                        {label.text}
-                    </text>
-                </g>
+                <text
+                    y={0}
+                    fontWeight={label.isSelected ? 700 : 400}
+                    fill={label.color}
+                    transform={`rotate(${LABEL_ANGLE_IN_DEGREES}, 0, 0)`}
+                    fontSize={this.entityLabelFontSize}
+                    textAnchor="end"
+                    dy={dyFromAlign(VerticalAlign.middle)}
+                    onMouseOver={(): void =>
+                        this.onEntityMouseOver(label.entityName)
+                    }
+                    onMouseLeave={(): void => this.dismissTooltip()}
+                    onClick={(): void => this.onEntityClick(label.entityName)}
+                >
+                    {label.text}
+                </text>
             </g>
         ))
     }

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoInternalLabels.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoInternalLabels.tsx
@@ -41,11 +41,8 @@ export class MarimekkoInternalLabels extends React.Component<MarimekkoInternalLa
                 if (series.yPoint === undefined) return undefined
 
                 const x = series.barX
-
-                const barY = this.props.dualAxis.verticalAxis.place(
-                    series.yPoint.value
-                )
-                const y = barY - this.props.labelPadding
+                const y =
+                    series.barY - series.barHeight - this.props.labelPadding
 
                 const label = series.shortEntityName ?? series.entityName
                 const bounds = Bounds.forText(label, {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Four independent cleanups in marimekko's rendering. The markup is the bulk of it. Every bar sat in an empty group with its rect at 0,0 plus a transform that only moved it down, entity labels nested two pure translations, and the no-data label rotated about a point and then translated to it.

- **Fix.** The thumbnail's internal labels placed themselves at the series value rather than at the top of the bar. Those differ when a value too small to paint a visible sliver is clamped to the one-pixel minimum height, so one of the 24 focused thumbnails moves its label up by a pixel.
- The markup change renders identically, so the pinned references need regenerating for no visual difference.