### PR TITLE
🎉🤖 (schema-versioning) upload a branch's schema artefacts to a preview path

### DIFF
--- a/.github/workflows/sync-grapher-schema-to-r2.yml
+++ b/.github/workflows/sync-grapher-schema-to-r2.yml
@@ -1,8 +1,8 @@
-name: Upload to R2
+name: Upload grapher schema to R2
 on:
   push:
     branches:
-      - master
+      - "**"
     paths:
       - "packages/@ourworldindata/grapher/src/schema/**"
       - "devTools/schema/**"
@@ -22,16 +22,19 @@ jobs:
 
       - uses: ./.github/actions/setup-node-yarn-deps
 
-      - name: Build schema artefacts
-        run: yarn buildGrapherSchema --out-dir "$RUNNER_TEMP/schemas" --latest
-
-      # Now upload all files in that folder to Cloudflare R2.
-      - name: Upload to R2
+      - name: Build and upload the schema artefacts
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
         run: |
-          aws s3 sync "$RUNNER_TEMP/schemas" s3://owid-public/schemas \
+          if [ "$GITHUB_REF_NAME" = master ]; then
+            prefix="schemas"
+            yarn buildGrapherSchema --out-dir "$RUNNER_TEMP/schemas" --latest
+          else
+            prefix="schemas/preview/$GITHUB_REF_NAME"
+            yarn buildGrapherSchema --out-dir "$RUNNER_TEMP/schemas"
+          fi
+          aws s3 sync "$RUNNER_TEMP/schemas" "s3://owid-public/$prefix" \
             --endpoint-url https://${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
 
       # The etl repo vendors this schema and its integration tests compare the vendored copy
@@ -41,6 +44,7 @@ jobs:
       # Needs a token with contents:write on owid/etl — GITHUB_TOKEN cannot dispatch across
       # repos. A failure here must not fail the upload that already succeeded.
       - name: Tell owid/etl the schema was published
+        if: github.ref_name == 'master'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.ETL_SCHEMA_SYNC_TOKEN }}

--- a/packages/@ourworldindata/grapher/src/schema/README.md
+++ b/packages/@ourworldindata/grapher/src/schema/README.md
@@ -39,14 +39,20 @@ Before merging:
 - Prepare a sibling PR in the etl repo, following the version-bump section of its
   `/sync-grapher-schema` skill. It moves `DEFAULT_GRAPHER_SCHEMA` in `etl/config.py`, updates
   the `$ref`s in the ETL's own schemas and re-vendors the schema.
+- Every push to a branch that touches this folder uploads the full JSON and the layer JSON
+  to `schemas/preview/<branch>/` on R2, without `.latest` aliases. The sibling ETL PR can pin
+  the new version against
+  `files.ourworldindata.org/schemas/preview/<branch>/grapher-schema.MMM.json` before this repo
+  publishes it.
 
 After merging:
 
-- `sync-grapher-schema-to-r2.yml` uploads the full JSON and the layer JSON to the `schemas`
-  prefix of the `owid-public` bucket on Cloudflare R2, each with a `.latest` alias.
-  The layer document is the same schema with `required` reduced to `$schema`, for configs that
-  are merged into a chart rather than rendered on their own. `files.ourworldindata.org/schemas/`
-  serves that bucket. The sync never deletes, so every version ever published keeps resolving.
+- The push to master runs `sync-grapher-schema-to-r2.yml`, which uploads the full JSON and the
+  layer JSON to the `schemas` prefix of the `owid-public` bucket on Cloudflare R2, each with a
+  `.latest` alias. The layer document is the same schema with `required` reduced to `$schema`,
+  for configs that are merged into a chart rather than rendered on their own.
+  `files.ourworldindata.org/schemas/` serves that bucket. The sync never deletes, so every
+  version ever published keeps resolving.
 - Once this repo has deployed, merge the sibling ETL PR. Never before, since the ETL pushes
   configs stamped with that version.
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @sophiamersmann at the wheel._

A push to any branch that touches the schema folder now uploads the full JSON and the layer JSON to `schemas/preview/<branch>/` on R2, without `.latest` aliases. A sibling ETL PR can pin a new version against that path before this repo publishes it. Master publishes to `schemas/` as before and stays the only branch that dispatches to owid/etl.

- The ETL has to keep stamping `$schema` with the canonical URL and only fetch its copy from the preview path. A preview URL in `$schema` does not match the version regex and, once writes validate, fails the schema's `const`.
- Branch names go into the prefix verbatim, not shortened the way staging server names are. R2 keys take slashes and the two files sit directly under the prefix, so the rule the ETL side needs is "the branch name as is".
- Nothing removes a preview when its branch is deleted. The sync never deletes and a preview is two small files, so cleanup is a follow-up if the prefix ever grows.
- Fork pushes get no preview. They run without secrets, like the rest of CI.