### PR TITLE
🐛🤖 route Brief opt-ins through Mailchimp

### DIFF
--- a/functions/README.md
+++ b/functions/README.md
@@ -207,10 +207,12 @@ edit preferences directly. Requesting a link for an unknown address produces
 the same public response without sending email, avoiding both address
 enumeration and an arbitrary-mail endpoint.
 
-The OWID Brief remains a separate Mailchimp subscription but uses the same
-single-opt-in policy. Mailchimp failures are fail-soft when saving notification
-preferences because the two subscriptions have different owners and should not
-make each other unavailable.
+The OWID Brief remains a separate Mailchimp subscription. Opt-ins continue in
+the browser through Mailchimp's hosted signup form, including when a contact
+previously unsubscribed themselves; the Functions API never forces that global
+status transition. The API reads the live status for the preferences page and
+disables only the Brief interest for opt-outs. Status reads fail soft so a
+Mailchimp outage does not make Follow Topics preferences unavailable.
 
 The relevant routes and their trust boundaries are:
 

--- a/functions/_common/emailNotifications.ts
+++ b/functions/_common/emailNotifications.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/cloudflare"
 import {
     EMAIL_NOTIFICATIONS_CONTENT_TYPE_LABELS,
     EMAIL_NOTIFICATIONS_FREQUENCY_LABELS,
@@ -8,6 +7,7 @@ import {
 import { JsonError } from "@ourworldindata/utils"
 import * as _ from "lodash-es"
 import { Env } from "./env.js"
+import { logErrorAndCaptureInSentry } from "./errorLog.js"
 import { getPostmarkClient } from "./postmarkClient.js"
 
 export function validateEmailNotificationsDatabase(env: Env): void {
@@ -313,12 +313,12 @@ export function makeJsonResponse(body: object, status: number): Response {
     })
 }
 
-/** Catch-block handler for JSON endpoints: report to Sentry, answer generically. */
-export function handleJsonError(error: unknown): Response {
+/** Catch-block handler for JSON endpoints: report to logs/Sentry, answer generically. */
+export function handleJsonError(error: unknown, message: string): Response {
     if (isExpectedClientError(error)) {
         return makeJsonResponse({ error: error.message }, error.status)
     }
-    Sentry.captureException(error)
+    logErrorAndCaptureInSentry(message, error)
     return makeJsonResponse(
         { error: GENERIC_ERROR_MESSAGE },
         error instanceof JsonError ? error.status : 500

--- a/functions/_common/errorLog.ts
+++ b/functions/_common/errorLog.ts
@@ -1,0 +1,9 @@
+import * as Sentry from "@sentry/cloudflare"
+
+export function logErrorAndCaptureInSentry(
+    message: string,
+    error: unknown
+): void {
+    console.error(message, error)
+    Sentry.captureException(error)
+}

--- a/functions/_common/mailchimp.ts
+++ b/functions/_common/mailchimp.ts
@@ -1,9 +1,10 @@
 import { Env } from "./env.js"
 
 /**
- * Helpers for the OWID Brief newsletter, which stays in Mailchimp: the
- * subscribe form and the magic-link preferences page manage the Brief
- * interest (group) on the Mailchimp list member.
+ * API helpers for the OWID Brief newsletter, which stays in Mailchimp.
+ * Opt-ins for active audience members update the Brief interest directly.
+ * Contacts in a compliance state still go through Mailchimp's hosted signup
+ * form so they can resubscribe.
  */
 
 function validateMailchimpConfiguration(env: Env): void {
@@ -45,47 +46,32 @@ function makeAuthHeader(env: Env): string {
 }
 
 /**
- * Enable or disable the OWID Brief interest on a Mailchimp list member.
- * Enabling creates or re-subscribes the member using single opt-in. Disabling
- * only patches an existing member; an address that has never joined the
- * Mailchimp audience remains absent rather than being created with the Brief
- * interest turned off.
+ * Disable the OWID Brief interest on an existing Mailchimp list member. An
+ * address that has never joined the audience is already not subscribed, so a
+ * missing member is an idempotent success.
  */
-export async function upsertOwidBriefSubscription(
+export async function disableOwidBriefSubscription(
     env: Env,
-    email: string,
-    shouldSubscribe: boolean
+    email: string
 ): Promise<void> {
     validateMailchimpConfiguration(env)
-
-    const member = shouldSubscribe
-        ? {
-              email_address: email,
-              status_if_new: "subscribed",
-              // status_if_new only applies when creating a member. An
-              // explicit Brief opt-in also re-subscribes an existing globally
-              // unsubscribed member.
-              status: "subscribed",
-              interests: { [env.MAILCHIMP_OWID_BRIEF_INTEREST_ID]: true },
-          }
-        : {
-              interests: { [env.MAILCHIMP_OWID_BRIEF_INTEREST_ID]: false },
-          }
 
     const response = await fetch(
         makeMemberUrl(env, await makeSubscriberHash(email)),
         {
-            method: shouldSubscribe ? "PUT" : "PATCH",
+            method: "PATCH",
             headers: {
                 Authorization: makeAuthHeader(env),
                 "Content-Type": "application/json",
             },
-            body: JSON.stringify(member),
+            body: JSON.stringify({
+                interests: {
+                    [env.MAILCHIMP_OWID_BRIEF_INTEREST_ID]: false,
+                },
+            }),
         }
     )
-    // An absent member is already not subscribed, so disabling their Brief
-    // interest is an idempotent success rather than an error.
-    if (!shouldSubscribe && response.status === 404) return
+    if (response.status === 404) return
     if (!response.ok) {
         const data = await response.json()
         console.error("Failed to update the OWID Brief subscription", data)
@@ -93,6 +79,64 @@ export async function upsertOwidBriefSubscription(
             `Failed to update the OWID Brief subscription (${response.status})`
         )
     }
+}
+
+/**
+ * Enable the OWID Brief interest when the address is an active Mailchimp
+ * audience member. Returns false when the hosted signup form is required to
+ * add or globally resubscribe the address.
+ */
+export async function enableOwidBriefSubscriptionForAudienceMember(
+    env: Env,
+    email: string
+): Promise<boolean> {
+    validateMailchimpConfiguration(env)
+
+    const memberUrl = makeMemberUrl(env, await makeSubscriberHash(email))
+    const memberResponse = await fetch(`${memberUrl}?fields=status,interests`, {
+        headers: { Authorization: makeAuthHeader(env) },
+    })
+    if (memberResponse.status === 404) return false
+    if (!memberResponse.ok) {
+        console.error(
+            `Failed to fetch the OWID Brief status (${memberResponse.status})`
+        )
+        throw new Error(
+            `Failed to fetch the OWID Brief status (${memberResponse.status})`
+        )
+    }
+
+    const member = (await memberResponse.json()) as {
+        status?: string
+        interests?: Record<string, boolean>
+    }
+    if (member.status !== "subscribed") return false
+    if (member.interests?.[env.MAILCHIMP_OWID_BRIEF_INTEREST_ID] === true) {
+        return true
+    }
+
+    const updateResponse = await fetch(memberUrl, {
+        method: "PATCH",
+        headers: {
+            Authorization: makeAuthHeader(env),
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            interests: {
+                [env.MAILCHIMP_OWID_BRIEF_INTEREST_ID]: true,
+            },
+        }),
+    })
+    // The member may have disappeared between the read and update.
+    if (updateResponse.status === 404) return false
+    if (!updateResponse.ok) {
+        const data = await updateResponse.json()
+        console.error("Failed to update the OWID Brief subscription", data)
+        throw new Error(
+            `Failed to update the OWID Brief subscription (${updateResponse.status})`
+        )
+    }
+    return true
 }
 
 /**

--- a/functions/api/email-notifications/postmark-webhook.ts
+++ b/functions/api/email-notifications/postmark-webhook.ts
@@ -1,6 +1,6 @@
-import * as Sentry from "@sentry/cloudflare"
 import { Env } from "../../_common/env.js"
 import { validateEmailNotificationsDatabase } from "../../_common/emailNotifications.js"
+import { logErrorAndCaptureInSentry } from "../../_common/errorLog.js"
 import {
     PostmarkWebhookEvent,
     applyPostmarkWebhookEvent,
@@ -29,7 +29,10 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     try {
         event = await request.json<PostmarkWebhookEvent>()
     } catch (error) {
-        reportWebhookError("Failed to parse Postmark webhook payload", error)
+        logErrorAndCaptureInSentry(
+            "Failed to parse Postmark webhook payload",
+            error
+        )
         return new Response(null, { status: 500 })
     }
 
@@ -37,14 +40,9 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
         await applyPostmarkWebhookEvent(env.EMAIL_NOTIFICATIONS_DB, event)
         return new Response(null, { status: 200 })
     } catch (error) {
-        reportWebhookError("Failed to process Postmark webhook", error)
+        logErrorAndCaptureInSentry("Failed to process Postmark webhook", error)
         return new Response(null, { status: 500 })
     }
-}
-
-function reportWebhookError(message: string, error: unknown): void {
-    console.error(message, error)
-    Sentry.captureException(error)
 }
 
 function validatePostmarkWebhookConfiguration(env: Env): void {

--- a/functions/api/email-notifications/preferences.ts
+++ b/functions/api/email-notifications/preferences.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/cloudflare"
 import * as z from "zod/mini"
 import {
     EmailNotificationsPreferences,
@@ -16,9 +15,11 @@ import {
     makeJsonResponse,
     validateEmailNotificationsDatabase,
 } from "../../_common/emailNotifications.js"
+import { logErrorAndCaptureInSentry } from "../../_common/errorLog.js"
 import {
+    disableOwidBriefSubscription,
+    enableOwidBriefSubscriptionForAudienceMember,
     getOwidBriefStatus,
-    upsertOwidBriefSubscription,
 } from "../../_common/mailchimp.js"
 import {
     POSTMARK_BROADCAST_MESSAGE_STREAM,
@@ -75,7 +76,10 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
                 env,
                 user.email
             ).catch((error) => {
-                Sentry.captureException(error)
+                logErrorAndCaptureInSentry(
+                    "Failed to load the OWID Brief subscription status",
+                    error
+                )
                 return null
             }),
             // Brief-only identities intentionally have no notification
@@ -92,17 +96,21 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
         }
         return makeJsonResponse(response, 200)
     } catch (error) {
-        return handleJsonError(error)
+        return handleJsonError(
+            error,
+            "Failed to load email notification preferences"
+        )
     }
 }
 
 /**
  * Save target of the magic-link preferences page. The magic link itself was
  * the proof of inbox control, so changes apply immediately. Notification
- * status and preferences are stored in D1; the optional Brief selection is
- * written directly to Mailchimp. Cross-system updates cannot be atomic, so
- * failures are surfaced rather than claiming that every requested preference
- * was saved.
+ * status and preferences are stored in D1. Brief opt-outs disable the
+ * Mailchimp interest directly. Opt-ins update the interest directly for
+ * active audience members, while globally unsubscribed or missing contacts
+ * return a signal that lets the browser continue through Mailchimp's hosted
+ * signup form.
  */
 export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
     try {
@@ -198,24 +206,39 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             ])
         }
 
-        if (data.subscribeToOwidBrief !== undefined) {
-            await upsertOwidBriefSubscription(
-                env,
-                user.email,
-                data.subscribeToOwidBrief
-            )
+        let mailchimpSignupRequired = false
+        if (data.subscribeToOwidBrief === false) {
+            await disableOwidBriefSubscription(env, user.email)
+        } else if (data.subscribeToOwidBrief === true) {
+            mailchimpSignupRequired =
+                !(await enableOwidBriefSubscriptionForAudienceMember(
+                    env,
+                    user.email
+                ))
         }
 
-        return makeJsonResponse({ ok: true }, 200)
+        return makeJsonResponse(
+            {
+                ok: true,
+                mailchimpSignupRequired,
+            },
+            200
+        )
     } catch (error) {
         if (error instanceof PostmarkRecipientReactivationError) {
-            Sentry.captureException(error)
+            logErrorAndCaptureInSentry(
+                "Failed to reactivate a Postmark recipient while saving preferences",
+                error
+            )
             return makeJsonResponse(
                 { error: POSTMARK_REACTIVATION_USER_MESSAGE },
                 500
             )
         }
-        return handleJsonError(error)
+        return handleJsonError(
+            error,
+            "Failed to save email notification preferences"
+        )
     }
 }
 

--- a/functions/api/email-notifications/request-link.ts
+++ b/functions/api/email-notifications/request-link.ts
@@ -134,7 +134,12 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             })
         )
     } catch (error) {
-        if (isJson) return handleJsonError(error)
+        if (isJson) {
+            return handleJsonError(
+                error,
+                "Failed to request an email notification preferences link"
+            )
+        }
         throw error
     }
 }

--- a/functions/api/email-notifications/subscribe.ts
+++ b/functions/api/email-notifications/subscribe.ts
@@ -1,4 +1,3 @@
-import * as Sentry from "@sentry/cloudflare"
 import * as z from "zod/mini"
 import {
     EmailNotificationsPreferences,
@@ -14,7 +13,8 @@ import {
     sendWelcomeEmail,
     validateEmailNotificationsDatabase,
 } from "../../_common/emailNotifications.js"
-import { upsertOwidBriefSubscription } from "../../_common/mailchimp.js"
+import { logErrorAndCaptureInSentry } from "../../_common/errorLog.js"
+import { enableOwidBriefSubscriptionForAudienceMember } from "../../_common/mailchimp.js"
 import {
     POSTMARK_REACTIVATION_USER_MESSAGE,
     PostmarkRecipientReactivationError,
@@ -92,22 +92,32 @@ export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
             })
         }
 
-        if (data.subscribeToOwidBrief) {
-            // The OWID Brief newsletter stays in Mailchimp and uses single
-            // opt-in, like email notifications.
-            await upsertOwidBriefSubscription(env, email, true)
-        }
+        const mailchimpSignupRequired = data.subscribeToOwidBrief
+            ? !(await enableOwidBriefSubscriptionForAudienceMember(env, email))
+            : false
 
-        return makeJsonResponse({ ok: true }, 200)
+        return makeJsonResponse(
+            {
+                ok: true,
+                mailchimpSignupRequired,
+            },
+            200
+        )
     } catch (error) {
         if (error instanceof PostmarkRecipientReactivationError) {
-            Sentry.captureException(error)
+            logErrorAndCaptureInSentry(
+                "Failed to reactivate a Postmark recipient while subscribing",
+                error
+            )
             return makeJsonResponse(
                 { error: POSTMARK_REACTIVATION_USER_MESSAGE },
                 500
             )
         }
-        return handleJsonError(error)
+        return handleJsonError(
+            error,
+            "Failed to handle an email notifications subscription"
+        )
     }
 }
 

--- a/packages/@ourworldindata/types/src/EmailNotificationsTypes.ts
+++ b/packages/@ourworldindata/types/src/EmailNotificationsTypes.ts
@@ -111,6 +111,13 @@ export function mergeEmailNotificationsPreferences(
 
 export interface EmailNotificationsSubscribeResponse {
     ok?: boolean
+    mailchimpSignupRequired?: boolean
+    error?: string
+}
+
+export interface EmailNotificationsUpdatePreferencesResponse {
+    ok?: boolean
+    mailchimpSignupRequired?: boolean
     error?: string
 }
 

--- a/packages/@ourworldindata/types/src/index.ts
+++ b/packages/@ourworldindata/types/src/index.ts
@@ -24,6 +24,7 @@ export {
     type EmailNotificationsSubscribeResponse,
     type EmailNotificationsRequestLinkRequest,
     type EmailNotificationsUpdatePreferencesRequest,
+    type EmailNotificationsUpdatePreferencesResponse,
     type EmailNotificationsPreferencesResponse,
 } from "./EmailNotificationsTypes.js"
 

--- a/site/Newsletter/EmailNotificationsPreferencesForm.tsx
+++ b/site/Newsletter/EmailNotificationsPreferencesForm.tsx
@@ -7,6 +7,7 @@ import {
     EmailNotificationsPreferencesResponse,
     EmailNotificationsRequestLinkRequest,
     EmailNotificationsUpdatePreferencesRequest,
+    EmailNotificationsUpdatePreferencesResponse,
 } from "@ourworldindata/types"
 import { Button, Checkbox, TextInput } from "@ourworldindata/components"
 import { SiteQueryClientProvider } from "../SiteQueryClientProvider.js"
@@ -18,6 +19,7 @@ import {
     throwIfApiError,
 } from "./emailNotificationsApi.js"
 import { useNotificationPreferences } from "./useNotificationPreferences.js"
+import { submitOwidBriefSignupToMailchimp } from "./mailchimpSignup.js"
 import {
     SUBSCRIBE_PAGE_CONTENT_GRID_CLASSES,
     SubscribePageConfirmation,
@@ -319,31 +321,51 @@ const PreferencesEditor = ({
     )
 
     const update = useMutation({
-        mutationFn: async (
+        mutationFn: async ({
+            request,
+            successResult,
+        }: {
             request: EmailNotificationsUpdatePreferencesRequest
-        ) => {
+            successResult: TokenScreenResult
+        }) => {
             const response = await apiPost("/preferences", request)
-            if (response.status === 410) return "expired" as const
+            if (response.status === 410) {
+                return {
+                    result: "expired" as const,
+                    mailchimpSignupRequired: false,
+                }
+            }
             await throwIfApiError(response)
-            return !request.subscribeToTopicNotifications &&
-                request.subscribeToOwidBrief === false
-                ? "unsubscribed"
-                : "saved"
+            const data =
+                (await response.json()) as EmailNotificationsUpdatePreferencesResponse
+            return {
+                result: successResult,
+                mailchimpSignupRequired: data.mailchimpSignupRequired ?? false,
+            }
         },
-        onSuccess: onDone,
+        onSuccess: ({ result, mailchimpSignupRequired }) => {
+            if (mailchimpSignupRequired) {
+                submitOwidBriefSignupToMailchimp(email)
+                return
+            }
+            onDone(result)
+        },
     })
 
     const handleSave = (event: React.SubmitEvent<HTMLFormElement>) => {
         event.preventDefault()
         preferences.resetValidation()
         if (subscribedToTopicNotifications && !preferences.validate()) return
+        const briefSubscriptionChange =
+            subscribedToOwidBrief === initialSubscribedToOwidBrief
+                ? undefined
+                : (subscribedToOwidBrief ?? undefined)
         const commonRequest = {
             token,
-            // Only included when the toggle was shown.
-            subscribeToOwidBrief: subscribedToOwidBrief ?? undefined,
+            subscribeToOwidBrief: briefSubscriptionChange,
         }
-        update.mutate(
-            subscribedToTopicNotifications
+        update.mutate({
+            request: subscribedToTopicNotifications
                 ? {
                       ...commonRequest,
                       subscribeToTopicNotifications: true,
@@ -352,16 +374,26 @@ const PreferencesEditor = ({
                 : {
                       ...commonRequest,
                       subscribeToTopicNotifications: false,
-                  }
-        )
+                  },
+            successResult:
+                !subscribedToTopicNotifications &&
+                subscribedToOwidBrief === false
+                    ? "unsubscribed"
+                    : "saved",
+        })
     }
 
     const handleUnsubscribe = () => {
         preferences.resetValidation()
         update.mutate({
-            token,
-            subscribeToTopicNotifications: false,
-            subscribeToOwidBrief: false,
+            request: {
+                token,
+                subscribeToTopicNotifications: false,
+                subscribeToOwidBrief: initialSubscribedToOwidBrief
+                    ? false
+                    : undefined,
+            },
+            successResult: "unsubscribed",
         })
     }
 

--- a/site/Newsletter/EmailNotificationsSubscribeForm.tsx
+++ b/site/Newsletter/EmailNotificationsSubscribeForm.tsx
@@ -1,7 +1,10 @@
 import { useState } from "react"
 import * as React from "react"
 import { useMutation } from "@tanstack/react-query"
-import { EmailNotificationsSubscribeRequest } from "@ourworldindata/types"
+import {
+    EmailNotificationsSubscribeRequest,
+    EmailNotificationsSubscribeResponse,
+} from "@ourworldindata/types"
 import { Button, Checkbox, TextInput } from "@ourworldindata/components"
 import { SiteAnalytics } from "../SiteAnalytics.js"
 import { EmailNotificationsPreferenceFields } from "./EmailNotificationsPreferenceFields.js"
@@ -11,6 +14,7 @@ import {
     throwIfApiError,
 } from "./emailNotificationsApi.js"
 import { useNotificationPreferences } from "./useNotificationPreferences.js"
+import { submitOwidBriefSignupToMailchimp } from "./mailchimpSignup.js"
 
 const analytics = new SiteAnalytics()
 
@@ -65,8 +69,6 @@ const NewsletterOption = ({
 
 export interface Subscription {
     email: string
-    followTopics: boolean
-    subscribeToOwidBrief: boolean
 }
 
 export const EmailNotificationsSubscribeForm = ({
@@ -86,16 +88,19 @@ export const EmailNotificationsSubscribeForm = ({
         mutationFn: async (request: EmailNotificationsSubscribeRequest) => {
             const response = await apiPost("/subscribe", request)
             await throwIfApiError(response)
+            return (await response.json()) as EmailNotificationsSubscribeResponse
         },
-        onSuccess: (_, request) => {
+        onSuccess: (response, request) => {
             analytics.logSiteFormSubmit(
                 "newsletter-subscribe",
                 "Subscribe [email-notifications]"
             )
+            if (response.mailchimpSignupRequired) {
+                submitOwidBriefSignupToMailchimp(request.email)
+                return
+            }
             onSubscribed({
                 email: request.email,
-                followTopics: request.notifications !== undefined,
-                subscribeToOwidBrief: request.subscribeToOwidBrief,
             })
         },
     })

--- a/site/Newsletter/SubscribeFlow.tsx
+++ b/site/Newsletter/SubscribeFlow.tsx
@@ -55,23 +55,14 @@ export const SubscribeFlow = ({
 }
 
 const SubscribedText = ({
-    subscription: { email, followTopics, subscribeToOwidBrief },
+    subscription: { email },
 }: {
     subscription: Subscription
 }) => (
-    <>
-        {followTopics && (
-            <p className="subscribe-page__confirmation-text">
-                We have sent a confirmation email to <strong>{email}</strong>{" "}
-                with a summary of your preferences.
-            </p>
-        )}
-        {subscribeToOwidBrief && (
-            <p className="subscribe-page__confirmation-text">
-                Your subscription to The OWID Brief is active.
-            </p>
-        )}
-    </>
+    <p className="subscribe-page__confirmation-text">
+        We have sent a confirmation email to <strong>{email}</strong> with a
+        summary of your preferences.
+    </p>
 )
 
 const SubscribeFormScreen = ({

--- a/site/Newsletter/mailchimpSignup.ts
+++ b/site/Newsletter/mailchimpSignup.ts
@@ -1,0 +1,49 @@
+export const MAILCHIMP_NEWSLETTER_SIGNUP_FORM_ACTION =
+    "https://ourworldindata.us8.list-manage.com/subscribe/post?u=18058af086319ba6afad752ec&id=2e166c1fc1"
+
+export const MAILCHIMP_NEWSLETTER_GROUP_ID = "85302"
+export const MAILCHIMP_OWID_BRIEF_GROUP_VALUE = "2"
+export const MAILCHIMP_SIGNUP_HONEYPOT_NAME =
+    "b_18058af086319ba6afad752ec_2e166c1fc1"
+
+export function makeMailchimpNewsletterGroupInputName(
+    groupValue: string
+): string {
+    return `group[${MAILCHIMP_NEWSLETTER_GROUP_ID}][${groupValue}]`
+}
+
+function appendHiddenInput(
+    form: HTMLFormElement,
+    name: string,
+    value: string
+): void {
+    const input = document.createElement("input")
+    input.type = "hidden"
+    input.name = name
+    input.value = value
+    form.append(input)
+}
+
+/**
+ * Continue an OWID Brief opt-in through Mailchimp's browser-hosted form
+ * endpoint. Unlike the Marketing API, this flow can resubscribe a contact who
+ * previously opted out and lets Mailchimp record the renewed consent.
+ */
+export function submitOwidBriefSignupToMailchimp(email: string): void {
+    const form = document.createElement("form")
+    form.action = MAILCHIMP_NEWSLETTER_SIGNUP_FORM_ACTION
+    form.method = "post"
+    form.hidden = true
+    form.className = "sentry-mask"
+
+    appendHiddenInput(form, "EMAIL", email)
+    appendHiddenInput(
+        form,
+        makeMailchimpNewsletterGroupInputName(MAILCHIMP_OWID_BRIEF_GROUP_VALUE),
+        MAILCHIMP_OWID_BRIEF_GROUP_VALUE
+    )
+    appendHiddenInput(form, MAILCHIMP_SIGNUP_HONEYPOT_NAME, "")
+
+    document.body.append(form)
+    form.submit()
+}

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -7,6 +7,13 @@ import { SiteAnalytics } from "./SiteAnalytics.js"
 import { TextInput } from "@ourworldindata/components"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { NewsletterIcon } from "./gdocs/components/NewsletterIcon.js"
+import {
+    MAILCHIMP_NEWSLETTER_GROUP_ID,
+    MAILCHIMP_NEWSLETTER_SIGNUP_FORM_ACTION,
+    MAILCHIMP_OWID_BRIEF_GROUP_VALUE,
+    MAILCHIMP_SIGNUP_HONEYPOT_NAME,
+    makeMailchimpNewsletterGroupInputName,
+} from "./Newsletter/mailchimpSignup.js"
 
 const analytics = new SiteAnalytics()
 
@@ -90,11 +97,9 @@ export const NewsletterSubscriptionForm = ({
     className?: string
 }) => {
     const DATA_INSIGHTS = "16"
-    const BIWEEKLY = "2"
-    const idDataInsights = `mce-group[85302]-85302-0${
-        context ? "-" + context : ""
-    }`
-    const idBiweekly = `mce-group[85302]-85302-1${context ? "-" + context : ""}`
+    const BIWEEKLY = MAILCHIMP_OWID_BRIEF_GROUP_VALUE
+    const idDataInsights = `mce-group[${MAILCHIMP_NEWSLETTER_GROUP_ID}]-${MAILCHIMP_NEWSLETTER_GROUP_ID}-0${context ? "-" + context : ""}`
+    const idBiweekly = `mce-group[${MAILCHIMP_NEWSLETTER_GROUP_ID}]-${MAILCHIMP_NEWSLETTER_GROUP_ID}-1${context ? "-" + context : ""}`
 
     const [frequencies, setFrequencies] = useState([DATA_INSIGHTS, BIWEEKLY])
     const isSubmittable = frequencies.length !== 0
@@ -112,7 +117,7 @@ export const NewsletterSubscriptionForm = ({
     return (
         <form
             className={cx("newsletter-subscription-form", className)}
-            action="https://ourworldindata.us8.list-manage.com/subscribe/post?u=18058af086319ba6afad752ec&id=2e166c1fc1"
+            action={MAILCHIMP_NEWSLETTER_SIGNUP_FORM_ACTION}
             method="post"
             id="mc-embedded-subscribe-banner"
             name="mc-embedded-subscribe-banner"
@@ -134,7 +139,7 @@ export const NewsletterSubscriptionForm = ({
                 <input
                     type="checkbox"
                     value={BIWEEKLY}
-                    name={`group[85302][${BIWEEKLY}]`}
+                    name={makeMailchimpNewsletterGroupInputName(BIWEEKLY)}
                     id={idBiweekly}
                     checked={frequencies.includes(BIWEEKLY)}
                     onChange={updateFrequencies}
@@ -169,7 +174,7 @@ export const NewsletterSubscriptionForm = ({
                 <input
                     type="checkbox"
                     value={DATA_INSIGHTS}
-                    name={`group[85302][${DATA_INSIGHTS}]`}
+                    name={makeMailchimpNewsletterGroupInputName(DATA_INSIGHTS)}
                     id={idDataInsights}
                     checked={frequencies.includes(DATA_INSIGHTS)}
                     onChange={updateFrequencies}
@@ -226,7 +231,7 @@ export const NewsletterSubscriptionForm = ({
             element instead */}
             <input
                 type="hidden"
-                name="b_18058af086319ba6afad752ec_2e166c1fc1"
+                name={MAILCHIMP_SIGNUP_HONEYPOT_NAME}
                 tabIndex={-1}
             />
             <div className="newsletter-subscription-form__privacy-notice">


### PR DESCRIPTION
Use Mailchimp's hosted form for Brief opt-ins so previously unsubscribed contacts can renew consent. Keep opt-outs in the Functions API and centralize Cloudflare error reporting.