### PR TITLE
🐛🤖 use the chart's own state on the data table tab

### DIFF
--- a/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.test.ts
@@ -2054,6 +2054,30 @@ describe("tableForDisplay", () => {
                 .length
         ).toBe(5)
     })
+
+    it("drops the entities a scatter plot never plots", () => {
+        const scatterTable = new OwidTable(
+            [
+                ["entityName", "year", "x", "y"],
+                ["France", 2000, 1, 1],
+                ["Germany", 2000, null, null],
+            ],
+            [
+                { slug: "x", type: ColumnTypeNames.Numeric },
+                { slug: "y", type: ColumnTypeNames.Numeric },
+            ]
+        )
+        const grapher = new GrapherState({
+            table: scatterTable,
+            tab: "table",
+            chartTypes: ["ScatterPlot"],
+            xSlug: "x",
+            ySlugs: "y",
+        })
+        expect(
+            grapher.tableForDisplayBeforeEntityFilter.availableEntityNames
+        ).toEqual(["France"])
+    })
 })
 
 describe("projectionColumnInfoBySlug", () => {

--- a/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
+++ b/packages/@ourworldindata/grapher/src/core/GrapherState.tsx
@@ -1584,8 +1584,7 @@ export class GrapherState
     }
 
     @computed get chartStateExceptMap(): ChartState {
-        const chartType = this.activeChartType ?? GRAPHER_CHART_TYPES.LineChart
-
+        const chartType = this.activeChartType ?? this.defaultChartType
         return makeChartState(chartType, this)
     }
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @sophiamersmann at the wheel._

On the data table tab `activeChartType` is undefined, since the table tab is not a chart type, and Grapher's chart state fell back to a line chart state for every chart. A scatter plot's data table therefore listed entities the chart never plots, because the scatter's display transform never ran. That is the situation #2692 reported and #2720 fixed, and it came back with #4159. The fallback is now the chart's default type, which is what the code did before.

To see it, take the chart from #2692, a scatter of Gini after tax against Gini before tax with circles sized by population:

- On production, [the table tab](https://ourworldindata.org/grapher/gini-coefficient-after-vs-before-tax-wb-scatter?tab=table) lists 269 entities while the chart plots 108. Afghanistan, Algeria, Angola and 158 others appear with a population value and nothing else, and the chart tab's entity selector does not offer them.
- On staging, [the same table tab](http://staging-site-table-tab-chart/grapher/gini-coefficient-after-vs-before-tax-wb-scatter?tab=table) lists the 108 plotted countries only, and the filter dropdown's count matches.

The change is to which chart state the table tab builds, so every getter that reads the chart state there sees the chart's own class instead of a line chart's. Most of those getters are gated to the chart or map tab and are unaffected. The only other visible effects are in code the diff does not touch:

- **Fix.** The admin's colour-scale section showed for chart types without a colour scale while the preview was on the table tab. It now stays hidden, as on the chart tab.
- **Fix.** `values.json?tab=table` served values from a line-chart transform for every chart. It now uses the chart's own.
