### PR TITLE
🐛🤖 Fix map thumbnails returning 500

### DIFF
--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -135,7 +135,14 @@ export const onRequest: PagesFunction<Env> = async (context) => {
                 return redirect || error(404, "Not found")
             } else if (e instanceof StatusError) {
                 return error(e.status, e.message)
-            } else return error(500, e)
+            } else {
+                // TEMPORARY DIAGNOSTIC - do not merge
+                const detail =
+                    e instanceof Error
+                        ? `${e.name}: ${e.message}\n${e.stack}`
+                        : String(e)
+                return error(500, detail)
+            }
         })
 }
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

**Draft — diagnostic only so far, fix to follow on this branch.**

Every map-tab thumbnail render on production returns 500 (`/grapher/<slug>.png`, `.svg`, and the OG/Twitter variants). `?tab=chart` renders fine, so the failure is inside `generateStaticSvg`, before resvg.

Bisected via the Cloudflare preview deployments: the 500 appears on every deployment that contains #7089 and on none that doesn't — including one built later the same evening — so it tracks the code, not a platform change.

It does not reproduce locally: master renders the map fine in node, in local workerd, and in the exact `wrangler pages functions build` bundle (minified, `NODE_ENV=production`) served from workerd against the real R2 config and data API. The route turns the exception into a bare `{"status":500}`, so this branch temporarily puts the message and stack in the response body to read what actually throws on Cloudflare.

The suspicion is the new `useEffect` in `HorizontalNumericColorLegend` / `HorizontalCategoricalColorLegend` — the first hook called inside Grapher's `renderToStaticMarkup` tree, and maps always render one of those legends while most chart types don't. Everything else in #7089 is gated on `interactive`, which is false in a static export.

The diagnostic commit gets dropped before review.
