### PR TITLE
Stop the versions drawer being cropped by the browser chrome

### DIFF
--- a/site/archive/VersionsDrawer.scss
+++ b/site/archive/VersionsDrawer.scss
@@ -1,6 +1,9 @@
 .versions-drawer-overlay {
     position: fixed;
     inset: 0;
+    // `inset: 0` can extend behind mobile browser chrome. Use the dynamic
+    // viewport height where supported, with `100vh` as a fallback.
+    height: var(--viewport-height);
     display: flex;
     justify-content: flex-end;
     background: rgba(0, 0, 0, 0.4);
@@ -32,7 +35,7 @@
 
 .versions-drawer-dialog {
     pointer-events: auto;
-    height: 100vh;
+    height: 100%;
     width: min(408px, 100%);
     background-color: $white;
     color: $blue-90;
@@ -198,8 +201,8 @@
     }
 
     .versions-drawer-dialog {
-        height: min(490px, 100vh);
-        max-height: 100vh;
+        height: min(490px, var(--viewport-height));
+        max-height: var(--viewport-height);
         width: 100%;
     }
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @mlbrgl at the wheel._

The "Browse past versions" drawer has the same problem #7141 fixes for the mobile feedback form: its overlay is `position: fixed; inset: 0`, which on mobile sizes it to the _large_ viewport, so the bottom sheet is glued to the bottom of a box that extends underneath the browser toolbar. The overlay and drawer now use the shared viewport-height variable — `100dvh` where supported, `100vh` as a fallback — while preserving the full-height desktop drawer and the mobile 490px cap.

| Before | After |
|--------|--------|
| <img width="914" height="457" alt="the drawer's bottom edge cropped by the browser toolbar" src="https://github.com/user-attachments/assets/9869298e-6394-4e63-b89f-85d0bcdc9b86" /> | <img width="921" height="473" alt="the drawer fitting the visible viewport" src="https://github.com/user-attachments/assets/7da0ba48-7cf7-4479-9bd6-6c04eda13bd9" /> |

**Where to find the drawer on staging:** on the archive baked on port 8789, not on the live staging article — the button is gated on `ARCHIVE_BASE_URL` (via `getLatestArchivedPostPageVersionsIfEnabled`), which only the archival bake sets. That is true on `master` too, and is worth knowing before concluding the drawer is broken rather than absent.

## Testing guidance

1. On a phone, open the archived article on `:8789` and tap **Browse all versions** while the URL bar is showing.
2. The sheet's bottom edge — the padding under "First available archived version of this article" — should be fully visible, and the last entry in the list reachable.
3. Scroll so the URL bar retracts, reopen, and confirm it still fits.
4. Check the desktop side drawer (≥769px) still runs the full height of the window.

<details><summary>Details</summary>

- The overlay gets an explicit viewport-aware height instead of relying only on `inset: 0`; the desktop drawer fills the overlay, and the mobile drawer remains capped at 490px.
- The `vh` fallback is kept in the `sm-only` block (unlike #7141, which needed none): dropping both `dvh` declarations there would fall through to `height: 100%` against a content-sized parent, giving an uncapped sheet with no `max-height` at all.
- The site-screenshots ⚠️ is not this PR's — all seven pages differ by the same 3,816px, the floating site-tools buttons inherited from the base branch. A closed drawer renders no `.versions-drawer-*` element, so this commit cannot change any screenshot.
- Verified with formatting checks, a production Vite build, and short mobile viewports. Emulation reports `svh == lvh == dvh`, so that does not exercise a real dynamic toolbar; the manual check above is still needed.

</details>
