### PR TITLE
🐛🤖 stop the admin's css breaking grapher's modals

### DIFF
--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -3,6 +3,11 @@
 @import "../public/fonts.css";
 @import "bootstrap/scss/bootstrap";
 
+// Bare `section` also matches the react-aria dialogs grapher renders inside an
+// embedded chart. `:where` keeps the exclusion at zero specificity, so a page-level
+// `section` rule still wins on source order alone.
+$admin-section: "section:not(:where(.GrapherComponent *))";
+
 @mixin draft-background {
     background: repeating-linear-gradient(
         135deg,
@@ -127,7 +132,7 @@ $nav-height: 45px;
         font-size: 0.8em;
     }
 
-    section {
+    #{$admin-section} {
         h1 {
             font-size: 26px;
             font-weight: 700;
@@ -151,7 +156,7 @@ $nav-height: 45px;
         }
     }
 
-    section:not(:first-child) {
+    #{$admin-section}:not(:first-child) {
         margin-top: 40px;
     }
 }
@@ -363,7 +368,7 @@ $nav-height: 45px;
         }
     }
 
-    section {
+    #{$admin-section} {
         padding: 1.2em;
         border-radius: 0.4em;
         margin-bottom: 1.2em;

--- a/packages/@ourworldindata/grapher/src/modal/Modal.scss
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.scss
@@ -16,17 +16,17 @@
     &[data-entering] {
         opacity: 0;
 
-        .modal-content--top,
-        .modal-content--bottom {
+        .modal-panel--top,
+        .modal-panel--bottom {
             transform: scale(0.97);
         }
 
-        .modal-content--center {
+        .modal-panel--center {
             transform: translateY(-50%) scale(0.97);
         }
     }
 
-    .modal-content {
+    .modal-panel {
         position: absolute;
         border-radius: 4px;
         background: #fff;
@@ -35,20 +35,20 @@
         transition: transform var(--duration-popover) var(--ease-out);
     }
 
-    .modal-content--top {
+    .modal-panel--top {
         transform-origin: center top;
     }
 
-    .modal-content--bottom {
+    .modal-panel--bottom {
         transform-origin: center bottom;
     }
 
-    .modal-content--center {
+    .modal-panel--center {
         top: 50%;
         transform: translateY(-50%);
     }
 
-    .modal-dialog {
+    .modal-panel-dialog {
         height: 100%;
         outline: none;
     }
@@ -56,17 +56,17 @@
     // Drop the panel's scale only. The overlay's opacity transition is what
     // React Aria waits on before unmounting, so it must survive.
     @media (prefers-reduced-motion: reduce) {
-        .modal-content {
+        .modal-panel {
             transition: none;
         }
 
         &[data-entering] {
-            .modal-content--top,
-            .modal-content--bottom {
+            .modal-panel--top,
+            .modal-panel--bottom {
                 transform: none;
             }
 
-            .modal-content--center {
+            .modal-panel--center {
                 transform: translateY(-50%);
             }
         }

--- a/packages/@ourworldindata/grapher/src/modal/Modal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/Modal.tsx
@@ -52,12 +52,15 @@ export function Modal({
             >
                 <AriaModal
                     className={cx(
-                        "modal-content",
-                        `modal-content--${alignVertical}`
+                        "modal-panel",
+                        `modal-panel--${alignVertical}`
                     )}
                     style={contentStyle}
                 >
-                    <Dialog className="modal-dialog" aria-label={ariaLabel}>
+                    <Dialog
+                        className="modal-panel-dialog"
+                        aria-label={ariaLabel}
+                    >
                         {/* Restore the default portal container for nested
                             overlays such as dropdowns. */}
                         <UNSAFE_PortalProvider getContainer={null}>


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Grapher's modals were broken in the chart editor three ways. Dead controls, a grey panel overflowing its frame, and Embed doing nothing at all. Two of them are the modal shell using a name the admin already owns.

- **Class name.** The react-aria rewrite put `modal-dialog` on the `Dialog`, which is bootstrap's own, and the admin imports bootstrap in full. Bootstrap declares `.modal-dialog { pointer-events: none }` and grapher declares no `pointer-events`, so nothing competed and every control in every modal went dead. `.modal-content` collided too. They are now `.modal-panel` and `.modal-panel-dialog`.
- **Element name.** React Aria renders a `Dialog` as a `<section>`, and the admin styles bare `section` as its own form cards, hence the grey background, the padding, and a 40px top margin that pushed `height: 100%` past the panel bottom. Those rules are now scoped to sections outside an embedded grapher.
Worth knowing before you read the diff:

- `:where()` keeps the `section` rules at the specificity they had. `.ImportPage section:not(:first-child)` overrides the `.AdminApp` one on source order alone, and a stronger selector breaks it.
- Cascade layers would not have fixed the class collision, so the CSS boundary work does not make this redundant. Layers decide ties, and there is no tie when only one side declares the property.
- The rendering to look at is [chart 64 in the editor](http://staging-site-modal-classes/admin/charts/64/edit), with Sources, Embed and the country selector each opened.
