### PR TITLE
🐛🤖 (marimekko) label the extreme of the sort instead of dropping it

### DIFF
--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.test.ts
@@ -728,3 +728,47 @@ it("ignores x-axis when scatter is also available", () => {
     // xColumnSlug should be undefined because scatter is available
     expect(marimekkoState.xColumnSlug).toBeUndefined()
 })
+
+it("doesn't label entities that are absent at the selected time", () => {
+    const csv = `year,entityName,population,percentBelow2USD
+2000,medium,4000,5
+2000,big,5000,10
+2000,small,800,2
+2001,medium,4000,4
+2001,big,5000,8
+2001,small,1000,3
+2001,newcomer,9000,99`
+    const table = new OwidTable(csv, [
+        { slug: "population", type: ColumnTypeNames.Numeric },
+        { slug: "percentBelow2USD", type: ColumnTypeNames.Numeric },
+        { slug: "year", type: ColumnTypeNames.Year },
+    ])
+
+    const grapher = new GrapherState({
+        chartTypes: [GRAPHER_CHART_TYPES.Marimekko],
+        table,
+        ySlugs: "percentBelow2USD",
+        xSlug: "population",
+        maxTime: 2000,
+    })
+    const chartState = new MarimekkoChartState({ manager: grapher })
+    const chart = new MarimekkoChart({
+        chartState,
+        bounds: new Bounds(0, 0, 1000, 1000),
+    })
+
+    expect(chart["latestTime"]).toEqual(2001)
+    expect(chart.placedSeries.map((series) => series.entityName)).toEqual([
+        "big",
+        "medium",
+        "small",
+    ])
+
+    const candidateNames = chart["pickedLabelCandidates"].map(
+        (candidate) => candidate.entityName
+    )
+    const labelNames = chart["placedLabels"].map((label) => label.entityName)
+
+    expect(candidateNames).not.toContain("newcomer")
+    expect(labelNames.toSorted()).toEqual(candidateNames.toSorted())
+})

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
@@ -581,7 +581,9 @@ export class MarimekkoChart
         const { selectedSeries, sortConfig, focusArray } = this.chartState
 
         return pickMarimekkoLabelCandidates({
-            series: this.series,
+            entityNamesWithBars: new Set(
+                this.series.map(({ entityName }) => entityName)
+            ),
             xColumnAtLastTimePoint,
             yColumnAtLastTimePoint,
             selectedEntityNames: new Set(

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartHelpers.ts
@@ -1,12 +1,6 @@
 import * as _ from "lodash-es"
 import * as R from "remeda"
-import {
-    Bounds,
-    Color,
-    EntityName,
-    excludeUndefined,
-    SortOrder,
-} from "@ourworldindata/utils"
+import { Bounds, Color, EntityName, SortOrder } from "@ourworldindata/utils"
 import { CoreColumn } from "@ourworldindata/core-table"
 import { DualAxis } from "../axis/Axis"
 import { ColorScaleBin } from "../color/ColorScaleBin"
@@ -155,13 +149,9 @@ const LABEL_SPACING = 5
 
 const MAX_LABEL_COUNT = 20
 
-/**
- * Picks the entities to label under the x axis. Candidates are taken from the latest
- * time point rather than the selected one, so the labels stay put as the user drags
- * the timeline.
- */
+/** Picks the entities to label under the x axis */
 export function pickMarimekkoLabelCandidates({
-    series,
+    entityNamesWithBars,
     xColumnAtLastTimePoint,
     yColumnAtLastTimePoint,
     selectedEntityNames,
@@ -170,7 +160,7 @@ export function pickMarimekkoLabelCandidates({
     availableWidth,
     fontSize,
 }: {
-    series: readonly MarimekkoSeries[]
+    entityNamesWithBars: Set<EntityName>
     xColumnAtLastTimePoint: CoreColumn | undefined
     yColumnAtLastTimePoint: CoreColumn | undefined
     selectedEntityNames: Set<EntityName>
@@ -204,6 +194,10 @@ export function pickMarimekkoLabelCandidates({
                 isSelected: selectedEntityNames.has(row.entityName),
             }
         })
+
+    candidates = candidates.filter((candidate) =>
+        entityNamesWithBars.has(candidate.entityName)
+    )
 
     // If focus mode is active, only label focused series
     if (focusArray.hasFocusedSeries)
@@ -264,11 +258,7 @@ export function pickMarimekkoLabelCandidates({
     )
 
     // Spread the rest evenly by labelling the widest bar of each chunk
-    const chunks = splitIntoEqualDomainSizeChunks(
-        series,
-        candidates,
-        numLabelsToAdd
-    )
+    const chunks = splitIntoEqualDomainSizeChunks(candidates, numLabelsToAdd)
     for (const chunk of chunks) {
         if (chunk.some((candidate) => picked.has(candidate.entityName)))
             continue
@@ -328,28 +318,21 @@ export function toPlacedMarimekkoLabels(
         x0: number
     }
 ): PlacedMarimekkoLabel[] {
-    const labels: PlacedMarimekkoLabel[] = excludeUndefined(
-        candidates.map((candidate) => {
-            const series = placedSeriesByEntityName.get(candidate.entityName)
-            if (!series) {
-                console.error("Could not find series", candidate.entityName)
-                return undefined
-            }
+    const labels: PlacedMarimekkoLabel[] = candidates.map((candidate) => {
+        // pickMarimekkoLabelCandidates keeps only entities that have a bar
+        const series = placedSeriesByEntityName.get(candidate.entityName)!
 
-            const centreX = series.barX + series.barWidth / 2
-            const domainColor = domainColorForEntityMap.get(
-                candidate.entityName
-            )
-            return {
-                entityName: candidate.entityName,
-                text: candidate.text,
-                color: domainColor?.color ?? fallbackColor,
-                isSelected: candidate.isSelected,
-                preferredX: centreX,
-                correctedX: centreX,
-            }
-        })
-    )
+        const centreX = series.barX + series.barWidth / 2
+        const domainColor = domainColorForEntityMap.get(candidate.entityName)
+        return {
+            entityName: candidate.entityName,
+            text: candidate.text,
+            color: domainColor?.color ?? fallbackColor,
+            isSelected: candidate.isSelected,
+            preferredX: centreX,
+            correctedX: centreX,
+        }
+    })
 
     // This collision detection code is optimized for the particular
     // case of distributing items in 1D, knowing that we picked a low
@@ -443,27 +426,16 @@ the same sum of x value metric. This is useful for picking labels because we wan
 20 labels relatively evenly spaced (in x domain space) and this function gives us 20 groups that
 are roughly of equal size and then we can pick the largest of each group */
 function splitIntoEqualDomainSizeChunks(
-    series: readonly MarimekkoSeries[],
     candidates: readonly MarimekkoLabelCandidate[],
     numChunks: number
 ): MarimekkoLabelCandidate[][] {
-    // candidates contains all entities available in the chart for some time
-    // series is just the entities for the currently selected time, so can be a way smaller subset
-    const validEntityNames = new Set(series.map(({ entityName }) => entityName))
-
-    // filter the list to remove any candidates that are not currently visible
-    // all further calculations are then done only with validCandidates
-    const validCandidates = candidates.filter((candidate) =>
-        validEntityNames.has(candidate.entityName)
-    )
-
     const chunks: MarimekkoLabelCandidate[][] = []
     let currentChunk: MarimekkoLabelCandidate[] = []
     let domainSizeOfChunk = 0
     const domainSizeThreshold = Math.ceil(
-        _.sumBy(validCandidates, (candidate) => candidate.xValue) / numChunks
+        _.sumBy(candidates, (candidate) => candidate.xValue) / numChunks
     )
-    for (const candidate of validCandidates) {
+    for (const candidate of candidates) {
         while (domainSizeOfChunk > domainSizeThreshold) {
             chunks.push(currentChunk)
             currentChunk = []


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Label candidates come from the latest time point so the label set stays put as the timeline moves, while the bars come from the selected time. Only the chunk pass intersected the two, so the both-ends and selected picks could name an entity with no bar. The label was then dropped during placement and the extreme of the sort went unlabelled. Taking the intersection once, before any picking, completes the partial fix from #3581, which added it to one of the four paths.

- **Fix.** 13 charts label the true extreme instead of an entity that was picked and then dropped. No chart loses a label.
- Taking the intersection up front makes the chunker's own filter and the placement guard dead code, and lets the ambiguous `series` parameter become the set it was only ever used to build.