### PR TITLE
🐛🤖 judge a scatter's entity selection by its config, not the timeline handles

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -16,6 +16,8 @@ import {
     TimeInterval,
     StackMode,
     FacetStrategy,
+    GrapherChartType,
+    GrapherTabName,
 } from "@ourworldindata/types"
 import {
     TimeBoundValue,
@@ -2969,6 +2971,14 @@ describe("adjustStateForTab", () => {
         })
     }
 
+    // Mirrors how the UI drives a tab switch: activeTab becomes the destination
+    // while the time handles still sit where the previous tab left them
+    const switchTab = (grapher: GrapherState, tab: GrapherTabName): void => {
+        const previousTab = grapher.activeTab
+        grapher.setTab(tab)
+        grapher.onTabChange(previousTab, tab)
+    }
+
     describe("time handle adjustment", () => {
         it("collapses time range to single time when switching to a single-time tab", () => {
             const grapher = createGrapher()
@@ -2979,7 +2989,7 @@ describe("adjustStateForTab", () => {
                 grapher.endHandleTimeBound
             )
 
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.DiscreteBar)
+            switchTab(grapher, GRAPHER_TAB_NAMES.DiscreteBar)
 
             // A single time is now selected
             expect(grapher.startHandleTimeBound).toBe(
@@ -2993,7 +3003,7 @@ describe("adjustStateForTab", () => {
             // Start with a single time
             grapher.timelineHandleTimeBounds = [2005, 2005]
 
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.LineChart)
+            switchTab(grapher, GRAPHER_TAB_NAMES.LineChart)
 
             // A time range is now selected
             expect(grapher.startHandleTimeBound).not.toBe(
@@ -3013,7 +3023,7 @@ describe("adjustStateForTab", () => {
             grapher.selection.clearSelection()
             grapher.timelineHandleTimeBounds = [2005, 2005]
 
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.LineChart)
+            switchTab(grapher, GRAPHER_TAB_NAMES.LineChart)
 
             expect(grapher.endHandleTimeBound).toBe(2005)
             expect(grapher.startHandleTimeBound).toBe(-Infinity)
@@ -3024,24 +3034,32 @@ describe("adjustStateForTab", () => {
 
             // Already a range — switching to LineChart should be a no-op
             grapher.timelineHandleTimeBounds = [2000, 2010]
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.LineChart)
+            switchTab(grapher, GRAPHER_TAB_NAMES.LineChart)
             expect(grapher.timelineHandleTimeBounds).toEqual([2000, 2010])
 
             // Already single time — switching to DiscreteBar should be a no-op
             grapher.timelineHandleTimeBounds = [2005, 2005]
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.DiscreteBar)
+            switchTab(grapher, GRAPHER_TAB_NAMES.DiscreteBar)
             expect(grapher.timelineHandleTimeBounds).toEqual([2005, 2005])
         })
 
-        it("collapses time range for StackedArea (range-preferred) tabs", () => {
-            const grapher = createGrapher()
+        it("expands a single time for StackedArea, which prefers a range", () => {
+            // The stacked chart types form their own valid combination, so a
+            // fixture mixing them with line and bar drops them from
+            // validChartTypes and never reaches a StackedArea tab
+            const grapher = createGrapher({
+                chartTypes: [
+                    GRAPHER_CHART_TYPES.StackedArea,
+                    GRAPHER_CHART_TYPES.StackedDiscreteBar,
+                ],
+            })
 
             // Start with a single time
             grapher.timelineHandleTimeBounds = [2005, 2005]
 
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.StackedArea)
+            switchTab(grapher, GRAPHER_TAB_NAMES.StackedArea)
 
-            // StackedArea prefers a range, so the single time should be expanded to a range
+            expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.StackedArea)
             expect(grapher.startHandleTimeBound).not.toBe(
                 grapher.endHandleTimeBound
             )
@@ -3049,54 +3067,199 @@ describe("adjustStateForTab", () => {
     })
 
     describe("entity selection adjustment", () => {
-        it("clears selection for all-entity chart type when selection matches authored", () => {
-            const grapher = createGrapher({
-                xSlug: SampleColumnSlugs.GDP,
-                chartTypes: [
-                    GRAPHER_CHART_TYPES.LineChart,
-                    GRAPHER_CHART_TYPES.ScatterPlot,
-                ],
+        const createGrapherWithSecondaryScatter = (
+            primaryChartType: GrapherChartType
+        ): GrapherState =>
+            createGrapher({
+                xSlug: SampleColumnSlugs.Population,
+                chartTypes: [primaryChartType, GRAPHER_CHART_TYPES.ScatterPlot],
             })
 
-            expect(grapher.selection.hasSelection).toBe(true)
+        // Mirrors a fresh load of ?tab=scatter&country=, which runs no adjustment
+        const loadOnScatterTab = (grapher: GrapherState): void => {
+            grapher.populateFromQueryParams({ tab: "scatter", country: "" })
+        }
 
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.ScatterPlot)
+        const swapMdimView = (
+            grapher: GrapherState,
+            view: GrapherProgrammaticInterface
+        ): void => {
+            // Mirrors how MultiDim swaps a view in: replace the authored config
+            // on the live state, then adjust once the table is in place
+            grapher.setAuthoredVersion(view)
+            grapher.reset()
+            grapher.updateFromObject(view)
+            grapher.inputTable = view.table!
+            grapher.adjustStateForTab(grapher.activeTab)
+        }
 
-            expect(grapher.selection.hasSelection).toBe(false)
+        it.each([
+            GRAPHER_CHART_TYPES.LineChart,
+            GRAPHER_CHART_TYPES.SlopeChart,
+            GRAPHER_CHART_TYPES.DiscreteBar,
+        ])(
+            "clears a secondary scatter's selection after a round trip via %s",
+            (primaryChartType) => {
+                const grapher =
+                    createGrapherWithSecondaryScatter(primaryChartType)
+                loadOnScatterTab(grapher)
+                expect(grapher.selection.hasSelection).toBe(false)
+
+                switchTab(grapher, primaryChartType)
+                expect(grapher.selection.hasSelection).toBe(true)
+
+                switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
+                expect(grapher.selection.selectedEntityNames).toEqual([])
+                expect(grapher.queryStr).toContain("country=")
+            }
+        )
+
+        it("clears a secondary scatter's selection in relative mode", () => {
+            const grapher = createGrapherWithSecondaryScatter(
+                GRAPHER_CHART_TYPES.LineChart
+            )
+            loadOnScatterTab(grapher)
+            grapher.stackMode = StackMode.relative
+            expect(grapher.isRelativeMode).toBe(true)
+
+            switchTab(grapher, GRAPHER_TAB_NAMES.LineChart)
+            switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
+
+            expect(grapher.selection.selectedEntityNames).toEqual([])
         })
 
-        it("preserves selection for all-entity chart types when user changed it", () => {
-            const grapher = createGrapher({
-                xSlug: SampleColumnSlugs.GDP,
-                chartTypes: [
-                    GRAPHER_CHART_TYPES.LineChart,
-                    GRAPHER_CHART_TYPES.ScatterPlot,
-                ],
-            })
-
-            // Simulate user changing the selection away from authored
+        it("keeps a secondary scatter's selection when the user changed it", () => {
+            const grapher = createGrapherWithSecondaryScatter(
+                GRAPHER_CHART_TYPES.LineChart
+            )
             grapher.selection.deselectEntity(
                 grapher.selection.selectedEntityNames[0]
             )
             expect(grapher.areSelectedEntitiesDifferentThanAuthors).toBe(true)
+            const userSelection = grapher.selection.selectedEntityNames
 
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.ScatterPlot)
+            switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
 
-            expect(grapher.selection.hasSelection).toBe(true)
+            expect(grapher.selection.selectedEntityNames).toEqual(userSelection)
         })
 
-        it("restores authored selection when selection is empty", () => {
+        it.each([
+            { label: "time range", minTime: 2000, maxTime: 2010 },
+            { label: "single time", minTime: 2010, maxTime: 2010 },
+        ])(
+            "keeps the authored selection and time handles of a scatter-only chart ($label)",
+            ({ minTime, maxTime }) => {
+                const grapher = createGrapher({
+                    xSlug: SampleColumnSlugs.Population,
+                    chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
+                    minTime,
+                    maxTime,
+                })
+                const authoredSelection = grapher.selection.selectedEntityNames
+                const authoredHandles = [...grapher.timelineHandleTimeBounds]
+
+                switchTab(grapher, GRAPHER_TAB_NAMES.Table)
+                switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
+
+                expect(grapher.selection.selectedEntityNames).toEqual(
+                    authoredSelection
+                )
+                expect(grapher.timelineHandleTimeBounds).toEqual(
+                    authoredHandles
+                )
+            }
+        )
+
+        // A time scatter has no x dimension, so it draws a line per entity and
+        // plotting every one of them is unreadable
+        it("keeps a time scatter's selection when it is the only chart type", () => {
             const grapher = createGrapher({
-                chartTypes: [GRAPHER_CHART_TYPES.LineChart],
+                chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
             })
             const authoredSelection = grapher.selection.selectedEntityNames
 
-            // Clear selection
-            grapher.selection.clearSelection()
+            switchTab(grapher, GRAPHER_TAB_NAMES.Table)
+            switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
+
+            expect(grapher.selection.selectedEntityNames).toEqual(
+                authoredSelection
+            )
+        })
+
+        it("keeps a secondary time scatter's selection", () => {
+            const grapher = createGrapher({
+                chartTypes: [
+                    GRAPHER_CHART_TYPES.LineChart,
+                    GRAPHER_CHART_TYPES.ScatterPlot,
+                ],
+            })
+            const authoredSelection = grapher.selection.selectedEntityNames
+            loadOnScatterTab(grapher)
+
+            switchTab(grapher, GRAPHER_TAB_NAMES.LineChart)
+            switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
+
+            expect(grapher.selection.selectedEntityNames).toEqual(
+                authoredSelection
+            )
+        })
+
+        it("keeps the authored selection of an mdim's scatter view", () => {
+            const table = SynthesizeGDPTable({
+                entityCount: 3,
+                timeRange: [2000, 2010],
+            })
+            const authoredSelection = table.availableEntityNames.slice(0, 2)
+            const lineView = {
+                table,
+                ySlugs: SampleColumnSlugs.GDP,
+                selectedEntityNames: authoredSelection,
+                chartTypes: [GRAPHER_CHART_TYPES.LineChart],
+            }
+            const grapher = new GrapherState(lineView)
+
+            swapMdimView(grapher, {
+                ...lineView,
+                xSlug: SampleColumnSlugs.Population,
+                chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
+                minTime: 2010,
+                maxTime: 2010,
+            })
+
+            expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.ScatterPlot)
+            expect(grapher.selection.selectedEntityNames).toEqual(
+                authoredSelection
+            )
+        })
+
+        it("re-applies the authored selection when an mdim leaves a Marimekko view", () => {
+            const table = SynthesizeGDPTable({
+                entityCount: 3,
+                timeRange: [2000, 2010],
+            })
+            const authoredSelection = table.availableEntityNames.slice(0, 2)
+            const grapher = new GrapherState({
+                table,
+                ySlugs: SampleColumnSlugs.GDP,
+                xSlug: SampleColumnSlugs.Population,
+                selectedEntityNames: authoredSelection,
+                chartTypes: [
+                    GRAPHER_CHART_TYPES.LineChart,
+                    GRAPHER_CHART_TYPES.Marimekko,
+                ],
+            })
+            grapher.populateFromQueryParams({ tab: "marimekko", country: "" })
+            expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.Marimekko)
             expect(grapher.selection.hasSelection).toBe(false)
 
-            grapher.adjustStateForTab(GRAPHER_TAB_NAMES.LineChart)
+            swapMdimView(grapher, {
+                table,
+                ySlugs: SampleColumnSlugs.GDP,
+                selectedEntityNames: authoredSelection,
+                chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
+            })
 
+            expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.StackedArea)
             expect(grapher.selection.selectedEntityNames).toEqual(
                 authoredSelection
             )

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -2971,8 +2971,6 @@ describe("adjustStateForTab", () => {
         })
     }
 
-    // Mirrors how the UI drives a tab switch: activeTab becomes the destination
-    // while the time handles still sit where the previous tab left them
     const switchTab = (grapher: GrapherState, tab: GrapherTabName): void => {
         const previousTab = grapher.activeTab
         grapher.setTab(tab)
@@ -3044,9 +3042,6 @@ describe("adjustStateForTab", () => {
         })
 
         it("expands a single time for StackedArea, which prefers a range", () => {
-            // The stacked chart types form their own valid combination, so a
-            // fixture mixing them with line and bar drops them from
-            // validChartTypes and never reaches a StackedArea tab
             const grapher = createGrapher({
                 chartTypes: [
                     GRAPHER_CHART_TYPES.StackedArea,
@@ -3075,24 +3070,6 @@ describe("adjustStateForTab", () => {
                 chartTypes: [primaryChartType, GRAPHER_CHART_TYPES.ScatterPlot],
             })
 
-        // Mirrors a fresh load of ?tab=scatter&country=, which runs no adjustment
-        const loadOnScatterTab = (grapher: GrapherState): void => {
-            grapher.populateFromQueryParams({ tab: "scatter", country: "" })
-        }
-
-        const swapMdimView = (
-            grapher: GrapherState,
-            view: GrapherProgrammaticInterface
-        ): void => {
-            // Mirrors how MultiDim swaps a view in: replace the authored config
-            // on the live state, then adjust once the table is in place
-            grapher.setAuthoredVersion(view)
-            grapher.reset()
-            grapher.updateFromObject(view)
-            grapher.inputTable = view.table!
-            grapher.adjustStateForTab(grapher.activeTab)
-        }
-
         it.each([
             GRAPHER_CHART_TYPES.LineChart,
             GRAPHER_CHART_TYPES.SlopeChart,
@@ -3102,7 +3079,7 @@ describe("adjustStateForTab", () => {
             (primaryChartType) => {
                 const grapher =
                     createGrapherWithSecondaryScatter(primaryChartType)
-                loadOnScatterTab(grapher)
+                grapher.populateFromQueryParams({ tab: "scatter", country: "" })
                 expect(grapher.selection.hasSelection).toBe(false)
 
                 switchTab(grapher, primaryChartType)
@@ -3118,7 +3095,7 @@ describe("adjustStateForTab", () => {
             const grapher = createGrapherWithSecondaryScatter(
                 GRAPHER_CHART_TYPES.LineChart
             )
-            loadOnScatterTab(grapher)
+            grapher.populateFromQueryParams({ tab: "scatter", country: "" })
             grapher.stackMode = StackMode.relative
             expect(grapher.isRelativeMode).toBe(true)
 
@@ -3143,35 +3120,44 @@ describe("adjustStateForTab", () => {
             expect(grapher.selection.selectedEntityNames).toEqual(userSelection)
         })
 
-        it.each([
-            { label: "time range", minTime: 2000, maxTime: 2010 },
-            { label: "single time", minTime: 2010, maxTime: 2010 },
-        ])(
-            "keeps the authored selection and time handles of a scatter-only chart ($label)",
-            ({ minTime, maxTime }) => {
-                const grapher = createGrapher({
-                    xSlug: SampleColumnSlugs.Population,
-                    chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
-                    minTime,
-                    maxTime,
-                })
-                const authoredSelection = grapher.selection.selectedEntityNames
-                const authoredHandles = [...grapher.timelineHandleTimeBounds]
+        it("keeps the authored selection and time range of a scatter-only chart", () => {
+            const grapher = createGrapher({
+                xSlug: SampleColumnSlugs.Population,
+                chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
+                minTime: 2000,
+                maxTime: 2010,
+            })
+            const authoredSelection = grapher.selection.selectedEntityNames
+            const authoredHandles = [...grapher.timelineHandleTimeBounds]
 
-                switchTab(grapher, GRAPHER_TAB_NAMES.Table)
-                switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
+            switchTab(grapher, GRAPHER_TAB_NAMES.Table)
+            switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
 
-                expect(grapher.selection.selectedEntityNames).toEqual(
-                    authoredSelection
-                )
-                expect(grapher.timelineHandleTimeBounds).toEqual(
-                    authoredHandles
-                )
-            }
-        )
+            expect(grapher.selection.selectedEntityNames).toEqual(
+                authoredSelection
+            )
+            expect(grapher.timelineHandleTimeBounds).toEqual(authoredHandles)
+        })
 
-        // A time scatter has no x dimension, so it draws a line per entity and
-        // plotting every one of them is unreadable
+        it("keeps the authored selection and single time of a scatter-only chart", () => {
+            const grapher = createGrapher({
+                xSlug: SampleColumnSlugs.Population,
+                chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
+                minTime: 2010,
+                maxTime: 2010,
+            })
+            const authoredSelection = grapher.selection.selectedEntityNames
+            const authoredHandles = [...grapher.timelineHandleTimeBounds]
+
+            switchTab(grapher, GRAPHER_TAB_NAMES.Table)
+            switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
+
+            expect(grapher.selection.selectedEntityNames).toEqual(
+                authoredSelection
+            )
+            expect(grapher.timelineHandleTimeBounds).toEqual(authoredHandles)
+        })
+
         it("keeps a time scatter's selection when it is the only chart type", () => {
             const grapher = createGrapher({
                 chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
@@ -3194,72 +3180,11 @@ describe("adjustStateForTab", () => {
                 ],
             })
             const authoredSelection = grapher.selection.selectedEntityNames
-            loadOnScatterTab(grapher)
+            grapher.populateFromQueryParams({ tab: "scatter", country: "" })
 
             switchTab(grapher, GRAPHER_TAB_NAMES.LineChart)
             switchTab(grapher, GRAPHER_TAB_NAMES.ScatterPlot)
 
-            expect(grapher.selection.selectedEntityNames).toEqual(
-                authoredSelection
-            )
-        })
-
-        it("keeps the authored selection of an mdim's scatter view", () => {
-            const table = SynthesizeGDPTable({
-                entityCount: 3,
-                timeRange: [2000, 2010],
-            })
-            const authoredSelection = table.availableEntityNames.slice(0, 2)
-            const lineView = {
-                table,
-                ySlugs: SampleColumnSlugs.GDP,
-                selectedEntityNames: authoredSelection,
-                chartTypes: [GRAPHER_CHART_TYPES.LineChart],
-            }
-            const grapher = new GrapherState(lineView)
-
-            swapMdimView(grapher, {
-                ...lineView,
-                xSlug: SampleColumnSlugs.Population,
-                chartTypes: [GRAPHER_CHART_TYPES.ScatterPlot],
-                minTime: 2010,
-                maxTime: 2010,
-            })
-
-            expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.ScatterPlot)
-            expect(grapher.selection.selectedEntityNames).toEqual(
-                authoredSelection
-            )
-        })
-
-        it("re-applies the authored selection when an mdim leaves a Marimekko view", () => {
-            const table = SynthesizeGDPTable({
-                entityCount: 3,
-                timeRange: [2000, 2010],
-            })
-            const authoredSelection = table.availableEntityNames.slice(0, 2)
-            const grapher = new GrapherState({
-                table,
-                ySlugs: SampleColumnSlugs.GDP,
-                xSlug: SampleColumnSlugs.Population,
-                selectedEntityNames: authoredSelection,
-                chartTypes: [
-                    GRAPHER_CHART_TYPES.LineChart,
-                    GRAPHER_CHART_TYPES.Marimekko,
-                ],
-            })
-            grapher.populateFromQueryParams({ tab: "marimekko", country: "" })
-            expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.Marimekko)
-            expect(grapher.selection.hasSelection).toBe(false)
-
-            swapMdimView(grapher, {
-                table,
-                ySlugs: SampleColumnSlugs.GDP,
-                selectedEntityNames: authoredSelection,
-                chartTypes: [GRAPHER_CHART_TYPES.StackedArea],
-            })
-
-            expect(grapher.activeTab).toEqual(GRAPHER_TAB_NAMES.StackedArea)
             expect(grapher.selection.selectedEntityNames).toEqual(
                 authoredSelection
             )

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -2051,8 +2051,9 @@ export class GrapherState
         // No-op if the current tab is a map or table tab
         if (!isChartTab(tab)) return
 
-        // Don't modify the selection for unusual scatters
-        if (this.isOnTimeScatterTab || this.isOnConnectedScatterTab) return
+        // Don't modify the selection for time scatters or primary scatter plots
+        if (this.isOnTimeScatterTab || (this.isOnScatterTab && this.isScatter))
+            return
 
         const isChartTypeThatShowsAllEntities =
             this.isChartTypeThatShowsAllEntities(tab)
@@ -2075,10 +2076,16 @@ export class GrapherState
         }
     }
 
+    /** Call after `setTab`, so that `activeTab` is already the given tab */
     @action.bound adjustStateForTab(tab: GrapherTabName): void {
         if (!this.isReady)
             console.warn(
                 "adjustStateForTab has been called before grapher has loaded its data, this is probably a mistake"
+            )
+
+        if (tab !== this.activeTab)
+            console.warn(
+                `adjustStateForTab has been called with ${tab} while the active tab is ${this.activeTab}; call setTab first, since the adjustments read the active tab`
             )
 
         // Skip in the editor: these adjustments mutate the entity selection


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Coming back to a chart's scatter tab from its line or slope tab painted every point the inactive grey and dropped `country=` from the URL. `ensureEntitySelectionIsSensibleForTab` decided whether to leave the selection alone by looking at where the timeline handles were, and it runs one statement before those handles are adjusted, so on the way back into the scatter they were still where the line tab left them and the chart read as a connected scatter. It asks the config instead: a scatter keeps its selection when it is the chart's own chart type, or when it plots time on the x-axis and every entity would be drawn as a line.

- **Fix.** All 20 charts with a scatter as a secondary tab, which is the reported bug. Closes #7012.
- **Fix.** A chart whose only chart type is a scatter, authored at a single time, lost its authored selection on a map or table round trip. Codex raised this on #6319 and it went unanswered.
- **Fix.** Switching an mdim into a scatter view wiped that view's authored selection, a regression from 2fa9973f38, the commit whose own purpose was to fix mdim view switching.
- **Behaviour change.** A secondary scatter in relative mode now clears its selection like any other secondary scatter. #6555 spread its handles on the grounds that a scatter in relative mode is a connected scatter, and that is what put it under this guard. Relative mode changes what is plotted, not who owns the entity selection.
- A chart whose only chart type is a Marimekko loses its authored selection the same way. The guard has never mentioned Marimekko, so that is a separate call and I have left it alone.
- The grey itself comes from `ScatterPointsWithLabels`, which backgrounds every point when a non-empty focus set matches nothing in the chart. That clause is deliberate, so this removes the trigger and not the amplifier.

### The selection should be cleared, and the points should keep their colours

- [slope and scatter](http://staging-site-scatter-tab-selection/grapher/maternal-mortality-slope-chart?tab=scatter&yScale=log&time=latest&country=), clicking Slope then Scatter
- [line, bar and scatter](http://staging-site-scatter-tab-selection/grapher/share-of-the-population-without-access-to-clean-fuels-for-cooking?tab=scatter&time=latest&country=), clicking Line then Scatter. Bar and back is the control that was always fine

### Nothing should change

- [scatter only, single time, 7 selected](http://staging-site-scatter-tab-selection/admin/charts/8592/preview), clicking Map then Chart. Unpublished, so it has no baked page
- [scatter only, time range, 10 selected](http://staging-site-scatter-tab-selection/grapher/covid-vaccinations-vs-covid-death-rate), clicking Table then Chart
- [scatter only, time range, 1 selected](http://staging-site-scatter-tab-selection/grapher/solar-pv-prices-vs-cumulative-capacity), the chart #6319 added this guard to protect
- [time scatter, 12 selected](http://staging-site-scatter-tab-selection/grapher/ai-frontiermath-over-time), no x dimension, so time is on the x-axis
- [an mdim leaving a Marimekko view](http://staging-site-scatter-tab-selection/grapher/incomes-across-distribution-wb?tab=marimekko&time=2023&country=&indicator=share&decile=_1&period=nan&survey_comparability=no_spells), switching Decile to "All deciles". The tab has to change and the empty selection has to refill from the author's, which is the other half of this function and the bug 2fa9973f38 set out to fix
- [the search thumbnail for `solar price`](http://staging-site-scatter-tab-selection/search?q=solar+price), a line of points rather than a single dot. Needs the `staging-algolia` label to resolve, which this PR carries

No published mdim has a scatter view, so there is no link for the mdim scatter case.

The mdim, the solar chart and the search thumbnail are #6319's own checklist, since this changes the guard that PR added. The thumbnail is the weakest of the three: `configureGrapherStateTab` calls only `ensureTimeHandlesAreSensibleForTab` and sets the selection explicitly, and `adjustStateForTab` has no caller under `functions/`, `baker/` or `devTools/`, so nothing that renders a chart image reaches the function this changes.


