### PR TITLE
Stop the mobile feedback form being cropped by the browser chrome

### DIFF
--- a/packages/@ourworldindata/components/src/styles/variables.scss
+++ b/packages/@ourworldindata/components/src/styles/variables.scss
@@ -12,9 +12,16 @@ $topic-page-header-margin-bottom: 32px;
 
 :root {
     --grid-gap: 24px;
+    --viewport-height: 100vh;
 
     @media (max-width: 768px) {
         --grid-gap: 16px;
+    }
+}
+
+@supports (height: 100dvh) {
+    :root {
+        --viewport-height: 100dvh;
     }
 }
 

--- a/site/SiteMobileMenu.scss
+++ b/site/SiteMobileMenu.scss
@@ -91,6 +91,8 @@
 .SiteMobileFeedbackModal {
     position: fixed;
     inset: 0;
+    // Keep the modal inside the visible viewport as browser chrome changes.
+    height: var(--viewport-height);
     z-index: $zindex-site-header + 1;
     display: flex;
     align-items: center;
@@ -104,7 +106,7 @@
 
 .SiteMobileFeedbackModal__box {
     position: relative;
-    height: 100vh;
+    height: 100%;
     @include popover-box-styles;
     width: 100vw;
     border-radius: 0;

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -797,8 +797,9 @@ a.ref sup {
 }
 
 .FeedbackForm {
-    height: calc(100vh - 155px);
-    max-height: 700px;
+    display: flex;
+    flex-direction: column;
+    max-height: min(700px, var(--viewport-height));
     transition: opacity var(--duration-panel) var(--ease-out);
 
     &.loading > * {
@@ -922,10 +923,14 @@ a.ref sup {
 
 .FeedbackPage {
     main {
-        height: calc(100vh - 100px);
+        min-height: calc(var(--viewport-height) - $header-height-md);
         display: flex;
         align-items: center;
         justify-content: center;
+
+        @include sm-only {
+            min-height: calc(var(--viewport-height) - $header-height-sm);
+        }
     }
 
     .box {
@@ -936,7 +941,27 @@ a.ref sup {
         outline: 1px solid $gray-10;
     }
 
-    .FeedbackForm > .footer {
+    main .FeedbackForm {
+        max-height: min(
+            700px,
+            calc(
+                var(--viewport-height) - $header-height-md - 2 *
+                    $vertical-spacing
+            )
+        );
+
+        @include sm-only {
+            max-height: min(
+                700px,
+                calc(
+                    var(--viewport-height) - $header-height-sm - 2 *
+                        $vertical-spacing
+                )
+            );
+        }
+    }
+
+    main .FeedbackForm > .footer {
         box-shadow: none;
         outline: 1px solid $gray-10;
     }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @mlbrgl at the wheel._

_raised by @mrwbkrm in https://github.com/owid/owid-grapher/pull/7106#issuecomment-5477257434_

On mobile, the feedback form at the bottom of the burger menu gets cropped: the modal was sized with `100vh`, which on mobile is the _large_ viewport height, so it permanently assumes the browser chrome is retracted. This PR introduces a shared viewport-height variable and makes the feedback modal and the standalone form fit the visible viewport, scrolling the form body when space is limited. This is live on production.

| Before | After |
|--------|--------|
| <img width="436" height="811" alt="the form cropped: header and Send message off-screen" src="https://github.com/user-attachments/assets/66951fc7-9b35-4b33-a184-1952dd2c261c" /> | <img width="468" height="886" alt="the form fitting the visible viewport" src="https://github.com/user-attachments/assets/691c790a-0c06-42a9-bb6d-a24dfc40119d" /> |

### On real devices

The same flow scripted on real hardware (BrowserStack), against production (`100vh`, live) and this branch's preview — burger menu → **Send feedback**, URL bar expanded:

| | Before (production) | After (this branch) |
|---|---|---|
| **iPhone 16 Pro** · Safari 18 | <img width="280" alt="production on iOS: header missing, Send message behind the URL bar" src="https://github.com/user-attachments/assets/61c876b7-31ea-415d-bab5-bb8c9bfa2cbd" /> | <img width="280" alt="this branch on iOS: header and Send message both visible" src="https://github.com/user-attachments/assets/2cda877c-4076-40c8-9f31-9c43bed59c4c" /> |
| | box 760px in a 678px viewport — header at `top: -41`, submit ends at 706 | box 678px = viewport — header at 0, submit ends at 665 |
| **Pixel 9** · Chrome | <img width="280" alt="production on Android: header missing, Send message clipped at the bottom edge" src="https://github.com/user-attachments/assets/7eb93da8-2569-40f0-954e-d9cc05f1cbfc" /> | <img width="280" alt="this branch on Android: header and Send message both visible" src="https://github.com/user-attachments/assets/f602df52-846a-4fed-975c-5dfe5dff30a6" /> |
| | box 869px in a 789px viewport — header at `top: -40`, submit ends at 817 | box 789px = viewport — header at 0, submit ends at 777 |

The overflow is exactly the browser chrome height on each platform (41px on iOS, 40px on Android).

## Testing guidance

On a phone, on the preview linked in owidbot's comment:

1. Open the burger menu → **Send feedback**.
2. Tap the Message field, type something, then dismiss the keyboard.
3. The "Leave us feedback" header and the "Send message" button should both stay visible throughout.

Worth doing on both iOS Safari and Chrome on Android — they handle the URL bar and keyboard differently.

<details><summary>Details</summary>

- Uses `100dvh` where supported, with a `100vh` fallback.
- The on-screen keyboard is deliberately not compensated for: the browser scrolls the focused field into view, which is better than shrinking the form into the strip above the keyboard.
- The device runs above cover the URL-bar geometry only. WebDriver could not tap the textarea, so no on-screen keyboard was ever raised — step 2 above still needs a human hand. They were also captured before the latest commits on this branch.
- Noted while in here, unrelated: while the cookie banner is showing, it overlays the modal's footer and hides "Send message" entirely, on production too.

</details>
