### PR TITLE
Edit gdoc tags from the preview settings drawer

### DIFF
--- a/adminSiteClient/EditableTags.tsx
+++ b/adminSiteClient/EditableTags.tsx
@@ -153,6 +153,7 @@ export function EditableTags(props: EditableTagsProps): React.ReactElement {
                     <>
                         {hasSuggestionsSupport && (
                             <button
+                                type="button"
                                 className="btn btn-link EditableTags__action"
                                 onClick={handleSuggest}
                                 disabled={
@@ -164,6 +165,7 @@ export function EditableTags(props: EditableTagsProps): React.ReactElement {
                             </button>
                         )}
                         <button
+                            type="button"
                             className="btn btn-link EditableTags__action"
                             onClick={(event) => {
                                 setInitialEditorTags(tags)

--- a/adminSiteClient/GdocsIndexRow.tsx
+++ b/adminSiteClient/GdocsIndexRow.tsx
@@ -23,7 +23,7 @@ import {
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { EditableTags } from "./EditableTags.js"
 import { GdocsEditLink } from "./GdocsEditLink.js"
-import { checkCanTagGdocType } from "./GdocsTags.js"
+import { checkCanTagGdocType } from "./gdocsTagging.js"
 import { Link } from "./Link.js"
 
 const iconGdocTypeMap = {

--- a/adminSiteClient/GdocsIndexRow.tsx
+++ b/adminSiteClient/GdocsIndexRow.tsx
@@ -23,6 +23,7 @@ import {
 import { BAKED_BASE_URL } from "../settings/clientSettings.js"
 import { EditableTags } from "./EditableTags.js"
 import { GdocsEditLink } from "./GdocsEditLink.js"
+import { checkCanTagGdocType } from "./GdocsTags.js"
 import { Link } from "./Link.js"
 
 const iconGdocTypeMap = {
@@ -39,15 +40,7 @@ const iconGdocTypeMap = {
 }
 
 function canTagGdoc(gdoc: OwidGdocIndexItem): boolean {
-    return (
-        !!gdoc.type &&
-        ![
-            OwidGdocType.AboutPage,
-            OwidGdocType.Author,
-            OwidGdocType.Fragment,
-            OwidGdocType.Homepage,
-        ].includes(gdoc.type)
-    )
+    return checkCanTagGdocType(gdoc.type)
 }
 
 function isGdocScheduled(gdoc: OwidGdocIndexItem, now: number): boolean {

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -171,7 +171,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
             try {
                 admin.loadingIndicatorSetting = "loading"
                 const [original, current] = await Promise.all([
-                    originalGdoc ?? fetchGdoc(GdocsContentSource.Internal),
+                    fetchGdoc(GdocsContentSource.Internal),
                     fetchGdoc(GdocsContentSource.Gdocs, acceptSuggestions),
                 ])
                 if (!isMounted || !original || !current) return
@@ -207,7 +207,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
             isMounted = false
             admin.loadingIndicatorSetting = "default"
         }
-    }, [admin, acceptSuggestions, fetchGdoc, handleError, originalGdoc])
+    }, [admin, acceptSuggestions, fetchGdoc, handleError])
 
     const isLightningUpdate = useLightningUpdate(
         originalGdoc,

--- a/adminSiteClient/GdocsPreviewPage.tsx
+++ b/adminSiteClient/GdocsPreviewPage.tsx
@@ -20,6 +20,7 @@ import {
     OwidGdocErrorMessage,
     OwidGdocErrorMessageType,
     slugify,
+    MinimalTag,
     OwidGdocType,
     OwidGdoc,
     Tippy,
@@ -43,6 +44,7 @@ import {
 import { getErrors } from "./gdocsValidation.js"
 import { GdocsSaveButtons } from "./GdocsSaveButtons.js"
 import { deleteGdoc, updateGdoc } from "./gdocsApi.js"
+import { useUpdateGdocTags } from "./gdocsQueries.js"
 import { IconBadge } from "./IconBadge.js"
 import { GdocsMoreMenu } from "./GdocsMoreMenu.js"
 import { GdocsEditLink } from "./GdocsEditLink.js"
@@ -267,6 +269,18 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
         history.push("/gdocs")
     }
 
+    const updateTagsMutation = useUpdateGdocTags()
+
+    // Tags are saved to the database immediately, so update both the original
+    // and current gdoc to avoid reporting phantom unsaved changes
+    const saveTags = async (tags: MinimalTag[]) => {
+        await updateTagsMutation.mutateAsync({ gdocId: id, tags })
+        setGdoc(({ original, current }) => ({
+            original: original && { ...original, tags },
+            current: current && { ...current, tags },
+        }))
+    }
+
     const toggleMobilePreview = () =>
         setIsMobilePreviewActive(
             (isMobilePreviewActive) => !isMobilePreviewActive
@@ -465,6 +479,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                         setCurrentGdoc(() => updatedGdoc)
                                     }
                                     errors={errors}
+                                    onSaveTags={saveTags}
                                 />
                             )
                         )
@@ -481,6 +496,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                         setCurrentGdoc(() => updatedGdoc)
                                     }
                                     errors={errors}
+                                    onSaveTags={saveTags}
                                 />
                             )
                         )
@@ -497,6 +513,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                         setCurrentGdoc(() => updatedGdoc)
                                     }
                                     errors={errors}
+                                    onSaveTags={saveTags}
                                 />
                             )
                         )
@@ -558,6 +575,7 @@ export const GdocsPreviewPage = ({ match, history }: GdocsMatchProps) => {
                                         setCurrentGdoc(() => updatedGdoc)
                                     }
                                     errors={errors}
+                                    onSaveTags={saveTags}
                                     selectedEntity={selectedEntity}
                                     setSelectedEntity={setSelectedEntity}
                                     entitiesInScope={entitiesInScope}

--- a/adminSiteClient/GdocsSettingsForms.tsx
+++ b/adminSiteClient/GdocsSettingsForms.tsx
@@ -1,5 +1,6 @@
 import { type Dispatch, type SetStateAction } from "react"
 import {
+    MinimalTag,
     OwidGdocPostInterface,
     OwidGdocErrorMessage,
     OwidGdocDataInsightInterface,
@@ -20,6 +21,9 @@ import {
 import { GdocsPublishedAt } from "./GdocsDateline.js"
 import { GdocsPublicationContext } from "./GdocsPublicationContext.js"
 import { GdocsManualBreadcrumbsInput } from "./GdocsManualBreadcrumbsInput.js"
+import { GdocsTags } from "./GdocsTags.js"
+
+type SaveTags = (tags: MinimalTag[]) => Promise<void>
 
 const GdocCommonErrors = ({
     errors,
@@ -91,10 +95,12 @@ export const GdocPostSettings = ({
     gdoc,
     setCurrentGdoc,
     errors,
+    onSaveTags,
 }: {
     gdoc: OwidGdocPostInterface
     setCurrentGdoc: (gdoc: OwidGdocPostInterface) => void
     errors?: OwidGdocErrorMessage[]
+    onSaveTags: SaveTags
 }) => {
     if (!gdoc || !errors) return null
     return (
@@ -114,6 +120,7 @@ export const GdocPostSettings = ({
                 setCurrentGdoc={setCurrentGdoc}
                 errors={errors}
             />
+            <GdocsTags gdoc={gdoc} onSaveTags={onSaveTags} />
             <div className="form-group">
                 <h3 className="form-section-heading">Post settings</h3>
                 <GdocsSettingsContentField
@@ -176,10 +183,12 @@ export const GdocInsightSettings = ({
     gdoc,
     setCurrentGdoc,
     errors,
+    onSaveTags,
 }: {
     gdoc: OwidGdocDataInsightInterface
     setCurrentGdoc: (gdoc: OwidGdocDataInsightInterface) => void
     errors?: OwidGdocErrorMessage[]
+    onSaveTags: SaveTags
 }) => {
     if (!gdoc || !errors) return null
 
@@ -195,6 +204,7 @@ export const GdocInsightSettings = ({
                 errors={errors}
                 subdirectory="data-insights/"
             />
+            <GdocsTags gdoc={gdoc} onSaveTags={onSaveTags} />
             <div className="form-group">
                 <h3 className="form-section-heading">Data insight settings</h3>
                 <GdocsPublicationContext
@@ -225,10 +235,12 @@ export const GdocAnnouncementSettings = ({
     gdoc,
     setCurrentGdoc,
     errors,
+    onSaveTags,
 }: {
     gdoc: OwidGdocAnnouncementInterface
     setCurrentGdoc: (gdoc: OwidGdocAnnouncementInterface) => void
     errors?: OwidGdocErrorMessage[]
+    onSaveTags: SaveTags
 }) => {
     if (!gdoc || !errors) return null
 
@@ -243,6 +255,7 @@ export const GdocAnnouncementSettings = ({
                 setCurrentGdoc={setCurrentGdoc}
                 errors={errors}
             />
+            <GdocsTags gdoc={gdoc} onSaveTags={onSaveTags} />
             <GdocsPublicationContext
                 gdoc={gdoc}
                 setCurrentGdoc={setCurrentGdoc}
@@ -365,6 +378,7 @@ export const GdocProfileSettings = ({
     gdoc,
     setCurrentGdoc,
     errors,
+    onSaveTags,
     selectedEntity,
     setSelectedEntity,
     entitiesInScope,
@@ -372,6 +386,7 @@ export const GdocProfileSettings = ({
     gdoc: OwidGdocProfileInterface
     setCurrentGdoc: (gdoc: OwidGdocProfileInterface) => void
     errors?: OwidGdocErrorMessage[]
+    onSaveTags: SaveTags
     selectedEntity?: string
     setSelectedEntity: Dispatch<SetStateAction<string | undefined>>
     entitiesInScope: { value: string; label: string }[]
@@ -423,6 +438,7 @@ export const GdocProfileSettings = ({
                 errors={errors}
                 subdirectory="profile/"
             />
+            <GdocsTags gdoc={gdoc} onSaveTags={onSaveTags} />
             <div className="form-group">
                 <h3 className="form-section-heading">Profile settings</h3>
                 <GdocsSettingsContentField

--- a/adminSiteClient/GdocsTags.tsx
+++ b/adminSiteClient/GdocsTags.tsx
@@ -1,22 +1,12 @@
-import {
-    DbChartTagJoin,
-    MinimalTag,
-    OwidGdoc,
-    OwidGdocType,
-} from "@ourworldindata/utils"
+import { useEffect, useRef, useState } from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCheck } from "@fortawesome/free-solid-svg-icons"
+import { DbChartTagJoin, MinimalTag, OwidGdoc } from "@ourworldindata/utils"
 import { EditableTags } from "./EditableTags.js"
+import { checkCanTagGdocType } from "./gdocsTagging.js"
 import { useTags } from "./tagQueries.js"
 
-const UNTAGGABLE_GDOC_TYPES = [
-    OwidGdocType.AboutPage,
-    OwidGdocType.Author,
-    OwidGdocType.Fragment,
-    OwidGdocType.Homepage,
-]
-
-export function checkCanTagGdocType(type: OwidGdocType | undefined): boolean {
-    return !!type && !UNTAGGABLE_GDOC_TYPES.includes(type)
-}
+const SAVED_INDICATOR_DURATION_MS = 2500
 
 export const GdocsTags = ({
     gdoc,
@@ -26,10 +16,19 @@ export const GdocsTags = ({
     onSaveTags: (tags: MinimalTag[]) => Promise<void>
 }) => {
     const { data: availableTags } = useTags()
+    // Incremented on every save; keys the indicator so its fade-out restarts
+    const [saveCount, setSaveCount] = useState(0)
+    const [showSaved, setShowSaved] = useState(false)
+    const savedTimeoutRef = useRef<number>(undefined)
+
+    useEffect(() => () => window.clearTimeout(savedTimeoutRef.current), [])
 
     if (!checkCanTagGdocType(gdoc.content.type)) return null
 
-    const suggestions = availableTags ?? []
+    // Tag badges need the tag graph metadata to render
+    if (!availableTags) return null
+
+    const suggestions = availableTags
 
     const handleSave = async (tags: DbChartTagJoin[]): Promise<void> => {
         const suggestionsById = new Map(suggestions.map((tag) => [tag.id, tag]))
@@ -38,16 +37,29 @@ export const GdocsTags = ({
                 .map((tag) => suggestionsById.get(tag.id))
                 .filter((tag) => tag !== undefined)
         )
+        setSaveCount((count) => count + 1)
+        setShowSaved(true)
+        window.clearTimeout(savedTimeoutRef.current)
+        savedTimeoutRef.current = window.setTimeout(
+            () => setShowSaved(false),
+            SAVED_INDICATOR_DURATION_MS
+        )
     }
 
     return (
         <div className="form-group">
-            <h3 className="form-section-heading">Tags</h3>
+            <h3 className="form-section-heading">
+                Tags
+                {showSaved && (
+                    <span key={saveCount} className="GdocsTags__saved">
+                        <FontAwesomeIcon icon={faCheck} /> Saved!
+                    </span>
+                )}
+            </h3>
             <EditableTags
                 tags={gdoc.tags ?? []}
                 onSave={handleSave}
                 suggestions={suggestions}
-                disabled={!availableTags}
             />
             <p className="form-text text-muted">
                 Tags are saved immediately. Without any topic tags, this

--- a/adminSiteClient/GdocsTags.tsx
+++ b/adminSiteClient/GdocsTags.tsx
@@ -1,0 +1,58 @@
+import {
+    DbChartTagJoin,
+    MinimalTag,
+    OwidGdoc,
+    OwidGdocType,
+} from "@ourworldindata/utils"
+import { EditableTags } from "./EditableTags.js"
+import { useTags } from "./tagQueries.js"
+
+const UNTAGGABLE_GDOC_TYPES = [
+    OwidGdocType.AboutPage,
+    OwidGdocType.Author,
+    OwidGdocType.Fragment,
+    OwidGdocType.Homepage,
+]
+
+export function checkCanTagGdocType(type: OwidGdocType | undefined): boolean {
+    return !!type && !UNTAGGABLE_GDOC_TYPES.includes(type)
+}
+
+export const GdocsTags = ({
+    gdoc,
+    onSaveTags,
+}: {
+    gdoc: OwidGdoc
+    onSaveTags: (tags: MinimalTag[]) => Promise<void>
+}) => {
+    const { data: availableTags } = useTags()
+
+    if (!checkCanTagGdocType(gdoc.content.type)) return null
+
+    const suggestions = availableTags ?? []
+
+    const handleSave = async (tags: DbChartTagJoin[]): Promise<void> => {
+        const suggestionsById = new Map(suggestions.map((tag) => [tag.id, tag]))
+        await onSaveTags(
+            tags
+                .map((tag) => suggestionsById.get(tag.id))
+                .filter((tag) => tag !== undefined)
+        )
+    }
+
+    return (
+        <div className="form-group">
+            <h3 className="form-section-heading">Tags</h3>
+            <EditableTags
+                tags={gdoc.tags ?? []}
+                onSave={handleSave}
+                suggestions={suggestions}
+                disabled={!availableTags}
+            />
+            <p className="form-text text-muted">
+                Tags are saved immediately. Without any topic tags, this
+                document will not be filterable in the search or latest page.
+            </p>
+        </div>
+    )
+}

--- a/adminSiteClient/admin.scss
+++ b/adminSiteClient/admin.scss
@@ -1332,6 +1332,28 @@ main:not(.ChartEditorPage):not(.GdocsEditPage):not(.MultiDimDetailPage) {
     margin-bottom: 8px;
 }
 
+.GdocsTags__saved {
+    margin-left: 8px;
+    font-size: 13px;
+    font-weight: 400;
+    color: #52c41a;
+    animation: gdocs-tags-saved-fade 2.5s ease forwards;
+
+    svg {
+        margin-right: 2px;
+    }
+}
+
+@keyframes gdocs-tags-saved-fade {
+    0%,
+    70% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+}
+
 .GdocsSettingsContentField__imagePreview {
     margin-top: 12px;
 }

--- a/adminSiteClient/gdocsTagging.ts
+++ b/adminSiteClient/gdocsTagging.ts
@@ -1,0 +1,12 @@
+import { OwidGdocType } from "@ourworldindata/utils"
+
+const UNTAGGABLE_GDOC_TYPES = [
+    OwidGdocType.AboutPage,
+    OwidGdocType.Author,
+    OwidGdocType.Fragment,
+    OwidGdocType.Homepage,
+]
+
+export function checkCanTagGdocType(type: OwidGdocType | undefined): boolean {
+    return !!type && !UNTAGGABLE_GDOC_TYPES.includes(type)
+}


### PR DESCRIPTION
For years now, authors haven't been able to set tags from the gdoc preview page itself. This PR fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLF52UF5tejeBap47ifo7c