### PR TITLE
🔨🤖 restrict the migrant pyramid to countries

### DIFF
--- a/bespoke/projects/migrant-demographics/src/components/PyramidControls.tsx
+++ b/bespoke/projects/migrant-demographics/src/components/PyramidControls.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react"
 
 import { Checkbox } from "@ourworldindata/components"
 import { BasicDropdownOption } from "@ourworldindata/grapher"
-import { WORLD_ENTITY_NAME } from "@ourworldindata/grapher/src/core/GrapherConstants.js"
 import { Tippy } from "@ourworldindata/utils"
 
 import {
@@ -99,7 +98,6 @@ function CountryDropdown({
         () =>
             orderOptionsByRelevance(flat, {
                 userCountryInfo,
-                pinnedToTop: [WORLD_ENTITY_NAME],
                 selectedValue: country,
             }),
         [flat, userCountryInfo, country]
@@ -108,12 +106,12 @@ function CountryDropdown({
     return (
         <LabeledDropdown
             className="migrant-pyramid-controls__country"
-            label="Country or region"
+            label="Country"
             options={options}
             selectedValue={country}
             onChange={setCountry}
-            placeholder="Select a country or region…"
-            aria-label="Select a country or region"
+            placeholder="Select a country…"
+            aria-label="Select a country"
             isSearchable
         />
     )

--- a/bespoke/projects/migrant-demographics/src/core/data.test.ts
+++ b/bespoke/projects/migrant-demographics/src/core/data.test.ts
@@ -27,7 +27,7 @@ describe(MigrantDemographics, () => {
     const data = new MigrantDemographics(RAW)
 
     it("skips entities with malformed data", () => {
-        expect(data.entityNames).toEqual(["World", "United States", "Kenya"])
+        expect(data.entityNames).toEqual(["United States", "Kenya"])
         expect(data.hasEntity("United States")).toBe(true)
         expect(data.hasEntity("Broken")).toBe(false)
     })
@@ -36,10 +36,14 @@ describe(MigrantDemographics, () => {
         expect(data.hasEntity("Monaco")).toBe(false)
     })
 
+    it("skips aggregates", () => {
+        expect(data.hasEntity("Europe (UN)")).toBe(false)
+    })
+
     it("returns pyramid data by entity name and year", () => {
-        expect(data.getPyramidData("World", 2010)?.migrantsTotal.total).toBe(
-            100
-        )
-        expect(data.getPyramidData("World", 1990)).toBeUndefined()
+        expect(
+            data.getPyramidData("United States", 2010)?.migrantsTotal.total
+        ).toBe(100)
+        expect(data.getPyramidData("United States", 1990)).toBeUndefined()
     })
 })

--- a/bespoke/projects/migrant-demographics/src/core/data.ts
+++ b/bespoke/projects/migrant-demographics/src/core/data.ts
@@ -53,6 +53,7 @@ export class MigrantDemographics {
 
         this.recordsByEntityName = new Map()
         for (const entity of raw.entities) {
+            if (entity.isAggregate) continue
             if (!isValidEntity(entity, raw.years, raw.ageBands.length)) {
                 console.warn(
                     `[migrant-demographics] Skipping entity with malformed data: ${entity.name}`

--- a/bespoke/projects/migrant-demographics/src/core/testFixtures.ts
+++ b/bespoke/projects/migrant-demographics/src/core/testFixtures.ts
@@ -28,7 +28,8 @@ export const RAW: RawMigrantDemographics = {
     years: [2010, 2020],
     entities: [
         {
-            name: "World",
+            name: "Europe (UN)",
+            isAggregate: true,
             data: { "2010": RECORD, "2020": RECORD },
         },
         {

--- a/bespoke/projects/migrant-demographics/src/core/types.ts
+++ b/bespoke/projects/migrant-demographics/src/core/types.ts
@@ -19,6 +19,8 @@ export interface RawYearRecord {
 
 export interface RawEntity {
     name: string
+    /** Regions and income groups, which the pyramid doesn't show */
+    isAggregate?: boolean
     data: Record<string, RawYearRecord>
 }
 

--- a/bespoke/projects/migrant-demographics/src/variants/PyramidVariant.tsx
+++ b/bespoke/projects/migrant-demographics/src/variants/PyramidVariant.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react"
 import cx from "clsx"
-import { WORLD_ENTITY_NAME } from "@ourworldindata/grapher/src/core/GrapherConstants.js"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { NuqsAdapter } from "nuqs/adapters/react"
 import {
@@ -269,8 +268,8 @@ function CaptionedPyramidVariant({
                     ) : (
                         <div className="migrant-pyramid__no-data">
                             {pyramidData
-                                ? `No immigrants recorded in ${formatEntityNameForSentence(country, ["UN"])} in ${year}.`
-                                : `No data for ${formatEntityNameForSentence(country, ["UN"])} in ${year}.`}
+                                ? `No immigrants recorded in ${formatEntityNameForSentence(country)} in ${year}.`
+                                : `No data for ${formatEntityNameForSentence(country)} in ${year}.`}
                         </div>
                     )}
                 </div>
@@ -284,16 +283,12 @@ function CaptionedPyramidVariant({
 }
 
 function chartTitle(country: string, year: number): string {
-    if (country === WORLD_ENTITY_NAME)
-        return `Population pyramid of immigrants worldwide in ${year}`
-    return `Population pyramid of immigrants living in ${formatEntityNameForSentence(country, ["UN"])} in ${year}`
+    return `Population pyramid of immigrants living in ${formatEntityNameForSentence(country)} in ${year}`
 }
 
 function chartSubtitle(country: string, total: number): string {
     const count = formatCountLong(total)
-    if (country === WORLD_ENTITY_NAME)
-        return `The age and sex profile of the ${count} people worldwide living outside their country of birth.`
-    return `The age and sex profile of the ${count} people living in ${formatEntityNameForSentence(country, ["UN"])} who were born elsewhere.`
+    return `The age and sex profile of the ${count} people living in ${formatEntityNameForSentence(country)} who were born elsewhere.`
 }
 
 function PyramidSkeleton(): React.ReactElement {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

The migrant-demographics data file no longer carries aggregates. World, the six `(UN)` regions and the four income groups are gone from the version now live in the bucket, leaving 200 countries, so this drops the code that only existed for those entities.

- **Behaviour change.** The country dropdown stops pinning World to the top, and its label and placeholder say "Country" rather than "Country or region".
- The loader skips entities flagged `isAggregate`, so the country-only rule holds even if a later data refresh puts regions back into the file.
- The footer note still explains the single-census fallback in terms of countries, which reads fine now. If we want the exclusion of regions spelled out for readers, that note is where it goes.