### PR TITLE
🔨🤖 move the svg tester's helpers out of baker/

### DIFF
--- a/baker/GrapherBakingUtils.ts
+++ b/baker/GrapherBakingUtils.ts
@@ -4,26 +4,8 @@ import fs from "fs-extra"
 import * as db from "../db/db.js"
 import { DbPlainTag, DbPlainUser } from "@ourworldindata/utils"
 import { isPathRedirectedToExplorer } from "../explorerAdminServer/ExplorerRedirects.js"
-import { hashMd5 } from "../serverUtils/hash.js"
 import { BAKE_ON_CHANGE } from "../settings/serverSettings.js"
 import { DeployQueueServer } from "./DeployQueueServer.js"
-
-// Combines a grapher slug, and potentially its query string, to _part_ of an export file
-// name. It's called fileKey and not fileName because the actual export filename also includes
-// other parts, like chart version and width/height.
-export const grapherSlugToExportFileKey = (
-    slug: string,
-    queryStr: string | undefined,
-    {
-        shouldHashQueryStr = true,
-        separator = "-",
-    }: { shouldHashQueryStr?: boolean; separator?: string } = {}
-) => {
-    const maybeHashedQueryStr = shouldHashQueryStr
-        ? hashMd5(queryStr ?? "")
-        : queryStr
-    return `${slug}${queryStr ? `${separator}${maybeHashedQueryStr}` : ""}`
-}
 
 /**
  * Returns a map that can resolve Tag names and Tag IDs to the Tag's slug

--- a/baker/GrapherImageBaker.tsx
+++ b/baker/GrapherImageBaker.tsx
@@ -1,124 +1,14 @@
-import {
-    DbPlainChartSlugRedirect,
-    DbPlainChart,
-    GrapherInterface,
-    DbRawChartConfig,
-} from "@ourworldindata/types"
+import { GrapherInterface } from "@ourworldindata/types"
 import {
     fetchInputTableForConfig,
     Grapher,
-    GrapherProgrammaticInterface,
     GrapherState,
     GRAPHER_IMAGE_WIDTH_2X,
 } from "@ourworldindata/grapher"
-import path from "path"
 import { runInAction } from "mobx"
-import * as db from "../db/db.js"
-import { grapherSlugToExportFileKey } from "./GrapherBakingUtils.js"
-import { BAKED_GRAPHER_URL } from "../settings/clientSettings.js"
 import { DATA_API_URL } from "../settings/serverSettings.js"
 import ReactDOMServer from "react-dom/server"
 import sharp from "sharp"
-
-interface SvgFilenameFragments {
-    slug: string
-    version: number
-    width: number
-    height: number
-    queryStr?: string
-}
-
-export async function getGraphersAndRedirectsBySlug(
-    knex: db.KnexReadonlyTransaction
-) {
-    const { graphersBySlug, graphersById } =
-        await getPublishedGraphersBySlug(knex)
-
-    const redirectQuery = await db.knexRaw<
-        Pick<DbPlainChartSlugRedirect, "slug" | "chart_id">
-    >(knex, `SELECT slug, chart_id FROM chart_slug_redirects`)
-
-    for (const row of redirectQuery) {
-        const grapher = graphersById.get(row.chart_id)
-        if (grapher) {
-            graphersBySlug.set(row.slug, grapher)
-        }
-    }
-
-    return graphersBySlug
-}
-
-export async function getPublishedGraphersBySlug(
-    knex: db.KnexReadonlyTransaction
-) {
-    const graphersBySlug: Map<string, GrapherInterface> = new Map()
-    const graphersById: Map<number, GrapherInterface> = new Map()
-
-    // Select all graphers that are published
-    const sql = `-- sql
-        SELECT c.id, cc.config as config
-        FROM charts c
-        JOIN chart_configs cc ON c.configId = cc.id
-        WHERE cc.config ->> "$.isPublished" = 'true'
-    `
-
-    const query = db.knexRaw<
-        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
-    >(knex, sql)
-    for (const row of await query) {
-        const grapher = JSON.parse(row.config)
-
-        grapher.id = row.id
-        graphersBySlug.set(grapher.slug, grapher)
-        graphersById.set(row.id, grapher)
-    }
-    return { graphersBySlug, graphersById }
-}
-
-export function initGrapherForSvgExport(
-    jsonConfig: GrapherProgrammaticInterface,
-    queryStr: string = ""
-) {
-    const grapher = new Grapher({
-        grapherState: new GrapherState({
-            bakedGrapherURL: BAKED_GRAPHER_URL,
-            ...jsonConfig,
-            queryStr,
-        }),
-    })
-    runInAction(() => {
-        grapher.grapherState.isExportingToSvgOrPng = true
-        grapher.grapherState.shouldIncludeDetailsInStaticExport = false
-    })
-    return grapher
-}
-
-export function buildSvgOutFilename(
-    fragments: SvgFilenameFragments,
-    {
-        shouldHashQueryStr = true,
-        separator = "-",
-    }: { shouldHashQueryStr?: boolean; separator?: string } = {}
-): string {
-    const { slug, version, width, height, queryStr = "" } = fragments
-    const fileKey = grapherSlugToExportFileKey(slug, queryStr, {
-        shouldHashQueryStr,
-        separator,
-    })
-    const outFilename = `${fileKey}_v${version}_${width}x${height}.svg`
-    return outFilename
-}
-
-export function buildSvgOutFilepath(
-    outDir: string,
-    fragments: SvgFilenameFragments,
-    verbose: boolean = false
-) {
-    const outFilename = buildSvgOutFilename(fragments)
-    const outPath = path.join(outDir, outFilename)
-    if (verbose) console.log(outPath)
-    return outPath
-}
 
 export async function grapherToSVG(
     jsonConfig: GrapherInterface

--- a/devTools/svgTester/dump-data.ts
+++ b/devTools/svgTester/dump-data.ts
@@ -4,17 +4,18 @@ import path from "path"
 import { match } from "ts-pattern"
 import {
     TransactionCloseMode,
+    knexRaw,
     knexReadonlyTransaction,
     type KnexReadonlyTransaction,
 } from "../../db/db.js"
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
-import { getPublishedGraphersBySlug } from "../../baker/GrapherImageBaker.js"
 import { getMostViewedGrapherIdsByChartType } from "../../db/model/Chart.js"
 import { getAllPublishedMultiDimDataPages } from "../../db/model/MultiDimDataPage.js"
 import {
     ALL_GRAPHER_CHART_TYPES,
     GrapherInterface,
     ChartConfigsTableName,
+    DbPlainChart,
     DbRawChartConfig,
     SVG_TESTER_SUITES,
     type SvgTesterSuite,
@@ -34,6 +35,29 @@ interface ChartInfo {
     config: GrapherInterface
 }
 
+async function getPublishedGraphersById(
+    trx: KnexReadonlyTransaction
+): Promise<Map<number, GrapherInterface>> {
+    const rows = await knexRaw<
+        Pick<DbPlainChart, "id"> & { config: DbRawChartConfig["config"] }
+    >(
+        trx,
+        `-- sql
+        SELECT c.id, cc.config as config
+        FROM charts c
+        JOIN chart_configs cc ON c.configId = cc.id
+        WHERE cc.config ->> "$.isPublished" = 'true'
+    `
+    )
+    return new Map(
+        rows.map((row) => {
+            const config: GrapherInterface = JSON.parse(row.config)
+            config.id = row.id
+            return [row.id, config]
+        })
+    )
+}
+
 async function getMostViewedGraphersPerChartType(
     trx: KnexReadonlyTransaction,
     topN = 10
@@ -45,11 +69,11 @@ async function getMostViewedGraphersPerChartType(
     )
     const chartIds = (await Promise.all(promises)).flatMap((ids) => ids)
 
-    const allGraphers = await getPublishedGraphersBySlug(trx)
+    const graphersById = await getPublishedGraphersById(trx)
 
     const relevantGraphers = chartIds
         .map((chartId) => {
-            const config = allGraphers.graphersById.get(chartId)
+            const config = graphersById.get(chartId)
             if (!config) return undefined
             return {
                 id: config.slug!, // All published graphers have slugs
@@ -64,8 +88,8 @@ async function getMostViewedGraphersPerChartType(
 async function getAllPublishedGraphers(
     trx: KnexReadonlyTransaction
 ): Promise<ChartInfo[]> {
-    const allGraphers = await getPublishedGraphersBySlug(trx)
-    return allGraphers.graphersBySlug
+    const graphersById = await getPublishedGraphersById(trx)
+    return graphersById
         .values()
         .map((config) => ({
             id: config.slug!, // All published graphers have slugs

--- a/devTools/svgTester/tsconfig.json
+++ b/devTools/svgTester/tsconfig.json
@@ -9,7 +9,7 @@
         { "path": "../../packages/@ourworldindata/types" },
         { "path": "../../packages/@ourworldindata/utils" },
 
-        { "path": "../../baker" },
+        { "path": "../../db" },
         { "path": "../../serverUtils" },
         { "path": "../../settings" }
     ]

--- a/devTools/svgTester/utils.test.ts
+++ b/devTools/svgTester/utils.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, describe } from "vitest"
 
-import { grapherSlugToExportFileKey } from "./GrapherBakingUtils.js"
+import { grapherSlugToExportFileKey } from "./utils.js"
 
 describe(grapherSlugToExportFileKey, () => {
     it("can handle empty query string", () => {

--- a/devTools/svgTester/utils.ts
+++ b/devTools/svgTester/utils.ts
@@ -23,10 +23,6 @@ import {
 import fs, { stat } from "fs-extra"
 import path from "path"
 import { execFileSync } from "child_process"
-import {
-    buildSvgOutFilename,
-    initGrapherForSvgExport,
-} from "../../baker/GrapherImageBaker.js"
 import { getVariableData } from "../../db/model/Variable.js"
 
 import * as _ from "lodash-es"
@@ -34,6 +30,7 @@ import { getHeapStatistics } from "v8"
 import { queryStringsByChartType } from "./chart-configurations.js"
 import * as d3 from "d3-dsv"
 import {
+    Grapher,
     GrapherProgrammaticInterface,
     legacyToOwidTableAndDimensions,
     migrateGrapherConfigToLatestVersion,
@@ -44,6 +41,8 @@ import {
 } from "@ourworldindata/grapher"
 import { hashMd5 } from "../../serverUtils/hash.js"
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
+import { BAKED_GRAPHER_URL } from "../../settings/clientSettings.js"
+import { runInAction } from "mobx"
 import * as R from "remeda"
 import ReactDOMServer from "react-dom/server"
 import pMap from "p-map"
@@ -53,6 +52,64 @@ export const TEST_SUITE_DESCRIPTION =
 
 const CONFIG_EXTENSION = ".json"
 const RESULTS_FILENAME = "results.csv"
+
+interface SvgFilenameFragments {
+    slug: string
+    version: number
+    width: number
+    height: number
+    queryStr?: string
+}
+
+// Combines a grapher slug, and potentially its query string, to _part_ of an export file
+// name. It's called fileKey and not fileName because the actual export filename also includes
+// other parts, like chart version and width/height.
+export const grapherSlugToExportFileKey = (
+    slug: string,
+    queryStr: string | undefined,
+    {
+        shouldHashQueryStr = true,
+        separator = "-",
+    }: { shouldHashQueryStr?: boolean; separator?: string } = {}
+): string => {
+    const maybeHashedQueryStr = shouldHashQueryStr
+        ? hashMd5(queryStr ?? "")
+        : queryStr
+    return `${slug}${queryStr ? `${separator}${maybeHashedQueryStr}` : ""}`
+}
+
+export function buildSvgOutFilename(
+    fragments: SvgFilenameFragments,
+    {
+        shouldHashQueryStr = true,
+        separator = "-",
+    }: { shouldHashQueryStr?: boolean; separator?: string } = {}
+): string {
+    const { slug, version, width, height, queryStr = "" } = fragments
+    const fileKey = grapherSlugToExportFileKey(slug, queryStr, {
+        shouldHashQueryStr,
+        separator,
+    })
+    return `${fileKey}_v${version}_${width}x${height}.svg`
+}
+
+export function initGrapherForSvgExport(
+    jsonConfig: GrapherProgrammaticInterface,
+    queryStr: string = ""
+): Grapher {
+    const grapher = new Grapher({
+        grapherState: new GrapherState({
+            bakedGrapherURL: BAKED_GRAPHER_URL,
+            ...jsonConfig,
+            queryStr,
+        }),
+    })
+    runInAction(() => {
+        grapher.grapherState.isExportingToSvgOrPng = true
+        grapher.grapherState.shouldIncludeDetailsInStaticExport = false
+    })
+    return grapher
+}
 
 export function configPathFor(configsDir: string, viewId: string): string {
     return path.join(configsDir, `${viewId}${CONFIG_EXTENSION}`)

--- a/devTools/svgTester/verify-graphs.ts
+++ b/devTools/svgTester/verify-graphs.ts
@@ -9,8 +9,11 @@ import * as _ from "lodash-es"
 
 import { SVG_TESTER_REPO_PATH } from "../../settings/serverSettings.js"
 import * as utils from "./utils.js"
-import { JOB_TIMEOUT_MS, MAX_WORKERS } from "./utils.js"
-import { grapherSlugToExportFileKey } from "../../baker/GrapherBakingUtils.js"
+import {
+    JOB_TIMEOUT_MS,
+    MAX_WORKERS,
+    grapherSlugToExportFileKey,
+} from "./utils.js"
 import {
     ALL_GRAPHER_CHART_TYPES,
     SVG_TESTER_SUITES,


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @sophiamersmann at the wheel._

The svg tester built every chart through `initGrapherForSvgExport` and named its reference files through `buildSvgOutFilename` and `grapherSlugToExportFileKey`, all exported from `baker/` but called by nothing in the baker. They now live in the tester, with the file-key test moved alongside. `GrapherImageBaker.tsx` keeps `grapherToSVG` and `grapherToPng`, the two functions the admin test page and the archival baker call.

The point is that a CI path filter for the svg tester can now watch the grapher packages and `devTools/svgTester/` alone, with no baker files on its list.

- The tester's published-graphers query moved into dump-data and returns one map by id, since neither caller used the slug map. Two exports nothing called, `getGraphersAndRedirectsBySlug` and `buildSvgOutFilepath`, are deleted.