### PR TITLE
✨🤖 (marimekko) resolve emphasis the way other chart types do

### DIFF
--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoBars.tsx
@@ -1,14 +1,12 @@
 import { dyFromAlign, makeFigmaId, VerticalAlign } from "@ourworldindata/utils"
 import {
+    MARIMEKKO_BAR_STYLE,
     MarimekkoNoDataArea,
     RenderMarimekkoSeries,
 } from "./MarimekkoChartConstants"
 import { GRAPHER_FONT_SCALE_12, Patterns } from "../core/GrapherConstants"
-import { Emphasis, OPACITY_BY_EMPHASIS } from "../interaction/Emphasis.js"
-import { GRAY_30 } from "../color/ColorConstants.js"
 
 const PLACEHOLDER_COLOR = "#555"
-const BACKGROUNDED_COLOR = GRAY_30
 
 interface MarimekkoBarsProps {
     series: RenderMarimekkoSeries[]
@@ -80,31 +78,12 @@ function MarimekkoBar({
     onEntityMouseLeave,
     onEntityMouseOver,
 }: MarimekkoBarProps): React.ReactElement {
-    const {
-        entityName,
-        emphasis,
-        isMuted,
-        isOutlined,
-        focus,
-        barX,
-        barY,
-        barWidth,
-        barHeight,
-    } = series
+    const { entityName, emphasis, barX, barY, barWidth, barHeight } = series
     const isPlaceholder = series.yPoint === undefined
 
-    const barColor = focus.background
-        ? BACKGROUNDED_COLOR
-        : isPlaceholder
-          ? PLACEHOLDER_COLOR
-          : series.color
-
-    // The one case the emphasis map cannot express, a selected placeholder being
-    // neither hovered nor faded but still picked out
-    const fillOpacity =
-        emphasis === Emphasis.Default && isOutlined && isPlaceholder
-            ? 0.3
-            : OPACITY_BY_EMPHASIS[emphasis]
+    const barColor = isPlaceholder ? PLACEHOLDER_COLOR : series.color
+    const { fillOpacity, strokeOpacity, strokeWidth } =
+        MARIMEKKO_BAR_STYLE[emphasis]
 
     return (
         <g
@@ -123,8 +102,8 @@ function MarimekkoBar({
                 fill={barColor}
                 fillOpacity={fillOpacity}
                 stroke={barColor}
-                strokeWidth={isOutlined ? 1 : 0.5}
-                strokeOpacity={isPlaceholder ? 0.8 : isMuted ? 0.2 : 1.0}
+                strokeWidth={strokeWidth}
+                strokeOpacity={isPlaceholder ? 0.8 : strokeOpacity}
                 opacity={isPlaceholder ? 0.2 : 1.0}
             />
         </g>

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.test.ts
@@ -59,7 +59,6 @@ it("can display a Marimekko chart correctly", () => {
 
     const manager: MarimekkoChartManager = {
         table,
-        selection: table.availableEntityNames,
         yColumnSlugs: ["percentBelow2USD"],
         xColumnSlug: "population",
         endTime: 2001,
@@ -174,7 +173,6 @@ it("can do sorting", () => {
 
     const manager: MarimekkoChartManager = {
         table,
-        selection: table.availableEntityNames,
         yColumnSlugs: ["percentBelow2USD"],
         xColumnSlug: "population",
         endTime: 2001,

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import * as R from "remeda"
 import {
     Bounds,
+    Color,
     excludeUndefined,
     HorizontalAlign,
     Position,
@@ -279,18 +280,13 @@ export class MarimekkoChart
     private readonly resolveLegendBinEmphasis = (
         bin: ColorScaleBin
     ): Emphasis => {
-        const { hoveredColorBin } = this
-
-        // If nothing is focused, all items are active
-        if (!hoveredColorBin && this.hoverColors.length === 0)
-            return Emphasis.Default
+        if (!this.activeColors && !this.hoverColors) return Emphasis.Default
 
         const isHovered = this.hoverColors?.includes(bin.color)
         if (isHovered) return Emphasis.Highlighted
 
-        // Check if this bin matches the focused color bin
-        const isFocused = hoveredColorBin && bin.equals(hoveredColorBin)
-        return isFocused ? Emphasis.Highlighted : Emphasis.Muted
+        const isActive = this.activeColors?.includes(bin.color)
+        return isActive ? Emphasis.Highlighted : Emphasis.Muted
     }
 
     @computed private get categoricalLegendEmphasis(): BinEmphasis {
@@ -302,23 +298,21 @@ export class MarimekkoChart
 
     legendStyleConfig: LegendStyleConfig = LEGEND_STYLE_FOR_STACKED_CHARTS
 
-    @computed get hoverColors(): string[] {
+    @computed private get hoverColors(): Color[] | undefined {
         if (this.hoveredColorBin) return [this.hoveredColorBin.color]
-        if (this.tooltipSeries?.entityColor)
-            return [this.tooltipSeries.entityColor.color]
-        const { selectionArray } = this.chartState
-        if (selectionArray.hasSelection) {
-            const selectedSeries = this.series.filter((series) =>
-                selectionArray.selectedSet.has(series.entityName)
+        const { entityColor } = this.tooltipSeries ?? {}
+        return entityColor ? [entityColor.color] : undefined
+    }
+
+    @computed private get activeColors(): Color[] | undefined {
+        const colors = R.unique(
+            excludeUndefined(
+                this.series
+                    .filter((series) => series.focus.active)
+                    .map((series) => series.entityColor?.color)
             )
-            const uniqueSelectedColors = new Set(
-                selectedSeries.map((series) => series.entityColor?.color)
-            )
-            return this.categoricalLegendData
-                .filter((bin) => uniqueSelectedColors.has(bin.color as any))
-                .map((bin) => bin.color)
-        }
-        return []
+        )
+        return colors.length > 0 ? colors : undefined
     }
 
     @computed private get showLegend(): boolean {
@@ -326,6 +320,7 @@ export class MarimekkoChart
     }
 
     @action.bound onLegendMouseOver(bin: ColorScaleBin): void {
+        this.chartState.focusArray.clear()
         this.hoveredColorBin = bin
     }
 
@@ -345,6 +340,7 @@ export class MarimekkoChart
     }
 
     @action.bound private onEntityMouseOver(entityName: string): void {
+        this.chartState.focusArray.clear()
         this.tooltipState.target = { entityName }
     }
 

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
@@ -87,13 +87,13 @@ export class MarimekkoChart
         super(props)
 
         makeObservable(this, {
-            focusColorBin: observable,
+            hoveredColorBin: observable,
             tooltipState: observable,
         })
     }
 
     // currently hovered legend color
-    focusColorBin: ColorScaleBin | undefined = undefined
+    hoveredColorBin: ColorScaleBin | undefined = undefined
 
     // current tooltip target & position
     tooltipState = new TooltipState<{
@@ -240,8 +240,7 @@ export class MarimekkoChart
     @computed private get renderSeries(): RenderMarimekkoSeries[] {
         return toRenderMarimekkoSeries(this.placedSeries, {
             hoveredEntityName: this.hoveredEntityName,
-            selectedEntityNames: this.chartState.selectionArray.selectedSet,
-            focusColorBin: this.focusColorBin,
+            hoveredColorBin: this.hoveredColorBin,
         })
     }
 
@@ -280,17 +279,17 @@ export class MarimekkoChart
     private readonly resolveLegendBinEmphasis = (
         bin: ColorScaleBin
     ): Emphasis => {
-        const { focusColorBin } = this
+        const { hoveredColorBin } = this
 
         // If nothing is focused, all items are active
-        if (!focusColorBin && this.hoverColors.length === 0)
+        if (!hoveredColorBin && this.hoverColors.length === 0)
             return Emphasis.Default
 
         const isHovered = this.hoverColors?.includes(bin.color)
         if (isHovered) return Emphasis.Highlighted
 
         // Check if this bin matches the focused color bin
-        const isFocused = focusColorBin && bin.equals(focusColorBin)
+        const isFocused = hoveredColorBin && bin.equals(hoveredColorBin)
         return isFocused ? Emphasis.Highlighted : Emphasis.Muted
     }
 
@@ -304,7 +303,7 @@ export class MarimekkoChart
     legendStyleConfig: LegendStyleConfig = LEGEND_STYLE_FOR_STACKED_CHARTS
 
     @computed get hoverColors(): string[] {
-        if (this.focusColorBin) return [this.focusColorBin.color]
+        if (this.hoveredColorBin) return [this.hoveredColorBin.color]
         if (this.tooltipSeries?.entityColor)
             return [this.tooltipSeries.entityColor.color]
         const { selectionArray } = this.chartState
@@ -327,11 +326,11 @@ export class MarimekkoChart
     }
 
     @action.bound onLegendMouseOver(bin: ColorScaleBin): void {
-        this.focusColorBin = bin
+        this.hoveredColorBin = bin
     }
 
     @action.bound onLegendMouseLeave(): void {
-        this.focusColorBin = undefined
+        this.hoveredColorBin = undefined
     }
 
     @computed private get legendState(): HorizontalCategoricalColorLegendState {

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartConstants.ts
@@ -4,7 +4,7 @@ import { Color, SortBy, Time, Bounds, EntityName } from "@ourworldindata/utils"
 import { OwidTable } from "@ourworldindata/core-table"
 import { ChartSeries } from "../chart/ChartInterface"
 import { InteractionState } from "../interaction/InteractionState.js"
-import { Emphasis } from "../interaction/Emphasis.js"
+import { Emphasis, OPACITY_BY_EMPHASIS } from "../interaction/Emphasis.js"
 
 export interface MarimekkoChartManager extends ChartManager {
     xOverrideTime?: number
@@ -33,6 +33,7 @@ export interface MarimekkoSeries extends ChartSeries {
     yPoint: MarimekkoPoint | undefined
     xPoint: MarimekkoPoint | undefined
     entityColor: EntityColorData | undefined
+    /** Covers both focus and selection, either of which singles the entity out */
     focus: InteractionState
 }
 
@@ -44,15 +45,34 @@ export interface PlacedMarimekkoSeries extends MarimekkoSeries {
 }
 
 export interface RenderMarimekkoSeries extends PlacedMarimekkoSeries {
-    /**
-     * Drives the fill. A hovered bar reads as highlighted even while the rest of it
-     * is faded, so this can be `Highlighted` while `isMuted` is true.
-     */
     emphasis: Emphasis
-    /** Faded because another bar is hovered, focused, or selected */
-    isMuted: boolean
-    /** Hovered or selected: thicker stroke, and drawn last so it overlaps its neighbours */
-    isOutlined: boolean
+}
+
+export interface MarimekkoBarStyle {
+    fillOpacity: number
+    strokeOpacity: number
+    strokeWidth: number
+}
+
+const DEFAULT_MARIMEKKO_BAR_STYLE: MarimekkoBarStyle = {
+    fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Default],
+    strokeOpacity: 1,
+    strokeWidth: 0.5,
+}
+
+export const MARIMEKKO_BAR_STYLE: Record<Emphasis, MarimekkoBarStyle> = {
+    [Emphasis.Default]: DEFAULT_MARIMEKKO_BAR_STYLE,
+    [Emphasis.Elevated]: DEFAULT_MARIMEKKO_BAR_STYLE,
+    [Emphasis.Highlighted]: {
+        fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Highlighted],
+        strokeOpacity: 1,
+        strokeWidth: 1,
+    },
+    [Emphasis.Muted]: {
+        fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Muted],
+        strokeOpacity: 0.2,
+        strokeWidth: 0.5,
+    },
 }
 
 /** The hatched band covering the entities that have no y value */

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartHelpers.ts
@@ -4,12 +4,16 @@ import { Bounds, Color, EntityName, SortOrder } from "@ourworldindata/utils"
 import { CoreColumn } from "@ourworldindata/core-table"
 import { DualAxis } from "../axis/Axis"
 import { ColorScaleBin } from "../color/ColorScaleBin"
-import { Emphasis } from "../interaction/Emphasis"
+import { resolveEmphasis } from "../interaction/Emphasis"
 import { FocusArray } from "../focus/FocusArray"
-import { getShortNameForEntity } from "../chart/ChartUtils"
+import {
+    getHoverStateForSeries,
+    getShortNameForEntity,
+} from "../chart/ChartUtils"
 import {
     EntityColorData,
     LABEL_ANGLE_IN_DEGREES,
+    MARIMEKKO_BAR_STYLE,
     MarimekkoLabelCandidate,
     MarimekkoLabelMeasurements,
     MarimekkoNoDataArea,
@@ -66,51 +70,42 @@ export function toRenderMarimekkoSeries(
     placedSeries: readonly PlacedMarimekkoSeries[],
     {
         hoveredEntityName,
-        selectedEntityNames,
-        focusColorBin,
+        hoveredColorBin,
     }: {
         hoveredEntityName?: EntityName
-        selectedEntityNames: Set<EntityName>
-        focusColorBin?: ColorScaleBin
-    }
+        hoveredColorBin?: ColorScaleBin
+    } = {}
 ): RenderMarimekkoSeries[] {
-    const hasSelection = placedSeries.some((series) =>
-        selectedEntityNames.has(series.entityName)
-    )
+    const hoveredSeriesNames = hoveredEntityName
+        ? [hoveredEntityName]
+        : hoveredColorBin
+          ? placedSeries
+                .filter((series) =>
+                    hoveredColorBin.contains(
+                        series.entityColor?.colorDomainValue
+                    )
+                )
+                .map((series) => series.seriesName)
+          : []
+
+    const isHoverModeActive =
+        hoveredEntityName !== undefined || hoveredColorBin !== undefined
 
     const renderSeries = placedSeries.map((series): RenderMarimekkoSeries => {
-        const isHovered = series.entityName === hoveredEntityName
-        const isSelected = selectedEntityNames.has(series.entityName)
-        const isMuted =
-            series.focus.background ||
-            (focusColorBin !== undefined &&
-                !focusColorBin.contains(
-                    series.entityColor?.colorDomainValue
-                )) ||
-            (focusColorBin === undefined && hasSelection && !isSelected) ||
-            (!isHovered && !isSelected && hoveredEntityName !== undefined)
-
-        const emphasis = isHovered
-            ? Emphasis.Highlighted
-            : isMuted
-              ? Emphasis.Muted
-              : Emphasis.Default
-
-        return {
-            ...series,
-            emphasis,
-            isMuted,
-            isOutlined: isHovered || isSelected,
-        }
+        const hover = getHoverStateForSeries(series, {
+            hoveredSeriesNames,
+            isHoverModeActive,
+        })
+        // A hovered legend bin decides membership on its own, so a selected bar outside it fades like any other
+        const focus = hoveredColorBin ? undefined : series.focus
+        return { ...series, emphasis: resolveEmphasis({ hover, focus }) }
     })
 
-    // Adjacent Marimekko bars share an edge, so an outlined bar has to paint after
-    // its neighbours for its thicker stroke to sit on top
-    const [outlined, plain] = _.partition(
+    // Adjacent marimekko bars share an edge, so a thicker stroke has to paint after its neighbours
+    return _.sortBy(
         renderSeries,
-        (series) => series.isOutlined
+        (series) => MARIMEKKO_BAR_STYLE[series.emphasis].strokeWidth
     )
-    return [...plain, ...outlined]
 }
 
 export function toMarimekkoNoDataArea(

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartState.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartState.ts
@@ -35,6 +35,7 @@ import { ColorSchemes } from "../color/ColorSchemes"
 import { excludeUndefined } from "@ourworldindata/utils"
 import { SelectionArray } from "../selection/SelectionArray"
 import { FocusArray } from "../focus/FocusArray"
+import { InteractionState } from "../interaction/InteractionState.js"
 import { AxisConfig } from "../axis/AxisConfig.js"
 import { HorizontalAxis, VerticalAxis } from "../axis/Axis.js"
 import { makeToleranceNotice } from "../chart/ToleranceNotice.js"
@@ -118,6 +119,15 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
 
     @computed get isFocusModeActive(): boolean {
         return this.focusArray.hasFocusedSeries
+    }
+
+    private focusOrSelectionState(entityName: EntityName): InteractionState {
+        const isSingledOut =
+            this.focusArray.has(entityName) ||
+            this.selectionArray.selectedSet.has(entityName)
+        const isModeActive =
+            this.focusArray.hasFocusedSeries || this.selectionArray.hasSelection
+        return new InteractionState(isSingledOut, isModeActive)
     }
 
     /** Marimekko plots a single y indicator; a config naming several keeps the first */
@@ -278,7 +288,7 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
                         : undefined,
                     color: entityColor?.color ?? yColumnColor,
                     entityColor,
-                    focus: this.focusArray.state(entityName),
+                    focus: this.focusOrSelectionState(entityName),
                 }
             })
         )

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartThumbnail.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartThumbnail.tsx
@@ -128,9 +128,7 @@ export class MarimekkoChartThumbnail
     }
 
     @computed private get renderSeries(): RenderMarimekkoSeries[] {
-        return toRenderMarimekkoSeries(this.placedSeries, {
-            selectedEntityNames: this.chartState.selectionArray.selectedSet,
-        })
+        return toRenderMarimekkoSeries(this.placedSeries)
     }
 
     @computed private get placedSeriesByEntityName(): Map<


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Marimekko was the only chart type that never called `resolveEmphasis`. It built the ladder from `isHovered`, `isSelected` and a four-clause `isMuted`, and `MarimekkoBars` painted from `emphasis`, `isMuted`, `isOutlined` and `focus.background` at once. Those four could disagree, and did. A focused bar rendered byte-identical to an idle one, and hovering a bar while another was focused painted it a solid grey block at full opacity behind a stroke at 20%.

Selection and focus are one intent here, because marimekko plots every entity regardless of selection. `MarimekkoChartState` now merges the two into the focus state each series already carried, `RenderMarimekkoSeries` keeps only `emphasis`, and a `Record<Emphasis, …>` table carries all three painted properties.

Selection on a live chart, on [human-development-index](http://staging-site-marimekko-emphasis/grapher/human-development-index), which selects 12 entities.

### Behaviour changes

- A selected or focused bar reads Highlighted rather than Default. Selection is authored on 178 of the 204 published marimekkos, so this is the change that moves the most charts.
- Backgrounded bars keep their own colour instead of going grey. Marimekko was the only chart type that swapped the colour rather than muting the opacity.
- A hovered legend bin lifts its bars to Highlighted, which is a stronger effect than the previous 0.8 against 0.3.
- A selected no-data placeholder loses its special-cased 0.3 fill.
- Focus is dismissed when the chart is interacted with, on hovering a bar or a legend bin, which is the idiom every other chart type already follows. The selection is not dismissed.
- A focused entity's legend bin is highlighted, as a selected entity's already was. The legend read the selection array directly, so it never saw focus.

### Worth a look

- A bin hover suppresses the focus axis while it is active, so a selected bar outside the bin still fades. Without that, the fix in #5690 comes back as a bug.
- `focusArray` stays focus-only and only `series.focus` widens. Widening the label path too would drop every non-selected x-axis label and add internal labels to thumbnails.
- Focus feeds the x-axis label set and thence the plot bounds, so the first interaction on a `?focus=` chart relabels the axis and resizes the plot area once. Reachable only through the URL param, since `canHighlightSeries` excludes marimekko from the admin's focus UI and no published chart authors focus.
- `focusColorBin` becomes `hoveredColorBin`. It is the hovered legend bin, unrelated to `FocusArray`, and the misnomer is why a fourth input accumulated in the first place.

