### PR TITLE
🔨🤖 (marimekko) drop sorting support from marimekko charts

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -3532,10 +3532,7 @@ export class GrapherState
         if (
             this.isRelativeMode &&
             sortConfig.sortBy === SortBy.total &&
-            // No need to do this for Marimekko and discrete bar charts
-            // since relative mode means something else for Marimekko charts
-            // and discrete bar charts don't support relative mode
-            !this.isOnMarimekkoTab &&
+            // Discrete bar charts don't support relative mode
             !this.isOnDiscreteBarTab
         ) {
             sortConfig.sortBy = SortBy.entityName

--- a/packages/@ourworldindata/grapher/src/interaction/Emphasis.ts
+++ b/packages/@ourworldindata/grapher/src/interaction/Emphasis.ts
@@ -1,8 +1,3 @@
-import {
-    GRAPHER_AREA_OPACITY_DEFAULT,
-    GRAPHER_AREA_OPACITY_HIGHLIGHTED,
-    GRAPHER_AREA_OPACITY_MUTED,
-} from "../core/GrapherConstants.js"
 import { InteractionState } from "./InteractionState.js"
 
 export enum Emphasis {
@@ -14,13 +9,6 @@ export enum Emphasis {
     Highlighted = "highlighted",
     /** Muted emphasis */
     Muted = "muted",
-}
-
-export const OPACITY_BY_EMPHASIS: Record<Emphasis, number> = {
-    [Emphasis.Default]: GRAPHER_AREA_OPACITY_DEFAULT,
-    [Emphasis.Elevated]: GRAPHER_AREA_OPACITY_DEFAULT,
-    [Emphasis.Highlighted]: GRAPHER_AREA_OPACITY_HIGHLIGHTED,
-    [Emphasis.Muted]: GRAPHER_AREA_OPACITY_MUTED,
 }
 
 export function resolveEmphasis({

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.test.ts
@@ -12,14 +12,9 @@ import { GrapherState } from "../core/GrapherState"
 import {
     GRAPHER_CHART_TYPES,
     GRAPHER_TAB_CONFIG_OPTIONS,
-    SortBy,
-    SortOrder,
 } from "@ourworldindata/types"
 import { MarimekkoChart } from "./MarimekkoChart"
-import {
-    MarimekkoChartManager,
-    MarimekkoSeries,
-} from "./MarimekkoChartConstants"
+import { MarimekkoChartManager } from "./MarimekkoChartConstants"
 import { MarimekkoChartState } from "./MarimekkoChartState"
 import { InteractionState } from "../interaction/InteractionState.js"
 
@@ -160,7 +155,7 @@ it("can display a Marimekko chart correctly", () => {
     expect(xPositions[2]).toBeCloseTo(xAxisRange * 0.9, 0)
 })
 
-it("can do sorting", () => {
+it("sorts entities by y value, largest first", () => {
     const csv = `year,entityName,population,percentBelow2USD
 2001,AA,4000,4
 2001,BB,5000,8
@@ -171,143 +166,21 @@ it("can do sorting", () => {
         { slug: "year", type: ColumnTypeNames.Year },
     ])
 
-    const manager: MarimekkoChartManager = {
-        table,
-        yColumnSlugs: ["percentBelow2USD"],
-        xColumnSlug: "population",
-        endTime: 2001,
-        showNoDataArea: false,
-    }
-    let chartState = new MarimekkoChartState({
+    const chartState = new MarimekkoChartState({
         manager: {
-            ...manager,
-            sortConfig: {
-                sortBy: SortBy.total,
-                sortOrder: SortOrder.asc,
-            },
+            table,
+            yColumnSlugs: ["percentBelow2USD"],
+            xColumnSlug: "population",
+            endTime: 2001,
+            showNoDataArea: false,
         },
     })
 
     expect(chartState.errorInfo.reason).toEqual("")
-    expect(chartState.series.length).toEqual(3)
-
-    const expectedXPoints = [
-        { value: 4000, time: 2001 },
-        { value: 5000, time: 2001 },
-        { value: 1000, time: 2001 },
-    ]
-    expect(chartState.series).toEqual([
-        {
-            seriesName: "AA",
-            entityName: "AA",
-            shortEntityName: undefined,
-            yPoint: { value: 4, time: 2001 },
-            xPoint: expectedXPoints[0],
-            color: DefaultColorScheme.colorSets[0][0],
-            entityColor: undefined,
-            focus: new InteractionState(),
-        },
-        {
-            seriesName: "BB",
-            entityName: "BB",
-            shortEntityName: undefined,
-            yPoint: { value: 8, time: 2001 },
-            xPoint: expectedXPoints[1],
-            color: DefaultColorScheme.colorSets[0][0],
-            entityColor: undefined,
-            focus: new InteractionState(),
-        },
-        {
-            seriesName: "CC",
-            entityName: "CC",
-            shortEntityName: undefined,
-            yPoint: { value: 3, time: 2001 },
-            xPoint: expectedXPoints[2],
-            color: DefaultColorScheme.colorSets[0][0],
-            entityColor: undefined,
-            focus: new InteractionState(),
-        },
-    ])
-    expect(chartState.series.map((series) => series.xPoint)).toEqual(
-        expectedXPoints
-    )
-
-    const series = new Map<string, MarimekkoSeries>([
-        [
-            "big",
-            {
-                seriesName: "BB",
-                entityName: "BB",
-                shortEntityName: undefined,
-                yPoint: { value: 8, time: 2001 },
-                xPoint: expectedXPoints[1],
-                color: DefaultColorScheme.colorSets[0][0],
-                entityColor: undefined,
-                focus: new InteractionState(),
-            },
-        ],
-        [
-            "medium",
-            {
-                seriesName: "AA",
-                entityName: "AA",
-                shortEntityName: undefined,
-                yPoint: { value: 4, time: 2001 },
-                xPoint: expectedXPoints[0],
-                color: DefaultColorScheme.colorSets[0][0],
-                entityColor: undefined,
-                focus: new InteractionState(),
-            },
-        ],
-        [
-            "small",
-            {
-                seriesName: "CC",
-                entityName: "CC",
-                shortEntityName: undefined,
-                yPoint: { value: 3, time: 2001 },
-                xPoint: expectedXPoints[2],
-                color: DefaultColorScheme.colorSets[0][0],
-                entityColor: undefined,
-                focus: new InteractionState(),
-            },
-        ],
-    ])
-    expect(chartState.sortedSeries).toEqual([
-        series.get("small"),
-        series.get("medium"),
-        series.get("big"),
-    ])
-
-    chartState = new MarimekkoChartState({
-        manager: {
-            ...manager,
-            sortConfig: {
-                sortBy: SortBy.column,
-                sortColumnSlug: "percentBelow2USD",
-                sortOrder: SortOrder.asc,
-            },
-        },
-    })
-    expect(chartState.sortedSeries).toEqual([
-        series.get("small"),
-        series.get("medium"),
-        series.get("big"),
-    ])
-
-    chartState = new MarimekkoChartState({
-        manager: {
-            ...manager,
-            sortConfig: {
-                sortBy: SortBy.entityName,
-                sortOrder: SortOrder.asc,
-            },
-        },
-    })
-    expect(chartState.sortedSeries).toEqual([
-        series.get("medium"),
-        series.get("big"),
-        series.get("small"),
+    expect(chartState.sortedSeries.map((series) => series.entityName)).toEqual([
+        "BB",
+        "AA",
+        "CC",
     ])
 })
 

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChart.tsx
@@ -573,7 +573,7 @@ export class MarimekkoChart
 
     @computed private get pickedLabelCandidates(): MarimekkoLabelCandidate[] {
         const { xColumnAtLastTimePoint, yColumnAtLastTimePoint, xRange } = this
-        const { selectedSeries, sortConfig, focusArray } = this.chartState
+        const { selectedSeries, focusArray } = this.chartState
 
         return pickMarimekkoLabelCandidates({
             entityNamesWithBars: new Set(
@@ -585,7 +585,6 @@ export class MarimekkoChart
                 selectedSeries.map((series) => series.entityName)
             ),
             focusArray,
-            sortOrder: sortConfig.sortOrder,
             availableWidth: xRange[1] - xRange[0],
             fontSize: this.entityLabelFontSize,
         })

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartConstants.ts
@@ -1,6 +1,6 @@
 import { ChartManager } from "../chart/ChartManager"
 
-import { Color, SortBy, Time, Bounds, EntityName } from "@ourworldindata/utils"
+import { Color, Time, Bounds, EntityName } from "@ourworldindata/utils"
 import { OwidTable } from "@ourworldindata/core-table"
 import { ChartSeries } from "../chart/ChartInterface"
 import { InteractionState } from "../interaction/InteractionState.js"
@@ -121,10 +121,3 @@ export interface MarimekkoLabelMeasurements {
     rotatedMaxWidth: number
     rotatedMaxHeight: number
 }
-
-export const MARIMEKKO_SORT_KEYS = [
-    SortBy.custom,
-    SortBy.entityName,
-    SortBy.total,
-] as const
-export type MarimekkoSortKey = (typeof MARIMEKKO_SORT_KEYS)[number]

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartConstants.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartConstants.ts
@@ -4,7 +4,12 @@ import { Color, Time, Bounds, EntityName } from "@ourworldindata/utils"
 import { OwidTable } from "@ourworldindata/core-table"
 import { ChartSeries } from "../chart/ChartInterface"
 import { InteractionState } from "../interaction/InteractionState.js"
-import { Emphasis, OPACITY_BY_EMPHASIS } from "../interaction/Emphasis.js"
+import { Emphasis } from "../interaction/Emphasis.js"
+import {
+    GRAPHER_AREA_OPACITY_DEFAULT,
+    GRAPHER_AREA_OPACITY_HIGHLIGHTED,
+    GRAPHER_AREA_OPACITY_MUTED,
+} from "../core/GrapherConstants.js"
 
 export interface MarimekkoChartManager extends ChartManager {
     xOverrideTime?: number
@@ -55,7 +60,7 @@ export interface MarimekkoBarStyle {
 }
 
 const DEFAULT_MARIMEKKO_BAR_STYLE: MarimekkoBarStyle = {
-    fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Default],
+    fillOpacity: GRAPHER_AREA_OPACITY_DEFAULT,
     strokeOpacity: 1,
     strokeWidth: 0.5,
 }
@@ -64,12 +69,12 @@ export const MARIMEKKO_BAR_STYLE: Record<Emphasis, MarimekkoBarStyle> = {
     [Emphasis.Default]: DEFAULT_MARIMEKKO_BAR_STYLE,
     [Emphasis.Elevated]: DEFAULT_MARIMEKKO_BAR_STYLE,
     [Emphasis.Highlighted]: {
-        fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Highlighted],
+        fillOpacity: GRAPHER_AREA_OPACITY_HIGHLIGHTED,
         strokeOpacity: 1,
         strokeWidth: 1,
     },
     [Emphasis.Muted]: {
-        fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Muted],
+        fillOpacity: GRAPHER_AREA_OPACITY_MUTED,
         strokeOpacity: 0.2,
         strokeWidth: 0.5,
     },

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartHelpers.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartHelpers.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash-es"
 import * as R from "remeda"
-import { Bounds, Color, EntityName, SortOrder } from "@ourworldindata/utils"
+import { Bounds, Color, EntityName } from "@ourworldindata/utils"
 import { CoreColumn } from "@ourworldindata/core-table"
 import { DualAxis } from "../axis/Axis"
 import { ColorScaleBin } from "../color/ColorScaleBin"
@@ -151,7 +151,6 @@ export function pickMarimekkoLabelCandidates({
     yColumnAtLastTimePoint,
     selectedEntityNames,
     focusArray,
-    sortOrder,
     availableWidth,
     fontSize,
 }: {
@@ -160,7 +159,6 @@ export function pickMarimekkoLabelCandidates({
     yColumnAtLastTimePoint: CoreColumn | undefined
     selectedEntityNames: Set<EntityName>
     focusArray: FocusArray
-    sortOrder: SortOrder | undefined
     availableWidth: number
     fontSize: number
 }): MarimekkoLabelCandidate[] {
@@ -202,23 +200,20 @@ export function pickMarimekkoLabelCandidates({
 
     if (candidates.length === 0) return []
 
+    // Ascending by y value, entities without a value last
     candidates.sort((a, b) => {
         const yValueForA = a.ySortValue
         const yValueForB = b.ySortValue
 
         if (yValueForA !== undefined && yValueForB !== undefined) {
-            const diff = yValueForB - yValueForA
+            const diff = yValueForA - yValueForB
             if (diff !== 0) return diff
-            else return b.entityName.localeCompare(a.entityName)
+            else return a.entityName.localeCompare(b.entityName)
         } else if (yValueForA === undefined && yValueForB !== undefined)
-            return -1
-        else if (yValueForA !== undefined && yValueForB === undefined) return 1
-        // (yValueForA === undefined && yValueForB === undefined)
+            return 1
+        else if (yValueForA !== undefined && yValueForB === undefined) return -1
         else return 0
     })
-
-    const isDescending = sortOrder === SortOrder.desc
-    if (isDescending) candidates.reverse()
 
     const picked = new Set<EntityName>(
         candidates
@@ -237,12 +232,7 @@ export function pickMarimekkoLabelCandidates({
         picked.add(R.first(withValues)!.entityName)
         picked.add(R.last(withValues)!.entityName)
     }
-    if (withoutValues.length)
-        picked.add(
-            isDescending
-                ? R.first(withoutValues)!.entityName
-                : R.last(withoutValues)!.entityName
-        )
+    if (withoutValues.length) picked.add(R.first(withoutValues)!.entityName)
 
     const labelHeight = candidates[0].bounds.height
     const numLabelsToAdd = Math.floor(

--- a/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartState.ts
+++ b/packages/@ourworldindata/grapher/src/marimekko/MarimekkoChartState.ts
@@ -4,19 +4,14 @@ import { ChartState } from "../chart/ChartInterface"
 import { ColorScale, ColorScaleManager } from "../color/ColorScale"
 import {
     EntityColorData,
-    MARIMEKKO_SORT_KEYS,
     MarimekkoChartManager,
     MarimekkoSeries,
-    MarimekkoSortKey,
 } from "./MarimekkoChartConstants"
 import { CoreColumn, OwidTable } from "@ourworldindata/core-table"
 import {
     autoDetectYColumnSlugs,
     getShortNameForEntity,
-    keepInputOrder,
     makeSelectionArray,
-    SortKey,
-    sortByConfig,
 } from "../chart/ChartUtils"
 import { ColorScaleConfig } from "../color/ColorScaleConfig"
 import {
@@ -24,8 +19,6 @@ import {
     ColorSchemeName,
     EntityName,
     ColorScaleConfigInterface,
-    SortConfig,
-    SortBy,
     ScaleType,
     Color,
 } from "@ourworldindata/types"
@@ -130,7 +123,6 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
         return new InteractionState(isSingledOut, isModeActive)
     }
 
-    /** Marimekko plots a single y indicator; a config naming several keeps the first */
     @computed get yColumnSlug(): string | undefined {
         const slugs =
             this.manager.yColumnSlugs ?? autoDetectYColumnSlugs(this.manager)
@@ -180,21 +172,7 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
     @computed get colorScaleColumn(): CoreColumn {
         const { manager, inputTable } = this
         return (
-            // For faceted charts, we have to get the values of inputTable before it's filtered by
-            // the faceting logic.
             manager.colorScaleColumnOverride ??
-            // We need to use filteredTable in order to get consistent coloring for a variable across
-            // charts, e.g. each continent being assigned to the same color.
-            // inputTable is unfiltered, so it contains every value that exists in the variable.
-
-            // 2022-05-25: I considered using the filtered table below to get rid of Antarctica automatically
-            // but the way things are currently done this leads to a shift in the colors assigned to continents
-            // (i.e. they are no longer consistent cross the site). I think this downside is heavier than the
-            // upside so I comment this out for now. Reconsider when we do colors differently.
-
-            // manager.tableAfterAuthorTimelineAndActiveChartTransform?.get(
-            //     this.colorColumnSlug
-            // ) ??
             inputTable.get(this.colorColumnSlug)
         )
     }
@@ -208,13 +186,8 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
         )
     }
 
-    /** Fallback bar color for entities the color column says nothing about */
     @computed get yColumnColor(): Color {
         return this.yColumn.def.color ?? this.colorScheme.getColors(1)[0]
-    }
-
-    @computed get sortConfig(): SortConfig {
-        return this.manager.sortConfig ?? {}
     }
 
     @computed get x0(): number {
@@ -270,7 +243,6 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
         return excludeUndefined(
             uniqueEntityNames.map((entityName) => {
                 const xRow = xRowsByEntity?.get(entityName)?.[0]
-                // An entity the x indicator says nothing about has no bar width
                 if (xColumn && !xRow) return undefined
 
                 const yRow = yRowsByEntity.get(entityName)?.[0]
@@ -294,36 +266,26 @@ export class MarimekkoChartState implements ChartState, ColorScaleManager {
         )
     }
 
+    /** Bars run left to right from the largest y value down, entities without a value last */
     @computed get sortedSeries(): MarimekkoSeries[] {
         const byYValue = (series: MarimekkoSeries): number =>
             series.yPoint?.value ?? 0
         const byEntityName = (series: MarimekkoSeries): string =>
             series.entityName
 
-        const keyFns: Record<
-            MarimekkoSortKey | SortBy.column,
-            SortKey<MarimekkoSeries>
-        > = {
-            [SortBy.custom]: keepInputOrder,
-            [SortBy.entityName]: byEntityName,
-            [SortBy.total]: [byYValue, byEntityName],
-            // With a single y indicator, sorting by column is sorting by total
-            [SortBy.column]: [byYValue, byEntityName],
-        }
-        const sortedSeries = sortByConfig(this.series, this.sortConfig, keyFns)
+        const descendingByYValue = _.sortBy(this.series, [
+            byYValue,
+            byEntityName,
+        ]).toReversed()
 
         // The no-data area is drawn as one rectangle spanning the entities without a
         // value, and MarimekkoBars asserts they are contiguous, so they go last.
         const [seriesWithValues, seriesWithoutValues] = _.partition(
-            sortedSeries,
+            descendingByYValue,
             (series) => series.yPoint !== undefined
         )
 
         return [...seriesWithValues, ...seriesWithoutValues]
-    }
-
-    @computed get availableSortKeys(): MarimekkoSortKey[] {
-        return [...MARIMEKKO_SORT_KEYS]
     }
 
     @computed get selectedSeries(): MarimekkoSeries[] {

--- a/packages/@ourworldindata/grapher/src/schema/grapher-schema.011.yaml
+++ b/packages/@ourworldindata/grapher/src/schema/grapher-schema.011.yaml
@@ -615,7 +615,7 @@ properties:
   sortBy:
     type: string
     description: |
-      Sort criterion (used by discrete bar, stacked discrete bar, marimekko, and dumbbell charts).
+      Sort criterion (used by discrete bar, stacked discrete bar, and dumbbell charts).
       - column: sort by the value of a specific column, identified by sortColumnSlug
       - total: sort by the total across all columns
       - entityName: sort alphabetically by entity name

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedConstants.ts
@@ -2,8 +2,13 @@ import { OwidVariableRow, SeriesName, Time } from "@ourworldindata/types"
 import { ChartSeries } from "../chart/ChartInterface"
 import { Point } from "@ourworldindata/utils"
 import { InteractionState } from "../interaction/InteractionState.js"
-import { Emphasis, OPACITY_BY_EMPHASIS } from "../interaction/Emphasis"
+import { Emphasis } from "../interaction/Emphasis"
 import { LegendStyleConfig } from "../legend/LegendStyleConfig"
+import {
+    GRAPHER_AREA_OPACITY_DEFAULT,
+    GRAPHER_AREA_OPACITY_HIGHLIGHTED,
+    GRAPHER_AREA_OPACITY_MUTED,
+} from "../core/GrapherConstants.js"
 
 export interface StackedAreaStyleConfig {
     fillOpacity: number
@@ -16,7 +21,7 @@ export interface StackedBarStyleConfig {
 }
 
 const DEFAULT_STACKED_AREA_STYLE: StackedAreaStyleConfig = {
-    fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Default],
+    fillOpacity: GRAPHER_AREA_OPACITY_DEFAULT,
     borderOpacity: 0.7,
     borderWidth: 0.5,
 }
@@ -25,34 +30,32 @@ export const STACKED_AREA_STYLE: Record<Emphasis, StackedAreaStyleConfig> = {
     [Emphasis.Default]: DEFAULT_STACKED_AREA_STYLE,
     [Emphasis.Elevated]: DEFAULT_STACKED_AREA_STYLE,
     [Emphasis.Highlighted]: {
-        fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Highlighted],
+        fillOpacity: GRAPHER_AREA_OPACITY_HIGHLIGHTED,
         borderOpacity: 1,
         borderWidth: 1.5,
     },
     [Emphasis.Muted]: {
-        fillOpacity: OPACITY_BY_EMPHASIS[Emphasis.Muted],
+        fillOpacity: GRAPHER_AREA_OPACITY_MUTED,
         borderOpacity: 0.3,
         borderWidth: 0.5,
     },
 }
 
 export const STACKED_BAR_STYLE: Record<Emphasis, StackedBarStyleConfig> = {
-    [Emphasis.Default]: { opacity: OPACITY_BY_EMPHASIS[Emphasis.Default] },
-    [Emphasis.Elevated]: { opacity: OPACITY_BY_EMPHASIS[Emphasis.Default] },
-    [Emphasis.Highlighted]: {
-        opacity: OPACITY_BY_EMPHASIS[Emphasis.Highlighted],
-    },
-    [Emphasis.Muted]: { opacity: OPACITY_BY_EMPHASIS[Emphasis.Muted] },
+    [Emphasis.Default]: { opacity: GRAPHER_AREA_OPACITY_DEFAULT },
+    [Emphasis.Elevated]: { opacity: GRAPHER_AREA_OPACITY_DEFAULT },
+    [Emphasis.Highlighted]: { opacity: GRAPHER_AREA_OPACITY_HIGHLIGHTED },
+    [Emphasis.Muted]: { opacity: GRAPHER_AREA_OPACITY_MUTED },
 }
 
 export const LEGEND_STYLE_FOR_STACKED_CHARTS: LegendStyleConfig = {
     marker: {
-        default: { opacity: OPACITY_BY_EMPHASIS[Emphasis.Default] },
-        highlighted: { opacity: OPACITY_BY_EMPHASIS[Emphasis.Highlighted] },
-        muted: { opacity: OPACITY_BY_EMPHASIS[Emphasis.Muted] },
+        default: { opacity: GRAPHER_AREA_OPACITY_DEFAULT },
+        highlighted: { opacity: GRAPHER_AREA_OPACITY_HIGHLIGHTED },
+        muted: { opacity: GRAPHER_AREA_OPACITY_MUTED },
     },
     text: {
-        muted: { opacity: OPACITY_BY_EMPHASIS[Emphasis.Muted] },
+        muted: { opacity: GRAPHER_AREA_OPACITY_MUTED },
     },
 }
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Marimekko bars are always sorted by y value, largest first, so the chart no longer reads `sortBy`, `sortColumnSlug` or `sortOrder` at all. Dropping the marimekko sort keys also takes the sort dropdown out of the admin for marimekko-only charts.

- Nothing in the database relies on a custom sort. Of the 677 `chart_configs` rows with Marimekko in `chartTypes`, 663 leave `sortBy` unset and 14 set `total`/`desc`, which is exactly the order the chart now hardcodes. The mdim authored layer does set `sortBy: "column"`, but only on views of `incomes-across-distribution-wb` that aren't Marimekko.
- Those 14 configs keep their now-ignored `sortBy`. It's a shared key (discrete bar, stacked discrete bar, dumbbell) so it stays in the schema, and I'd rather leave the stale values than migrate keys that no longer do anything.