### PR TITLE
Rework the data-download readme

### DIFF
--- a/functions/_common/readmeTools.test.ts
+++ b/functions/_common/readmeTools.test.ts
@@ -1,8 +1,12 @@
+import * as _ from "lodash-es"
 import { expect, it, describe } from "vitest"
 
-import { SynthesizeNonCountryTable } from "@ourworldindata/core-table"
+import {
+    type CoreColumn,
+    SynthesizeNonCountryTable,
+} from "@ourworldindata/core-table"
 import { GrapherState } from "@ourworldindata/grapher"
-import { ColumnTypeNames } from "@ourworldindata/types"
+import { ColumnTypeNames, type OwidColumnDef } from "@ourworldindata/types"
 import { getRandomNumberGenerator } from "@ourworldindata/utils"
 import { constructReadme } from "./readmeTools.js"
 
@@ -64,4 +68,137 @@ describe(constructReadme, () => {
         expect(readme).toContain(attribution)
         expect(readme).toContain(`Source: ${attribution}`)
     })
+
+    it("puts every indicator under the heading that introduces it", () => {
+        // The per-indicator sections are children of "Detailed information ..."; at
+        // the levels they used to use, an indicator was a sibling of that heading and
+        // the second half of the readme had no structure at all.
+        const readme = constructReadme(
+            ...readmeArgs({
+                sourceName: "Test source",
+                descriptionKey: "Only counts utility-scale generation.",
+                descriptionFromProducer: "Compiled from national statistics.",
+                descriptionProcessing: "We convert everything to TWh.",
+            })
+        )
+
+        const headings = readme
+            .split("\n")
+            .filter((line) => /^#{1,6} /.test(line))
+        expect(headings).toEqual([
+            "# Population - Data package",
+            "## CSV structure",
+            "## Metadata.json structure",
+            "## How we process data at Our World in Data",
+            "## Detailed information about the data",
+            "### Population",
+            "#### How to cite this data",
+            "#### What you should know about this data",
+            "#### How this data is described by its producers",
+            "#### Notes on our processing step for this indicator",
+        ])
+    })
+
+    it("drops the full citation and softens the next-update date", () => {
+        // The full citation restated producer names the Sources section now gives in
+        // detail; metadata.json still carries it. The next-update date is our last
+        // update plus the producer's stated period, so it is an expectation.
+        const readme = constructReadme(
+            ...readmeArgs({
+                origins: [
+                    {
+                        producer: "IHME",
+                        title: "Global Burden of Disease",
+                        datePublished: "2020-01-01",
+                        dateAccessed: "2020-06-01",
+                        urlMain: "https://example.org/gbd",
+                    },
+                ],
+                updatePeriodDays: 365,
+            })
+        )
+
+        expect(readme).toContain("Next expected update:")
+        expect(readme).not.toContain("Next update:")
+        expect(readme).not.toContain("#### In-line citation")
+        expect(readme).not.toContain("[original data]")
+        // The attribution sits with the other facts about the indicator, above the
+        // citation rather than trailing it.
+        expect(readme.indexOf("Source: ")).toBeLessThan(
+            readme.indexOf("#### How to cite this data")
+        )
+    })
+
+    it("lists each source once, with what a re-user needs to know about it", () => {
+        // Two indicators drawing on the same origin used to produce two identical
+        // source blocks, each holding only a retrieval date and a URL.
+        const readme = constructReadme(
+            ...readmeArgs(
+                {
+                    origins: [
+                        {
+                            producer: "IHME",
+                            title: "Global Burden of Disease",
+                            description: "Estimates of disease burden.",
+                            datePublished: "2020-01-01",
+                            dateAccessed: "2020-06-01",
+                            urlMain: "https://example.org/gbd",
+                            urlDownload: "https://example.org/gbd.csv",
+                            citationFull: "IHME (2020). GBD.",
+                            license: {
+                                name: "CC BY 4.0",
+                                url: "https://example.org/license",
+                            },
+                        },
+                    ],
+                },
+                2
+            )
+        )
+
+        expect(
+            readme.match(/^### IHME – Global Burden of Disease$/gm)
+        ).toHaveLength(1)
+        expect(readme).toContain("Producer: IHME")
+        expect(readme).toContain("Published: 2020-01-01")
+        expect(readme).toContain("Direct download: https://example.org/gbd.csv")
+        expect(readme).toContain(
+            "License: CC BY 4.0 (https://example.org/license)"
+        )
+        expect(readme).toContain("Citation: IHME (2020). GBD.")
+        // The Sources section is one of the document's own, above the per-indicator
+        // detail rather than repeated inside it.
+        expect(readme.indexOf("## Sources")).toBeLessThan(
+            readme.indexOf("## Detailed information")
+        )
+    })
 })
+
+/**
+ * A GrapherState over `count` synthetic columns sharing `def`, plus the rest of
+ * `constructReadme`'s arguments.
+ */
+function readmeArgs(
+    def: Partial<OwidColumnDef>,
+    count = 1
+): [GrapherState, CoreColumn[], URLSearchParams] {
+    const slugs = _.range(count).map((i) =>
+        i === 0 ? "population" : `population${i}`
+    )
+    const table = SynthesizeNonCountryTable({
+        columnDefs: slugs.map((slug) => ({
+            ...def,
+            slug,
+            type: ColumnTypeNames.Population,
+            name: slug === "population" ? "Population" : `Population ${slug}`,
+            generator: getRandomNumberGenerator(1e7, 1e9),
+            growthRateGenerator: getRandomNumberGenerator(-5, 5),
+        })),
+    })
+    const grapherState = new GrapherState({ table, ySlugs: slugs.join(" ") })
+    return [
+        grapherState,
+        grapherState.tableForDownload.getColumns(slugs),
+        new URLSearchParams(""),
+    ]
+}

--- a/functions/_common/readmeTools.test.ts
+++ b/functions/_common/readmeTools.test.ts
@@ -167,16 +167,13 @@ describe(constructReadme, () => {
         )
         expect(readme).toContain("Citation: IHME (2020). GBD.")
         // One heading for the document, after the indicators, rather than a block
-        // repeated inside each of them. Matched on the exact line because a single
-        // deduplicated source is titled "## Source", not "## Sources".
+        // repeated inside each of them.
         const headings = readme
             .split("\n")
-            .filter((line) =>
-                /^## (Source|Sources|Detailed information)/.test(line)
-            )
+            .filter((line) => /^## (Sources|Detailed information)/.test(line))
         expect(headings).toEqual([
             "## Detailed information about each time series",
-            "## Source",
+            "## Sources",
         ])
     })
 })

--- a/functions/_common/readmeTools.test.ts
+++ b/functions/_common/readmeTools.test.ts
@@ -166,11 +166,18 @@ describe(constructReadme, () => {
             "License: CC BY 4.0 (https://example.org/license)"
         )
         expect(readme).toContain("Citation: IHME (2020). GBD.")
-        // The Sources section is one of the document's own, above the per-indicator
-        // detail rather than repeated inside it.
-        expect(readme.indexOf("## Sources")).toBeLessThan(
-            readme.indexOf("## Detailed information")
-        )
+        // One heading for the document, after the indicators, rather than a block
+        // repeated inside each of them. Matched on the exact line because a single
+        // deduplicated source is titled "## Source", not "## Sources".
+        const headings = readme
+            .split("\n")
+            .filter((line) =>
+                /^## (Source|Sources|Detailed information)/.test(line)
+            )
+        expect(headings).toEqual([
+            "## Detailed information about each time series",
+            "## Source",
+        ])
     })
 })
 

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -14,42 +14,44 @@ import {
     stripDetailOnDemandLinks,
 } from "@ourworldindata/utils"
 import type { CoreColumn } from "@ourworldindata/core-table"
+import type { DisplaySource } from "@ourworldindata/types"
 import { GrapherState } from "@ourworldindata/grapher"
 import { getGrapherFilters } from "./urlTools.js"
 
 const markdownNewlineEnding = "  "
 
+/**
+ * The readme used to print both the short in-line citation and a full one spelling
+ * out every origin. The full one repeats producer names that the document's Sources
+ * section now gives in far more detail, and on a multi-indicator download it was a
+ * fifth of the file, so only the short one is left. Nothing is lost: metadata.json
+ * still carries `citationLong` for every column, and each source's own requested
+ * citation is in the Sources section verbatim.
+ */
 export function* getCitationLines(
     def: OwidColumnDef,
     col: CoreColumn
 ): Generator<string, void, unknown> {
     yield ""
-    yield "### How to cite this data"
+    yield "#### How to cite this data"
     yield ""
-    yield "#### In-line citation"
-    yield (
-        `If you have limited space (e.g. in data visualizations), you can use this abbreviated in-line citation:` +
-            markdownNewlineEnding
-    )
-    const attributionFragments = getAttributionFragments(col)
-    const { short: citationShort, long: citationLong } = getIndicatorCitations({
+    const { short: citationShort } = getIndicatorCitations({
         indicatorTitle: col.titlePublicOrDisplayName,
         origins: def.origins ?? [],
         source: col.source ?? {},
-        attributions: attributionFragments,
+        attributions: getAttributionFragments(col),
         attributionShort: def.presentation?.attributionShort,
         titleVariant: def.presentation?.titleVariant,
         owidProcessingLevel: def.owidProcessingLevel,
     })
-
     yield citationShort
-
-    yield ""
-
-    yield "#### Full citation"
-    yield citationLong
 }
 
+/**
+ * The one heading not pushed a level deeper, because it already was: at `####` among
+ * `###` siblings it read as a child of whatever came last (the final source block).
+ * Now that its siblings are `####` too, it is where it belongs.
+ */
 export function* getDataProcessingLines(
     def: OwidColumnDef
 ): Generator<string, void, unknown> {
@@ -60,26 +62,32 @@ export function* getDataProcessingLines(
     }
 }
 
+/**
+ * The descriptionFromProducer heading used to name the producers. For an indicator
+ * combining several it ran to a full line of names and read as a question about a
+ * list ("How is this data described by its producer - Ember (2026), Energy Institute
+ * (2026), Pinto et al. (2023)?"). The plural heading works for one producer as well
+ * as seven.
+ */
 export function* getDescriptionLines(
-    def: OwidColumnDef,
-    attribution: string
+    def: OwidColumnDef
 ): Generator<string, void, unknown> {
     const descriptionKey = def.descriptionKey
     if (descriptionKey) {
         yield ""
-        yield `### What you should know about this data`
+        yield `#### What you should know about this data`
         yield descriptionKey.trim()
     }
 
     if (def.descriptionFromProducer) {
         yield ""
-        yield `### How is this data described by its producer - ${attribution}?`
+        yield `#### How this data is described by its producers`
         yield def.descriptionFromProducer.trim()
     }
 
     if (def.additionalInfo) {
         yield ""
-        yield `### Additional information about this data`
+        yield `#### Additional information about this data`
         yield def.additionalInfo.trim()
     }
 }
@@ -95,10 +103,12 @@ export function* getKeyDataLines(
                 markdownNewlineEnding
         )
 
+    // "Next expected update", not "Next update": the date is the producer's stated
+    // update period added to our last update, so it is our expectation, not a promise.
     const nextUpdate = getNextUpdateFromVariable(def)
     if (nextUpdate)
         yield (
-            `Next update: ${formatSourceDate(nextUpdate, "MMMM YYYY")}` +
+            `Next expected update: ${formatSourceDate(nextUpdate, "MMMM YYYY")}` +
                 markdownNewlineEnding
         )
 
@@ -123,38 +133,85 @@ export function yieldMultilineTextAsLines(line: string): string[] {
     return line.split("\n").map((l) => l.trim())
 }
 
-export function* getSources(
-    def: OwidColumnDef
+/**
+ * Every distinct source across the columns, in first-seen order.
+ *
+ * Deduplicated on everything that gets rendered rather than on the label alone: the
+ * same producer retrieved twice on different dates is two rows a reader may need, and
+ * collapsing them would quietly drop a retrieval date.
+ */
+export function collectUniqueSources(columns: CoreColumn[]): DisplaySource[] {
+    const sources = columns.flatMap((col) =>
+        prepareSourcesForDisplay(col.def as OwidColumnDef)
+    )
+    return _.uniqBy(sources, (source) =>
+        JSON.stringify([
+            source.label,
+            source.dataPublishedBy,
+            source.retrievedOn,
+            source.retrievedFrom,
+        ])
+    )
+}
+
+/**
+ * The document's Sources section, listing each source once instead of repeating it
+ * inside every indicator's block. Repeating them is bearable for a chart's handful of
+ * columns and unreadable for a complete-dataset download: 46 columns drawn from 7
+ * sources produced 354 blocks, most of the file.
+ *
+ * Listing them once is also what makes room for the detail someone re-using the data
+ * actually needs — what the source is, who published it and when, where to get it
+ * (including the direct file, where the origin records one), the terms it comes under,
+ * and how to cite it — rather than the retrieval date and URL the per-indicator blocks
+ * were limited to.
+ */
+export function* getSourcesSection(
+    columns: CoreColumn[]
 ): Generator<string, void, undefined> {
-    const sourcesForDisplay = _.uniqBy(prepareSourcesForDisplay(def), "label")
+    const sources = collectUniqueSources(columns)
+    if (sources.length === 0) return
 
-    if (sourcesForDisplay.length === 0) return
-    else if (sourcesForDisplay.length === 1) {
-        yield ""
-        yield "### Source"
-    } else {
-        yield ""
-        yield "### Sources"
-    }
+    yield ""
+    yield sources.length === 1 ? "## Source" : "## Sources"
+    yield ""
+    yield "These are the sources behind the data in this package. Each time series below names the ones it draws on in its citation."
 
-    for (const source of sourcesForDisplay) {
+    for (const source of sources) {
         yield ""
-        yield `#### ${source.label}`
-        if (source.dataPublishedBy)
-            yield (
-                `Data published by: ${source.dataPublishedBy.trim()}` +
-                    markdownNewlineEnding
-            )
-        if (source.retrievedOn)
-            yield (
-                `Retrieved on: ${source.retrievedOn.trim()}` +
-                    markdownNewlineEnding
-            )
-        if (source.retrievedFrom)
-            yield (
-                `Retrieved from: ${source.retrievedFrom.trim()}` +
-                    markdownNewlineEnding
-            )
+        yield `### ${source.label}`
+
+        const description = source.description?.trim()
+        if (description) {
+            yield ""
+            yield description
+        }
+
+        const facts = _.compact([
+            source.producer && `Producer: ${source.producer.trim()}`,
+            source.dataPublishedBy &&
+                `Data published by: ${source.dataPublishedBy.trim()}`,
+            source.datePublished && `Published: ${source.datePublished.trim()}`,
+            source.retrievedOn && `Retrieved on: ${source.retrievedOn.trim()}`,
+            source.retrievedFrom &&
+                `Retrieved from: ${source.retrievedFrom.trim()}`,
+            source.urlDownload &&
+                `Direct download: ${source.urlDownload.trim()}`,
+            source.license?.name &&
+                `License: ${source.license.name.trim()}${
+                    source.license.url ? ` (${source.license.url.trim()})` : ""
+                }`,
+        ])
+        if (facts.length > 0) {
+            yield ""
+            for (const fact of facts) yield fact + markdownNewlineEnding
+        }
+
+        const citation = source.citation?.trim()
+        if (citation) {
+            yield ""
+            yield `Citation: ${citation}`
+        }
     }
 }
 
@@ -188,33 +245,36 @@ export function getTitle(col: CoreColumn): string {
     return title
 }
 
+/**
+ * One indicator's section. Every heading sits a level deeper than it used to, because
+ * these sections are children of the document's "Detailed information ..." heading —
+ * at the old levels an indicator was a sibling of the heading introducing it, so the
+ * whole second half of the readme was flat.
+ */
 function* columnReadmeText(col: CoreColumn) {
     const def = col.def as OwidColumnDef
 
     const title = getTitle(col)
     yield ""
-    yield `## ${title}`
+    yield `### ${title}`
 
     yield* getDescription(def)
 
     yield* getKeyDataLines(def, col)
 
-    yield ""
-
-    const attribution = getAttribution(col)
-
+    // The attribution is a fact about the indicator like the ones above, so it goes
+    // with them. It used to print immediately after the full citation, where it read
+    // as a trailing fragment of it; with the full citation gone it would have sat next
+    // to the short one looking like a duplicate.
     const source = getAttributionWithProcessing(
-        attribution,
+        getAttribution(col),
         def.owidProcessingLevel
     )
+    yield `Source: ${source}` + markdownNewlineEnding
 
     yield* getCitationLines(def, col)
 
-    yield `Source: ${source}`
-
-    yield* getDescriptionLines(def, attribution)
-
-    yield* getSources(def)
+    yield* getDescriptionLines(def)
 
     yield* getDataProcessingLines(def)
     yield ""
@@ -244,6 +304,15 @@ function* activeFilterSettings(
     }
 }
 
+/**
+ * The chart's `readme.md`.
+ *
+ * The single- and multi-column readmes used to be two separately maintained template
+ * strings, which is how they came to disagree: only the multi-column one told readers
+ * how we process data. They are one template now, differing where they genuinely
+ * differ — whether a download date is stated, and how the data columns and the
+ * tolerance columns are described.
+ */
 export function constructReadme(
     grapherState: GrapherState,
     columns: CoreColumn[],
@@ -252,12 +321,13 @@ export function constructReadme(
 ): string {
     const isSingleColumn = columns.length === 1
     // Some computed columns have neither a source nor origins - filter these away
-    const sources = columns
-        .filter(
-            (column) => !!column.source.name || !_.isEmpty(column.def.origins)
-        )
-        .flatMap((col) => [...columnReadmeText(col)])
-    let readme: string
+    const columnsWithSources = columns.filter(
+        (column) => !!column.source.name || !_.isEmpty(column.def.origins)
+    )
+    const columnSections = columnsWithSources.flatMap((col) => [
+        ...columnReadmeText(col),
+    ])
+    const sourcesSection = [...getSourcesSection(columnsWithSources)].join("\n")
     const urlWithFilters = `${grapherState.canonicalUrl}`
 
     const downloadDate = formatDate(new Date()) // formats the date as "October 10, 2024"
@@ -270,71 +340,56 @@ export function constructReadme(
         (column) => column.def.derivedFrom?.relationship === "originalTime"
     )
 
-    if (isSingleColumn) {
-        const toleranceExplanation = `\nThe data file includes an additional column suffixed with (Original Year) or (Original Day). This column appears when we use "tolerance" to display data for time points where exact data is unavailable. For example, if a country does not have data for one or more years, we use tolerance to fill the gaps using the closest available data points. These suffix columns show you which year (or day) the value really came from, allowing you to see when the data was actually measured.`
-        readme = `# ${grapherState.effectiveTitle} - Data package
+    // A single-column download is the one served from the chart page itself, so it can
+    // say when it was downloaded; the multi-column one is also built ahead of time.
+    const downloadedOn = isSingleColumn
+        ? ` It was downloaded on ${downloadDate}.`
+        : ""
 
-This data package contains the data that powers the chart ["${grapherState.effectiveTitle}"](${urlWithFilters}) on the Our World in Data website. It was downloaded on ${downloadDate}.
+    const dataColumnBullet = isSingleColumn
+        ? `- The final column is the data column — the time series that powers the chart. Downloaded with the "full data" option it corresponds to the time series below; with "only selected data visible in the chart" it is transformed depending on the chart type, so the correspondence may be less direct.`
+        : `- Every remaining column is a data column, each one a time series. Downloaded with the "full data" option each corresponds to one time series below; with "only selected data visible in the chart" they are transformed depending on the chart type, so the correspondence may be less direct.`
+
+    const toleranceExplanation = isSingleColumn
+        ? `\nThe data file includes an additional column suffixed with (Original Year) or (Original Day). This column appears when we use "tolerance" to display data for time points where exact data is unavailable. For example, if a country does not have data for one or more years, we use tolerance to fill the gaps using the closest available data points. These suffix columns show you which year (or day) the value really came from, allowing you to see when the data was actually measured.`
+        : `\nThe data file includes additional columns suffixed with (Original Year) or (Original Day). These appear when we use "tolerance" to display data for time points where exact data is unavailable. For example, if a country does not have data for one or more years, we use tolerance to fill the gaps using the closest available data points. These suffix columns show you which year (or day) the value really came from, allowing you to see when the data was actually measured.`
+
+    const detailHeading = isSingleColumn
+        ? "Detailed information about the data"
+        : "Detailed information about each time series"
+
+    const readme = `# ${grapherState.effectiveTitle} - Data package
+
+This data package contains the data that powers the chart ["${grapherState.effectiveTitle}"](${urlWithFilters}) on the Our World in Data website.${downloadedOn}
 ${[...activeFilterSettings(searchParams, multiDimAvailableDimensions)].join("\n")}
-## CSV Structure
+## CSV structure
 
-The high level structure of the CSV file is that each row is an observation for an entity (usually a country or region) and a timepoint (usually a year).
+Each row is an observation for an entity (usually a country or region) at a timepoint.
 
-The first two columns in the CSV file are "Entity" and "Code". "Entity" is the name of the entity (e.g. "United States"). "Code" is the OWID internal entity code that we use if the entity is a country or region. For most countries, this is the same as the [iso alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the entity (e.g. "USA") - for non-standard countries like historical countries these are custom codes.
-
-The third column is either "Year" or "Day". If the data is annual, this is "Year" and contains only the year as an integer. If the column is "Day", the column contains a date string in the form "YYYY-MM-DD".
-
-The final column is the data column, which is the time series that powers the chart. If the CSV data is downloaded using the "full data" option, then the column corresponds to the time series below. If the CSV data is downloaded using the "only selected data visible in the chart" option then the data column is transformed depending on the chart type and thus the association with the time series might not be as straightforward.
+- "Entity" — the name of the entity, e.g. "United States".
+- "Code" — our internal entity code. For most countries this is the [ISO alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code, e.g. "USA"; historical and other non-standard entities get a custom code.
+- "Year" or "Day" — the timepoint. Annual data has a "Year" column holding an integer year; otherwise a "Day" column holds a date string in the form "YYYY-MM-DD".
+${dataColumnBullet}
 ${hasOriginalTimeColumn ? toleranceExplanation : ""}
 
 ## Metadata.json structure
 
 The .metadata.json file contains metadata about the data package. The "charts" key contains information to recreate the chart, like the title, subtitle etc.. The "columns" key contains information about each of the columns in the csv, like the unit, timespan covered, citation for the data etc..
 
-## About the data
+## How we process data at Our World in Data
 
 Our World in Data is almost never the original producer of the data - almost all of the data we use has been compiled by others. If you want to re-use data, it is your responsibility to ensure that you adhere to the sources' license and to credit them correctly. Please note that a single time series may have more than one source - e.g. when we stich together data from different time periods by different producers or when we calculate per capita metrics using population data from a second source.
 
-## Detailed information about the data
-
-${sources.join("\n")}
-
-    `
-    } else {
-        const toleranceExplanation = `\nThe data file includes additional columns suffixed with (Original Year) or (Original Day). These appear when we use "tolerance" to display data for time points where exact data is unavailable. For example, if a country does not have data for one or more years, we use tolerance to fill the gaps using the closest available data points. These suffix columns show you which year (or day) the value really came from, allowing you to see when the data was actually measured.`
-        readme = `# ${grapherState.effectiveTitle} - Data package
-
-This data package contains the data that powers the chart ["${grapherState.effectiveTitle}"](${urlWithFilters}) on the Our World in Data website.
-
-## CSV Structure
-
-The high level structure of the CSV file is that each row is an observation for an entity (usually a country or region) and a timepoint (usually a year).
-
-The first two columns in the CSV file are "Entity" and "Code". "Entity" is the name of the entity (e.g. "United States"). "Code" is the OWID internal entity code that we use if the entity is a country or region. For most countries, this is the same as the [iso alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) code of the entity (e.g. "USA") - for non-standard countries like historical countries these are custom codes.
-
-The third column is either "Year" or "Day". If the data is annual, this is "Year" and contains only the year as an integer. If the column is "Day", the column contains a date string in the form "YYYY-MM-DD".
-
-The remaining columns are the data columns, each of which is a time series. If the CSV data is downloaded using the "full data" option, then each column corresponds to one time series below. If the CSV data is downloaded using the "only selected data visible in the chart" option then the data columns are transformed depending on the chart type and thus the association with the time series might not be as straightforward.
-${hasOriginalTimeColumn ? toleranceExplanation : ""}
-
-## Metadata.json structure
-
-The .metadata.json file contains metadata about the data package. The "charts" key contains information to recreate the chart, like the title, subtitle etc.. The "columns" key contains information about each of the columns in the csv, like the unit, timespan covered, citation for the data etc..
-
-## About the data
-
-Our World in Data is almost never the original producer of the data - almost all of the data we use has been compiled by others. If you want to re-use data, it is your responsibility to ensure that you adhere to the sources' license and to credit them correctly. Please note that a single time series may have more than one source - e.g. when we stich together data from different time periods by different producers or when we calculate per capita metrics using population data from a second source.
-
-### How we process data at Our World In Data
 All data and visualizations on Our World in Data rely on data sourced from one or several original data providers. Preparing this original data involves several processing steps. Depending on the data, this can include standardizing country names and world region definitions, converting units, calculating derived indicators such as per capita measures, as well as adding or adapting metadata such as the name or the description given to an indicator.
 [Read about our data pipeline](https://docs.owid.io/projects/etl/)
 
-## Detailed information about each time series
+${sourcesSection}
 
-${sources.join("\n")}
+## ${detailHeading}
+
+${columnSections.join("\n")}
 
     `
-    }
     // Detail-on-demand links (e.g. [terawatt-hours](#dod:watt-hours)) render as
     // hover tooltips on the website, but the readme ships inside a downloaded
     // zip where they're just dead links. Strip them here, over the fully

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -177,7 +177,9 @@ export function* getSourcesSection(
     if (sources.length === 0) return
 
     yield ""
-    yield sources.length === 1 ? "## Source" : "## Sources"
+    // Always plural: the sentence below is written that way, and a section heading
+    // naming a category reads fine over one item, so the branch decided nothing.
+    yield "## Sources"
     yield ""
     yield "These are the sources behind the data in this package. Each time series above names the ones it draws on in its citation."
 
@@ -378,14 +380,14 @@ ${hasOriginalTimeColumn ? toleranceExplanation : ""}
 
 ## Metadata.json structure
 
-The .metadata.json file contains metadata about the data package. The "charts" key contains information to recreate the chart, like the title, subtitle etc.. The "columns" key contains information about each of the columns in the csv, like the unit, timespan covered, citation for the data etc..
+The .metadata.json file contains metadata about the data package. The "charts" key contains information to recreate the chart, like the title, subtitle etc. The "columns" key contains information about each of the columns in the csv, like the unit, timespan covered, citation for the data etc.
 
 ## How we process data at Our World in Data
 
-Our World in Data is almost never the original producer of the data - almost all of the data we use has been compiled by others. If you want to re-use data, it is your responsibility to ensure that you adhere to the sources' license and to credit them correctly. Please note that a single time series may have more than one source - e.g. when we stich together data from different time periods by different producers or when we calculate per capita metrics using population data from a second source.
+Our World in Data is almost never the original producer of the data - almost all of the data we use has been compiled by others. If you want to re-use data, it is your responsibility to ensure that you adhere to the sources' license and to credit them correctly. Please note that a single time series may have more than one source - e.g. when we stitch together data from different time periods by different producers or when we calculate per capita metrics using population data from a second source.
 
-All data and visualizations on Our World in Data rely on data sourced from one or several original data providers. Preparing this original data involves several processing steps. Depending on the data, this can include standardizing country names and world region definitions, converting units, calculating derived indicators such as per capita measures, as well as adding or adapting metadata such as the name or the description given to an indicator.
-[Read about our data pipeline](https://docs.owid.io/projects/etl/)
+Preparing this data involves several processing steps. Depending on the data, this can include standardizing country names and world region definitions, converting units, calculating derived indicators such as per capita measures, as well as adding or adapting metadata such as the name or the description given to an indicator.
+[Read about our data pipeline](https://docs.owid.io/projects/etl/).
 
 ## ${detailHeading}
 

--- a/functions/_common/readmeTools.ts
+++ b/functions/_common/readmeTools.ts
@@ -160,6 +160,10 @@ export function collectUniqueSources(columns: CoreColumn[]): DisplaySource[] {
  * columns and unreadable for a complete-dataset download: 46 columns drawn from 7
  * sources produced 354 blocks, most of the file.
  *
+ * The section sits last, after the indicators: it is reference material a reader
+ * arrives at from a citation, not something to read past on the way to the column they
+ * opened the file for.
+ *
  * Listing them once is also what makes room for the detail someone re-using the data
  * actually needs — what the source is, who published it and when, where to get it
  * (including the direct file, where the origin records one), the terms it comes under,
@@ -175,7 +179,7 @@ export function* getSourcesSection(
     yield ""
     yield sources.length === 1 ? "## Source" : "## Sources"
     yield ""
-    yield "These are the sources behind the data in this package. Each time series below names the ones it draws on in its citation."
+    yield "These are the sources behind the data in this package. Each time series above names the ones it draws on in its citation."
 
     for (const source of sources) {
         yield ""
@@ -383,11 +387,10 @@ Our World in Data is almost never the original producer of the data - almost all
 All data and visualizations on Our World in Data rely on data sourced from one or several original data providers. Preparing this original data involves several processing steps. Depending on the data, this can include standardizing country names and world region definitions, converting units, calculating derived indicators such as per capita measures, as well as adding or adapting metadata such as the name or the description given to an indicator.
 [Read about our data pipeline](https://docs.owid.io/projects/etl/)
 
-${sourcesSection}
-
 ## ${detailHeading}
 
 ${columnSections.join("\n")}
+${sourcesSection}
 
     `
     // Detail-on-demand links (e.g. [terawatt-hours](#dod:watt-hours)) render as

--- a/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
+++ b/packages/@ourworldindata/types/src/gdocTypes/Datapage.ts
@@ -2,6 +2,7 @@ import { OwidOrigin } from "../OwidOrigin.js"
 import { OwidSource } from "../OwidSource.js"
 import {
     IndicatorTitleWithFragments,
+    OwidLicense,
     OwidProcessingLevel,
 } from "../OwidVariable.js"
 import { LicenseOption, RelatedChart } from "../grapherTypes/GrapherTypes.js"
@@ -92,4 +93,10 @@ export interface DisplaySource {
     retrievedOn?: string
     retrievedFrom?: string
     citation?: string
+    // Only the data-download readme reads these; the Sources UIs render the
+    // fields above. They are here so both start from one shape.
+    producer?: string
+    datePublished?: string
+    urlDownload?: string
+    license?: OwidLicense
 }

--- a/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.test.ts
@@ -453,6 +453,7 @@ describe(prepareSourcesForDisplay, () => {
                 retrievedOn: "2024-02-02",
                 retrievedFrom: "https://origin.example.com",
                 citation: "Citation",
+                producer: "Producer",
             },
         ])
     })
@@ -460,7 +461,7 @@ describe(prepareSourcesForDisplay, () => {
     it("labels an origin with its producer only", () => {
         expect(
             prepareSourcesForDisplay({ origins: [{ producer: "Producer" }] })
-        ).toEqual([{ label: "Producer" }])
+        ).toEqual([{ label: "Producer", producer: "Producer" }])
     })
 
     it("does not repeat the producer if the title matches it", () => {
@@ -468,7 +469,7 @@ describe(prepareSourcesForDisplay, () => {
             prepareSourcesForDisplay({
                 origins: [{ producer: "Producer", title: "Producer" }],
             })
-        ).toEqual([{ label: "Producer" }])
+        ).toEqual([{ label: "Producer", producer: "Producer" }])
     })
 
     it("omits the separator when an origin has no producer", () => {
@@ -482,7 +483,41 @@ describe(prepareSourcesForDisplay, () => {
             prepareSourcesForDisplay({
                 origins: [{ producer: "B" }, { producer: "A" }],
             })
-        ).toEqual([{ label: "B" }, { label: "A" }])
+        ).toEqual([
+            { label: "B", producer: "B" },
+            { label: "A", producer: "A" },
+        ])
+    })
+
+    it("carries the fields only the data-download readme renders", () => {
+        // The Sources UIs read the fields above; the readme lists each source once and
+        // has room to say who published it, when, where the file is and on what terms.
+        expect(
+            prepareSourcesForDisplay({
+                origins: [
+                    {
+                        producer: "Producer",
+                        datePublished: "2024-01-01",
+                        urlDownload: "https://example.com/data.csv",
+                        license: {
+                            name: "CC BY 4.0",
+                            url: "https://example.com/license",
+                        },
+                    },
+                ],
+            })
+        ).toEqual([
+            {
+                label: "Producer",
+                producer: "Producer",
+                datePublished: "2024-01-01",
+                urlDownload: "https://example.com/data.csv",
+                license: {
+                    name: "CC BY 4.0",
+                    url: "https://example.com/license",
+                },
+            },
+        ])
     })
 })
 

--- a/packages/@ourworldindata/utils/src/metadataHelpers.ts
+++ b/packages/@ourworldindata/utils/src/metadataHelpers.ts
@@ -168,6 +168,12 @@ const prepareOriginForDisplay = (origin: OwidOrigin): DisplaySource => {
         retrievedOn: origin.dateAccessed,
         retrievedFrom: origin.urlMain,
         citation: origin.citationFull,
+        // Read only by the data-download readme, which lists each source once and
+        // has room to say more about it than the Sources UIs do.
+        producer: origin.producer,
+        datePublished: origin.datePublished,
+        urlDownload: origin.urlDownload,
+        license: origin.license,
     }
 }
 


### PR DESCRIPTION
## 👨 Summary

Rework data download readme following pablo's suggestions. The best way to see what's going on is to check side-by-side comparison [here](https://claude.ai/code/artifact/772f26df-08f3-40cf-8285-277ffd7f434c).

The biggest difference is that we show **much more information in Sources section**. It's at the bottom and could be useful for LLMs, but we can revert it.

I haven't changed `.metadata.json` or added Excel format (created a separate issue from it).


> _Written by Claude Opus 5 — @Marigold at the wheel._

**Before/after review of the readme, rendered:** [https://claude.ai/code/artifact/772f26df-08f3-40cf-8285-277ffd7f434c](https://claude.ai/code/artifact/772f26df-08f3-40cf-8285-277ffd7f434c)

Brings the chart data-download `readme.md` up to the same format as the MDIM complete-dataset package (owid/etl#6769), following [Pablo's review](https://github.com/owid/etl/issues/6668#issuecomment-5397836871). Both files are the same document produced by two codebases; the ETL side has already landed these changes, so this is the half that reaches every chart download.

What a reader sees change:

- **Per-indicator headings sit a level deeper.** An indicator was `##` — a sibling of the `## Detailed information …` that introduces it — so the second half of the readme was flat.
- **The full citation is gone.** It restated producer names the Sources section gives in far more detail; on `per-capita-energy-stacked` it was a fifth of the file. `metadata.json` still carries `citationLong`, and each source's own requested citation is now in the readme verbatim.
- **Sources are listed once for the document, at the end** instead of repeated inside every indicator's block — 24 blocks describing 3 sources on that chart — and each entry now carries producer, publication date, direct download link, license and citation alongside the retrieval date and URL it was limited to. The list sits after the indicators: it is reference material a reader arrives at from a citation, not something to read past on the way to the column they opened the file for.
- **`Source:` moves up** with `Last updated` / `Date range` / `Unit`. It used to print immediately after the full citation, reading as a trailing fragment of it; with the full citation gone it would have sat next to the short one looking like a duplicate.
- **"Next update" → "Next expected update"**, since the date is the producer's stated period added to our last update.
- **"How is this data described by its producer - HYDE (2023); Gapminder (2022); UN WPP (2024); UN FAO (2024)?" → "How this data is described by its producers".**
- **"About the data" → "How we process data at Our World in Data"** — what the section actually says — and the sub-heading of that name inside it is gone.
- **The CSV columns are a bulleted list.**

Net effect on size cuts both ways, and that's expected: a multi-column download shrinks (`per-capita-energy-stacked` 21 kB → 13 kB) because the repetition goes, while a single-column one grows (`population-density` 6 kB → 12 kB) because six sources gain descriptions, licenses and citations they never had.

Worth a look in review: **the two readme templates are merged into one.** They were separately maintained copies of the same text, which is how only the multi-column one came to tell readers how we process data. They now differ only where they genuinely differ — whether a download date is stated, how the data columns are described, and the tolerance-column wording.

<details><summary>Details</summary>

### Files

- `functions/_common/readmeTools.ts`
    - `getCitationLines` — `#### How to cite this data` holding only the short citation; the `#### In-line citation` / `#### Full citation` sub-headings and `citationLong` are dropped.
    - `getDescriptionLines` — `####` headings; the `attribution` parameter is gone with the producer names it fed into the heading.
    - `getKeyDataLines` — "Next expected update".
    - `getSources(def)` (per-indicator) replaced by `collectUniqueSources(columns)` + `getSourcesSection(columns)`, emitted after the per-indicator sections. Dedupe key is `[label, dataPublishedBy, retrievedOn, retrievedFrom]`, not the label alone — the same producer retrieved twice on different dates is two rows a reader may need.
    - `columnReadmeText` — `###` heading, `Source:` moved above the citation, per-indicator sources dropped.
    - `constructReadme` — one template instead of two; `isSingleColumn` now only selects the download-date sentence, the data-column bullet, the tolerance paragraph and the `Detailed information about …` heading.
- `packages/@ourworldindata/utils/src/metadataHelpers.ts` — `prepareOriginForDisplay` passes `producer`, `datePublished`, `urlDownload`, `license` through.
- `packages/@ourworldindata/types/src/gdocTypes/Datapage.ts` — those four as optional fields on `DisplaySource`. The Sources UIs (`IndicatorSources`, `SourcesModal`, `MetadataSection`, `IndicatorMetadataBox`) read named fields, so they ignore them; nothing else consumes the shape.

### Testing

`yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` clean. `yarn test run` — the four `prepareSourcesForDisplay` cases that assert an exact object needed the new `producer` field added to their expectations; the rest of the 2,492 tests pass untouched.

One existing assertion was passing vacuously and is fixed: it searched for `## Sources` in a readme whose single deduplicated source is titled `## Source`, so `indexOf` returned -1 and the ordering check held whatever the order was. It now matches the heading lines.

`functions/_common/readmeTools.test.ts` gains three tests: the full heading list of a single-indicator readme, the dropped full citation plus the softened update date plus the `Source:` ordering, and one source rendered once with every field when two indicators share it. `metadataHelpers.test.ts` gains one for the passed-through fields.

Checked against production rather than only synthetic tables: a throwaway script fed the real `population-density` and `per-capita-energy-stacked` grapher configs through `fetchInputTableForConfig` + `constructReadme`, reproduced today's published `.readme.md` for both **byte for byte** on master, then regenerated them on this branch for a side-by-side diff. The script is not committed.

### Not done

- The Excel variant Pablo suggested (Data / Metadata / Sources / Readme tabs) is on hold until we know whether anyone would use it.
- `metadata.json` stays in the download; we decided against dropping it.

</details>
