### PR TITLE
🔨🤖 take urlSync from a shared embed config

### DIFF
--- a/bespoke/helpers/config.ts
+++ b/bespoke/helpers/config.ts
@@ -5,9 +5,14 @@
  * config value must not take the whole viz down.
  */
 
-/** Props a variant component takes: its parsed config */
+/** How the surrounding page embeds a bespoke component */
+export interface EmbedConfig {
+    urlSync: boolean
+}
+
+/** Props a variant component takes: its parsed config, embed flags included */
 export interface VariantProps<Config> {
-    config: Config
+    config: Config & EmbedConfig
 }
 
 export function parseBoolean(value: unknown): boolean {
@@ -34,4 +39,8 @@ export function parseEnum<T extends string>(
     return (allowed as readonly string[]).includes(value)
         ? (value as T)
         : undefined
+}
+
+export function parseEmbedConfig(raw: Record<string, string>): EmbedConfig {
+    return { urlSync: parseBoolean(raw.urlSync) }
 }

--- a/bespoke/hooks/useEmbedConfig.tsx
+++ b/bespoke/hooks/useEmbedConfig.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react"
+
+import type { EmbedConfig } from "../helpers/config.js"
+
+/** Defaults to an in-article embed: no URL syncing unless the host asks for it */
+const EmbedConfigContext = createContext<EmbedConfig>({ urlSync: false })
+
+export function EmbedConfigProvider({
+    config,
+    children,
+}: {
+    config: EmbedConfig
+    children: React.ReactNode
+}): React.ReactElement {
+    return (
+        <EmbedConfigContext.Provider value={config}>
+            {children}
+        </EmbedConfigContext.Provider>
+    )
+}
+
+export function useEmbedConfig(): EmbedConfig {
+    return useContext(EmbedConfigContext)
+}

--- a/bespoke/hooks/useResolveUserLocation.ts
+++ b/bespoke/hooks/useResolveUserLocation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { useUserCountryInformation } from "./useUserCountryInformation.js"
+import { useEmbedConfig } from "./useEmbedConfig.js"
 
 const USER_LOCATION_CONFIG_OPTION = "userLocation"
 
@@ -12,16 +13,15 @@ export function isUserLocationCountry(
 export function useResolveUserLocation({
     configCountry,
     availableCountryNames,
-    urlSync,
     urlStateKey,
     setCountry,
 }: {
     configCountry: string | undefined
     availableCountryNames: Set<string> | undefined
-    urlSync: boolean
     urlStateKey: string
     setCountry: (name: string) => void
 }): { isResolved: boolean } {
+    const { urlSync } = useEmbedConfig()
     const isUserLocation = isUserLocationCountry(configCountry)
 
     const [isResolved, setIsResolved] = useState(!isUserLocation)

--- a/bespoke/hooks/useUrlState.ts
+++ b/bespoke/hooks/useUrlState.ts
@@ -1,22 +1,23 @@
 import { useState } from "react"
 import { useQueryState, type SingleParserBuilder } from "nuqs"
 
+import { useEmbedConfig } from "./useEmbedConfig.js"
+
 export function useUrlState<T extends NonNullable<unknown>>({
     key,
     parser,
     defaultValue,
-    enabled,
 }: {
     key: string
     parser: SingleParserBuilder<T>
     defaultValue: T
-    enabled: boolean
 }): [T, (next: T) => void] {
+    const { urlSync } = useEmbedConfig()
     const local = useState<T>(defaultValue)
     const [urlValue, setUrl] = useQueryState(
         key,
         parser.withDefault(defaultValue)
     )
-    if (enabled) return [urlValue, setUrl]
+    if (urlSync) return [urlValue, setUrl]
     return local
 }

--- a/bespoke/projects/causes-of-death/src/components/CausesOfDeathChart.tsx
+++ b/bespoke/projects/causes-of-death/src/components/CausesOfDeathChart.tsx
@@ -11,6 +11,7 @@ import * as R from "remeda"
 import { Time } from "@ourworldindata/types"
 import { WORLD_ENTITY_NAME } from "@ourworldindata/grapher/src/core/GrapherConstants.js"
 
+import type { EmbedConfig } from "../../../../helpers/config.js"
 import { CausesOfDeathConfig } from "../core/config.js"
 import {
     useCausesOfDeathEntityData,
@@ -21,6 +22,7 @@ import { CausesOfDeathCaptionedChart } from "./CausesOfDeathCaptionedChart.js"
 import { CausesOfDeathControls } from "./CausesOfDeathControls.js"
 
 import { useUrlState } from "../../../../hooks/useUrlState.js"
+import { EmbedConfigProvider } from "../../../../hooks/useEmbedConfig.js"
 import { useDelayedLoading } from "../../../../hooks/useDelayedLoading.js"
 
 import { Spinner } from "../../../../components/Spinner/Spinner.js"
@@ -37,14 +39,16 @@ const queryClient = new QueryClient()
 
 export function CausesOfDeathChartWithProviders(props: {
     container?: HTMLDivElement
-    config?: CausesOfDeathConfig
+    config: CausesOfDeathConfig & EmbedConfig
 }): React.ReactElement {
     return (
-        <NuqsAdapter>
-            <QueryClientProvider client={queryClient}>
-                <CausesOfDeathChart config={props.config} />
-            </QueryClientProvider>
-        </NuqsAdapter>
+        <EmbedConfigProvider config={props.config}>
+            <NuqsAdapter>
+                <QueryClientProvider client={queryClient}>
+                    <CausesOfDeathChart config={props.config} />
+                </QueryClientProvider>
+            </NuqsAdapter>
+        </EmbedConfigProvider>
     )
 }
 
@@ -53,32 +57,26 @@ function CausesOfDeathChart(props: {
 }): React.ReactElement {
     const { config } = props
 
-    const urlSync = config?.urlSync ?? false
-
-    // State, synced to the URL if the urlSync flag is set
+    // State, synced to the URL when the embedding page asks for it
     const [ageGroup, setAgeGroup] = useUrlState({
         key: "causesOfDeathAge",
         parser: parseAsString,
         defaultValue: config?.ageGroup ?? DEFAULT_AGE_GROUP,
-        enabled: urlSync,
     })
     const [sex, setSex] = useUrlState({
         key: "causesOfDeathSex",
         parser: parseAsString,
         defaultValue: config?.sex ?? DEFAULT_SEX,
-        enabled: urlSync,
     })
     const [entityName, setEntityName] = useUrlState({
         key: "causesOfDeathRegion",
         parser: parseAsString,
         defaultValue: config?.region ?? DEFAULT_ENTITY_NAME,
-        enabled: urlSync,
     })
     const [year, setYear] = useUrlState({
         key: "causesOfDeathYear",
         parser: parseAsInteger,
         defaultValue: config?.year ?? LATEST_YEAR,
-        enabled: urlSync,
     })
 
     // Fetch the metadata and the data for the selected entity

--- a/bespoke/projects/causes-of-death/src/index.tsx
+++ b/bespoke/projects/causes-of-death/src/index.tsx
@@ -7,6 +7,8 @@ import type {
 } from "owid-bespoke-types"
 import StylesTarget from "vite-plugin-css-position/react"
 
+import { parseEmbedConfig } from "../../../helpers/config.js"
+
 import { CausesOfDeathChartWithProviders } from "./components/CausesOfDeathChart.js"
 import { parseConfig } from "./core/config.js"
 
@@ -33,7 +35,11 @@ export const mount: BespokeComponentMountFn = (
         return
     }
 
-    const config = parseConfig(opts.config ?? {})
+    const rawConfig = opts.config ?? {}
+    const config = {
+        ...parseConfig(rawConfig),
+        ...parseEmbedConfig(rawConfig),
+    }
 
     const root = createRoot(container)
     root.render(

--- a/bespoke/projects/demography/src/components/SimulationContent.tsx
+++ b/bespoke/projects/demography/src/components/SimulationContent.tsx
@@ -33,6 +33,7 @@ import {
 import { ProjectionLegend } from "./ProjectionLegend.js"
 import { parameterConfigByKey } from "../core/parameterConfigs.js"
 import { useTippyContainer } from "../../../../hooks/useTippyContainer.js"
+import { useEmbedConfig } from "../../../../hooks/useEmbedConfig.js"
 
 const PARAMETER_TAB_LABELS: Record<ParameterKey, string> = {
     fertilityRate: "Fertility rate",
@@ -48,7 +49,6 @@ export function SimulationContent({
     fertilityRateAssumptions,
     lifeExpectancyAssumptions,
     netMigrationRateAssumptions,
-    urlSync,
     urlFertilityRateAssumptions,
     urlLifeExpectancyAssumptions,
     urlNetMigrationRateAssumptions,
@@ -64,7 +64,6 @@ export function SimulationContent({
     fertilityRateAssumptions?: Record<number, number>
     lifeExpectancyAssumptions?: Record<number, number>
     netMigrationRateAssumptions?: Record<number, number>
-    urlSync?: boolean
     urlFertilityRateAssumptions?: Record<number, number>
     urlLifeExpectancyAssumptions?: Record<number, number>
     urlNetMigrationRateAssumptions?: Record<number, number>
@@ -73,6 +72,8 @@ export function SimulationContent({
     urlTab?: ParameterKey
     urlYear?: number
 }) {
+    const { urlSync } = useEmbedConfig()
+
     const baselineTab: ParameterKey = focusParameter ?? "fertilityRate"
     const baselineYear = END_YEAR
 

--- a/bespoke/projects/demography/src/core/config.ts
+++ b/bespoke/projects/demography/src/core/config.ts
@@ -27,7 +27,6 @@ export interface SimulationVariantConfig {
     focusParameter?: ParameterKey
     hidePopulationPyramid?: boolean
     populationPyramidUnit?: PopulationPyramidUnit
-    urlSync?: boolean
     fertilityRateAssumptions?: Record<number, number>
     lifeExpectancyAssumptions?: Record<number, number>
     netMigrationRateAssumptions?: Record<number, number>
@@ -91,7 +90,6 @@ export function parseConfig(
                     raw.populationPyramidUnit,
                     POPULATION_PYRAMID_UNITS
                 ),
-                urlSync: parseBoolean(raw.urlSync),
                 fertilityRateAssumptions: parseControlPoints(
                     raw.fertilityRateAssumptions
                 ),

--- a/bespoke/projects/demography/src/index.tsx
+++ b/bespoke/projects/demography/src/index.tsx
@@ -7,6 +7,8 @@ import type {
 } from "owid-bespoke-types"
 import StylesTarget from "vite-plugin-css-position/react"
 
+import { parseEmbedConfig } from "../../../helpers/config.js"
+
 import { SimulationVariant } from "./variants/SimulationVariant.js"
 import { PopulationVariant } from "./variants/PopulationVariant.js"
 import { PopulationPyramidVariant } from "./variants/PopulationPyramidVariant.js"
@@ -56,7 +58,11 @@ export const mount: BespokeComponentMountFn = (
         return
     }
 
-    const config = parseConfig(variant.name, opts.config ?? {})
+    const rawConfig = opts.config ?? {}
+    const config = {
+        ...parseConfig(variant.name, rawConfig),
+        ...parseEmbedConfig(rawConfig),
+    }
 
     const root = createRoot(container)
     root.render(

--- a/bespoke/projects/demography/src/variants/SimulationVariant.tsx
+++ b/bespoke/projects/demography/src/variants/SimulationVariant.tsx
@@ -19,6 +19,10 @@ import {
     DemographySkeleton,
 } from "../components/DemographyLoadAndError.js"
 import { Spinner } from "../../../../components/Spinner/Spinner.js"
+import {
+    EmbedConfigProvider,
+    useEmbedConfig,
+} from "../../../../hooks/useEmbedConfig.js"
 import { CountryData, DemographyMetadata, ParameterKey } from "../core/types.js"
 
 import { Frame } from "../../../../components/Frame/Frame.js"
@@ -38,19 +42,21 @@ export function SimulationVariant({
     const { breakpoint, ref: rootRef } = useContainerBreakpoint()
 
     return (
-        <QueryClientProvider client={queryClient}>
-            <BreakpointProvider value={breakpoint}>
-                <div
-                    ref={rootRef}
-                    className={cx(
-                        "demography-chart demography-chart__simulation-variant",
-                        breakpointClass(breakpoint)
-                    )}
-                >
-                    <FetchingSimulationVariant config={config} />
-                </div>
-            </BreakpointProvider>
-        </QueryClientProvider>
+        <EmbedConfigProvider config={config}>
+            <QueryClientProvider client={queryClient}>
+                <BreakpointProvider value={breakpoint}>
+                    <div
+                        ref={rootRef}
+                        className={cx(
+                            "demography-chart demography-chart__simulation-variant",
+                            breakpointClass(breakpoint)
+                        )}
+                    >
+                        <FetchingSimulationVariant config={config} />
+                    </div>
+                </BreakpointProvider>
+            </QueryClientProvider>
+        </EmbedConfigProvider>
     )
 }
 
@@ -59,9 +65,11 @@ function FetchingSimulationVariant({
 }: {
     config: SimulationVariantConfig
 }): React.ReactElement {
+    const { urlSync } = useEmbedConfig()
+
     const urlState = useMemo(
-        () => (config.urlSync ? parseSimulationUrlState() : {}),
-        [config.urlSync]
+        () => (urlSync ? parseSimulationUrlState() : {}),
+        [urlSync]
     )
     const [urlAssumptionState, setUrlAssumptionState] =
         useState<SimulationUrlAssumptionState>(() =>
@@ -74,13 +82,13 @@ function FetchingSimulationVariant({
         useInitialEntityName(urlState.entityName ?? config.region)
     const setEntityName = useCallback(
         (name: string) => {
-            if (config.urlSync) {
+            if (urlSync) {
                 setShouldSyncEntityName(true)
                 setUrlAssumptionState({})
             }
             setEntityNameRaw(name)
         },
-        [config.urlSync, setEntityNameRaw]
+        [urlSync, setEntityNameRaw]
     )
 
     const { metadata, entityData, isLoadingEntityData, status } =
@@ -100,7 +108,7 @@ function FetchingSimulationVariant({
 
     useEffect(() => {
         const shouldSyncAutoDetectedEntityName =
-            config.urlSync &&
+            urlSync &&
             !urlState.entityName &&
             (!config.region || config.region === "userLocation") &&
             isInitialEntityNameResolved
@@ -108,7 +116,7 @@ function FetchingSimulationVariant({
         if (shouldSyncAutoDetectedEntityName) setShouldSyncEntityName(true)
     }, [
         config.region,
-        config.urlSync,
+        urlSync,
         isInitialEntityNameResolved,
         urlState.entityName,
     ])
@@ -133,7 +141,6 @@ function FetchingSimulationVariant({
             fertilityRateAssumptions={config.fertilityRateAssumptions}
             lifeExpectancyAssumptions={config.lifeExpectancyAssumptions}
             netMigrationRateAssumptions={config.netMigrationRateAssumptions}
-            urlSync={config.urlSync}
             urlFertilityRateAssumptions={
                 urlAssumptionState.fertilityRateAssumptions
             }
@@ -188,7 +195,6 @@ function CaptionedSimulationVariant({
     fertilityRateAssumptions,
     lifeExpectancyAssumptions,
     netMigrationRateAssumptions,
-    urlSync,
     urlFertilityRateAssumptions,
     urlLifeExpectancyAssumptions,
     urlNetMigrationRateAssumptions,
@@ -211,7 +217,6 @@ function CaptionedSimulationVariant({
     fertilityRateAssumptions?: Record<number, number>
     lifeExpectancyAssumptions?: Record<number, number>
     netMigrationRateAssumptions?: Record<number, number>
-    urlSync?: boolean
     urlFertilityRateAssumptions?: Record<number, number>
     urlLifeExpectancyAssumptions?: Record<number, number>
     urlNetMigrationRateAssumptions?: Record<number, number>
@@ -260,7 +265,6 @@ function CaptionedSimulationVariant({
                     fertilityRateAssumptions={fertilityRateAssumptions}
                     lifeExpectancyAssumptions={lifeExpectancyAssumptions}
                     netMigrationRateAssumptions={netMigrationRateAssumptions}
-                    urlSync={urlSync}
                     urlFertilityRateAssumptions={urlFertilityRateAssumptions}
                     urlLifeExpectancyAssumptions={urlLifeExpectancyAssumptions}
                     urlNetMigrationRateAssumptions={

--- a/bespoke/projects/food-trade/src/core/config.ts
+++ b/bespoke/projects/food-trade/src/core/config.ts
@@ -12,7 +12,6 @@ export interface SankeyVariantConfig {
     product?: string
     country?: string
     flow?: Flow
-    urlSync?: boolean
 }
 
 export function parseConfig(raw: Record<string, string>): SankeyVariantConfig {
@@ -24,6 +23,5 @@ export function parseConfig(raw: Record<string, string>): SankeyVariantConfig {
         product: raw.product,
         country: raw.country,
         flow: parseEnum(raw.flow, FLOWS),
-        urlSync: parseBoolean(raw.urlSync),
     }
 }

--- a/bespoke/projects/food-trade/src/index.tsx
+++ b/bespoke/projects/food-trade/src/index.tsx
@@ -11,6 +11,8 @@ import type {
 } from "owid-bespoke-types"
 import StylesTarget from "vite-plugin-css-position/react"
 
+import { parseEmbedConfig } from "../../../helpers/config.js"
+
 import "./index.scss"
 
 // Enable react-aria's internal Shadow DOM handling paths.
@@ -31,7 +33,11 @@ export const mount: BespokeComponentMountFn = (
         return
     }
 
-    const config = parseConfig(opts.config ?? {})
+    const rawConfig = opts.config ?? {}
+    const config = {
+        ...parseConfig(rawConfig),
+        ...parseEmbedConfig(rawConfig),
+    }
 
     const root = createRoot(container)
     root.render(

--- a/bespoke/projects/food-trade/src/variants/SankeyVariant.tsx
+++ b/bespoke/projects/food-trade/src/variants/SankeyVariant.tsx
@@ -24,6 +24,7 @@ import {
     BILATERAL_LOW_VOLUME_THRESHOLD,
 } from "../core/helpers.js"
 import { useUrlState } from "../../../../hooks/useUrlState.js"
+import { EmbedConfigProvider } from "../../../../hooks/useEmbedConfig.js"
 import { useDelayedLoading } from "../../../../hooks/useDelayedLoading.js"
 import { useContainerWidth } from "../../../../hooks/useContainerWidth.js"
 import {
@@ -45,18 +46,20 @@ export function SankeyVariant({
     const isNarrow = width > 0 && width < MOBILE_BREAKPOINT
 
     return (
-        <NuqsAdapter>
-            <QueryClientProvider client={queryClient}>
-                <div
-                    ref={ref}
-                    className={cx("food-trade-chart", {
-                        "food-trade-chart--narrow": isNarrow,
-                    })}
-                >
-                    <FetchingSankeyVariant config={config} />
-                </div>
-            </QueryClientProvider>
-        </NuqsAdapter>
+        <EmbedConfigProvider config={config}>
+            <NuqsAdapter>
+                <QueryClientProvider client={queryClient}>
+                    <div
+                        ref={ref}
+                        className={cx("food-trade-chart", {
+                            "food-trade-chart--narrow": isNarrow,
+                        })}
+                    >
+                        <FetchingSankeyVariant config={config} />
+                    </div>
+                </QueryClientProvider>
+            </NuqsAdapter>
+        </EmbedConfigProvider>
     )
 }
 
@@ -69,25 +72,20 @@ function FetchingSankeyVariant({ config }: { config: SankeyVariantConfig }) {
         !isUserLocation && isAllCountry(initialCountry)
             ? "both"
             : (config.flow ?? DEFAULT_VIEW)
-    const urlSync = config.urlSync ?? false
-
     const [product, setProduct] = useUrlState({
         key: "foodTradeProduct",
         parser: parseAsString,
         defaultValue: initialProduct,
-        enabled: urlSync,
     })
     const [country, _setCountry] = useUrlState({
         key: "foodTradeCountry",
         parser: parseAsString,
         defaultValue: initialCountry,
-        enabled: urlSync,
     })
     const [_view, setView] = useUrlState({
         key: "foodTradeFlow",
         parser: parseAsStringEnum<Flow>(["both", "import", "export"]),
         defaultValue: initialView,
-        enabled: urlSync,
     })
 
     const { data: metadata, status: metadataStatus } = useFoodTradeMetadata()
@@ -138,7 +136,6 @@ function FetchingSankeyVariant({ config }: { config: SankeyVariantConfig }) {
     const { isResolved: isCountryResolved } = useResolveUserLocation({
         configCountry: config.country,
         availableCountryNames,
-        urlSync,
         urlStateKey: "foodTradeCountry",
         setCountry,
     })

--- a/bespoke/projects/migrant-demographics/src/core/config.ts
+++ b/bespoke/projects/migrant-demographics/src/core/config.ts
@@ -14,7 +14,6 @@ export interface PyramidVariantConfig {
     year?: number
     show?: ShowMode
     compare: boolean
-    urlSync: boolean
 }
 
 export function parseConfig(raw: Record<string, string>): PyramidVariantConfig {
@@ -26,6 +25,5 @@ export function parseConfig(raw: Record<string, string>): PyramidVariantConfig {
         year: parseNumber(raw.year),
         show: parseEnum(raw.show, SHOW_MODES),
         compare: parseBoolean(raw.compare),
-        urlSync: parseBoolean(raw.urlSync),
     }
 }

--- a/bespoke/projects/migrant-demographics/src/index.tsx
+++ b/bespoke/projects/migrant-demographics/src/index.tsx
@@ -7,6 +7,8 @@ import type {
 } from "owid-bespoke-types"
 import StylesTarget from "vite-plugin-css-position/react"
 
+import { parseEmbedConfig } from "../../../helpers/config.js"
+
 import { VariantName } from "./core/types.js"
 import { parseConfig } from "./core/config.js"
 import { PyramidVariant } from "./variants/PyramidVariant.js"
@@ -31,7 +33,11 @@ export const mount: BespokeComponentMountFn = (
         return
     }
 
-    const config = parseConfig(opts.config ?? {})
+    const rawConfig = opts.config ?? {}
+    const config = {
+        ...parseConfig(rawConfig),
+        ...parseEmbedConfig(rawConfig),
+    }
 
     const root = createRoot(container)
     root.render(

--- a/bespoke/projects/migrant-demographics/src/variants/PyramidVariant.tsx
+++ b/bespoke/projects/migrant-demographics/src/variants/PyramidVariant.tsx
@@ -14,6 +14,7 @@ import { ChartHeader } from "../../../../components/ChartHeader/ChartHeader.js"
 import { ChartFooter } from "../../../../components/ChartFooter/ChartFooter.js"
 import { Spinner } from "../../../../components/Spinner/Spinner.js"
 import { useUrlState } from "../../../../hooks/useUrlState.js"
+import { EmbedConfigProvider } from "../../../../hooks/useEmbedConfig.js"
 import { useContainerWidth } from "../../../../hooks/useContainerWidth.js"
 import {
     isUserLocationCountry,
@@ -46,21 +47,23 @@ export function PyramidVariant({
     const isNarrow = width > 0 && width < NARROW_BREAKPOINT
 
     return (
-        <NuqsAdapter>
-            <QueryClientProvider client={queryClient}>
-                <div
-                    ref={ref}
-                    className={cx("migrant-pyramid", {
-                        "migrant-pyramid--narrow": isNarrow,
-                    })}
-                >
-                    <FetchingPyramidVariant
-                        config={config}
-                        isNarrow={isNarrow}
-                    />
-                </div>
-            </QueryClientProvider>
-        </NuqsAdapter>
+        <EmbedConfigProvider config={config}>
+            <NuqsAdapter>
+                <QueryClientProvider client={queryClient}>
+                    <div
+                        ref={ref}
+                        className={cx("migrant-pyramid", {
+                            "migrant-pyramid--narrow": isNarrow,
+                        })}
+                    >
+                        <FetchingPyramidVariant
+                            config={config}
+                            isNarrow={isNarrow}
+                        />
+                    </div>
+                </QueryClientProvider>
+            </NuqsAdapter>
+        </EmbedConfigProvider>
     )
 }
 
@@ -71,8 +74,6 @@ function FetchingPyramidVariant({
     config: PyramidVariantConfig
     isNarrow: boolean
 }): React.ReactElement {
-    const urlSync = config.urlSync
-
     const initialCountry =
         !config.country || isUserLocationCountry(config.country)
             ? DEFAULT_COUNTRY
@@ -82,25 +83,21 @@ function FetchingPyramidVariant({
         key: "migrantPyramidCountry",
         parser: parseAsString,
         defaultValue: initialCountry,
-        enabled: urlSync,
     })
     const [year, setYear] = useUrlState({
         key: "migrantPyramidYear",
         parser: parseAsInteger,
         defaultValue: config.year ?? 0, // 0 = latest available year
-        enabled: urlSync,
     })
     const [show, setShow] = useUrlState({
         key: "migrantPyramidShow",
         parser: parseAsStringEnum<ShowMode>(["number", "share"]),
         defaultValue: config.show ?? "number",
-        enabled: urlSync,
     })
     const [compare, setCompare] = useUrlState({
         key: "migrantPyramidCompare",
         parser: parseAsBoolean,
         defaultValue: config.compare,
-        enabled: urlSync,
     })
 
     const { data, status } = useMigrantDemographics()
@@ -112,7 +109,6 @@ function FetchingPyramidVariant({
     const { isResolved: isCountryResolved } = useResolveUserLocation({
         configCountry: config.country,
         availableCountryNames,
-        urlSync,
         urlStateKey: "migrantPyramidCountry",
         setCountry,
     })

--- a/bespoke/projects/migration/src/core/config.ts
+++ b/bespoke/projects/migration/src/core/config.ts
@@ -14,7 +14,6 @@ export interface SankeyVariantConfig {
     sex?: Sex
     year?: number
     flow?: MigrationView
-    urlSync?: boolean
 }
 
 export function parseConfig(raw: Record<string, string>): SankeyVariantConfig {
@@ -27,6 +26,5 @@ export function parseConfig(raw: Record<string, string>): SankeyVariantConfig {
         sex: parseEnum(raw.sex, SEXES),
         year: parseNumber(raw.year),
         flow: parseEnum(raw.flow, MIGRATION_VIEWS),
-        urlSync: parseBoolean(raw.urlSync),
     }
 }

--- a/bespoke/projects/migration/src/index.tsx
+++ b/bespoke/projects/migration/src/index.tsx
@@ -11,6 +11,8 @@ import type {
 } from "owid-bespoke-types"
 import StylesTarget from "vite-plugin-css-position/react"
 
+import { parseEmbedConfig } from "../../../helpers/config.js"
+
 import "./index.scss"
 
 // Enable react-aria's internal Shadow DOM handling paths.
@@ -31,7 +33,11 @@ export const mount: BespokeComponentMountFn = (
         return
     }
 
-    const config = parseConfig(opts.config ?? {})
+    const rawConfig = opts.config ?? {}
+    const config = {
+        ...parseConfig(rawConfig),
+        ...parseEmbedConfig(rawConfig),
+    }
 
     const root = createRoot(container)
     root.render(

--- a/bespoke/projects/migration/src/variants/SankeyVariant.tsx
+++ b/bespoke/projects/migration/src/variants/SankeyVariant.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../../../components/Sankey/SankeyHelpers.js"
 import { MOBILE_BREAKPOINT } from "../../../../components/Sankey/SplitFlowSankey.js"
 import { useUrlState } from "../../../../hooks/useUrlState.js"
+import { EmbedConfigProvider } from "../../../../hooks/useEmbedConfig.js"
 import { useDelayedLoading } from "../../../../hooks/useDelayedLoading.js"
 import { useContainerWidth } from "../../../../hooks/useContainerWidth.js"
 import {
@@ -54,26 +55,26 @@ export function SankeyVariant({
     const isNarrow = width > 0 && width < MOBILE_BREAKPOINT
 
     return (
-        <NuqsAdapter>
-            <QueryClientProvider client={queryClient}>
-                <div
-                    ref={ref}
-                    className={cx("migration-chart", {
-                        "migration-chart--narrow": isNarrow,
-                    })}
-                >
-                    <FetchingSankeyVariant config={config} />
-                </div>
-            </QueryClientProvider>
-        </NuqsAdapter>
+        <EmbedConfigProvider config={config}>
+            <NuqsAdapter>
+                <QueryClientProvider client={queryClient}>
+                    <div
+                        ref={ref}
+                        className={cx("migration-chart", {
+                            "migration-chart--narrow": isNarrow,
+                        })}
+                    >
+                        <FetchingSankeyVariant config={config} />
+                    </div>
+                </QueryClientProvider>
+            </NuqsAdapter>
+        </EmbedConfigProvider>
     )
 }
 
 type Metadata = NonNullable<ReturnType<typeof useMigrationMetadata>["data"]>
 
 function FetchingSankeyVariant({ config }: { config: SankeyVariantConfig }) {
-    const urlSync = config.urlSync ?? false
-
     const initialCountry =
         !config.country || isUserLocationCountry(config.country)
             ? DEFAULT_COUNTRY
@@ -83,19 +84,16 @@ function FetchingSankeyVariant({ config }: { config: SankeyVariantConfig }) {
         key: "migrationCountry",
         parser: parseAsString,
         defaultValue: initialCountry,
-        enabled: urlSync,
     })
     const [year, setYear] = useUrlState({
         key: "migrationYear",
         parser: parseAsInteger,
         defaultValue: config.year ?? 2024,
-        enabled: urlSync,
     })
     const [sex, setSex] = useUrlState({
         key: "migrationSex",
         parser: parseAsStringEnum<Sex>(["both", "female", "male"]),
         defaultValue: config.sex ?? "both",
-        enabled: urlSync,
     })
     const [_view, setView] = useUrlState({
         key: "migrationFlow",
@@ -105,7 +103,6 @@ function FetchingSankeyVariant({ config }: { config: SankeyVariantConfig }) {
             "emigrants",
         ]),
         defaultValue: config.flow ?? DEFAULT_VIEW,
-        enabled: urlSync,
     })
 
     const { data: metadata, status: metadataStatus } = useMigrationMetadata()
@@ -120,7 +117,6 @@ function FetchingSankeyVariant({ config }: { config: SankeyVariantConfig }) {
     const { isResolved: isCountryResolved } = useResolveUserLocation({
         configCountry: config.country,
         availableCountryNames,
-        urlSync,
         urlStateKey: "migrationCountry",
         setCountry,
     })


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @sophiamersmann at the wheel._

`urlSync` says how a page embeds a bespoke component, not anything about the viz itself, but all five projects declared it, parsed it, handed it to every `useUrlState` call and threaded it down their own component trees. A featured viz page turns the flag on, so every project that gets such a page has to carry all of that.

A mount now spreads `parseEmbedConfig` into the config it hands the variant, each project's provider stack gains `EmbedConfigProvider`, and `useUrlState` and `useResolveUserLocation` take the flag from that context. Fifteen `enabled:` arguments go, and demography loses three levels of prop drilling. Nothing changes for readers.

- The embed flags ride in the same object as a project's own config, so no variant grows a second prop. That keeps `config.urlSync` reachable inside a project, but the hooks are what projects should read.
- Two pieces can't land here, because `bespoke-metadata-debug` has unmerged commits in the same files: causes-of-death keeps a dead `urlSync` field in its config, and the `create-bespoke-viz` skill still documents the old "gate behind the `urlSync` flag" contract. Both belong with that stack.