### PR TITLE
🔨🤖 (schema-versioning) restamp $schema in the migration runner and dispatch steps from a table

### DIFF
--- a/packages/@ourworldindata/grapher/src/schema/README.md
+++ b/packages/@ourworldindata/grapher/src/schema/README.md
@@ -30,7 +30,9 @@ In one commit:
 - Update the version in the docs that name it: `packageDocs/docs/chart-config/index.md` and
   `docs/chart-api.openapi.yaml`.
 - Add `migrateFromNNNToMMM` to `migrations/migrations.ts` and its `"NNN"` entry in
-  `MIGRATION_STEPS`. A missing entry fails typecheck.
+  `MIGRATION_STEPS`; a missing entry fails typecheck. The runner restamps `$schema`, so the
+  step does not. Pin each branch of the step with a before/after pair in
+  `migrations/migrations.fixture.ts`.
 - Write the DB migration in `db/migration/` that rewrites the stored rows and restamps
   `$schema` in `chart_configs.config` and `chart_revisions.config`. Ship the restamp and the
   rewrite together.

--- a/packages/@ourworldindata/grapher/src/schema/README.md
+++ b/packages/@ourworldindata/grapher/src/schema/README.md
@@ -29,8 +29,8 @@ In one commit:
   the version.
 - Update the version in the docs that name it: `packageDocs/docs/chart-config/index.md` and
   `docs/chart-api.openapi.yaml`.
-- Add `migrateFromNNNToMMM` to `migrations/migrations.ts` and add a case for `NNN` to the
-  match in `runMigration`. The match is exhaustive, so a missing case fails typecheck.
+- Add `migrateFromNNNToMMM` to `migrations/migrations.ts` and its `"NNN"` entry in
+  `MIGRATION_STEPS`. A missing entry fails typecheck.
 - Write the DB migration in `db/migration/` that rewrites the stored rows and restamps
   `$schema` in `chart_configs.config` and `chart_revisions.config`. Ship the restamp and the
   rewrite together.

--- a/packages/@ourworldindata/grapher/src/schema/migrations/helpers.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/helpers.ts
@@ -5,9 +5,9 @@ import {
 
 const allSchemaVersions = [...outdatedSchemaVersions, latestSchemaVersion]
 
-type LatestSchemaVersion = typeof latestSchemaVersion
-type OutdatedSchemaVersion = (typeof outdatedSchemaVersions)[number]
-type SchemaVersion = OutdatedSchemaVersion | LatestSchemaVersion
+export type LatestSchemaVersion = typeof latestSchemaVersion
+export type OutdatedSchemaVersion = (typeof outdatedSchemaVersions)[number]
+export type SchemaVersion = OutdatedSchemaVersion | LatestSchemaVersion
 
 type Schema =
     `https://files.ourworldindata.org/schemas/grapher-schema.${SchemaVersion}.json`
@@ -40,8 +40,15 @@ export function createSchemaForVersion(version: SchemaVersion): Schema {
     return `https://files.ourworldindata.org/schemas/grapher-schema.${version}.json`
 }
 
-export const isLatestVersion = (version: SchemaVersion) =>
-    version === latestSchemaVersion
+export const isLatestVersion = (
+    version: SchemaVersion
+): version is LatestSchemaVersion => version === latestSchemaVersion
+
+export function getNextSchemaVersion(
+    version: OutdatedSchemaVersion
+): SchemaVersion {
+    return allSchemaVersions[allSchemaVersions.indexOf(version) + 1]
+}
 
 export const isOutdatedVersion = (version: SchemaVersion) =>
     outdatedSchemaVersions.includes(version as any)

--- a/packages/@ourworldindata/grapher/src/schema/migrations/helpers.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/helpers.ts
@@ -5,7 +5,7 @@ import {
 
 const allSchemaVersions = [...outdatedSchemaVersions, latestSchemaVersion]
 
-export type LatestSchemaVersion = typeof latestSchemaVersion
+type LatestSchemaVersion = typeof latestSchemaVersion
 export type OutdatedSchemaVersion = (typeof outdatedSchemaVersions)[number]
 export type SchemaVersion = OutdatedSchemaVersion | LatestSchemaVersion
 
@@ -50,16 +50,10 @@ export function getNextSchemaVersion(
     return allSchemaVersions[allSchemaVersions.indexOf(version) + 1]
 }
 
-export const isOutdatedVersion = (version: SchemaVersion) =>
-    outdatedSchemaVersions.includes(version as any)
+export const isOutdatedVersion = (
+    version: SchemaVersion
+): version is OutdatedSchemaVersion => !isLatestVersion(version)
 
 export const hasValidSchema = (
     config: AnyConfig
 ): config is AnyConfigWithValidSchema => getSchemaVersion(config) !== null
-
-export const hasOutdatedSchema = (
-    config: AnyConfigWithValidSchema
-): boolean => {
-    const version = getSchemaVersion(config)
-    return isOutdatedVersion(version)
-}

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
@@ -1,9 +1,9 @@
-import { expect, it, vi } from "vitest"
+import { assert, expect, it, vi } from "vitest"
 
 import { defaultGrapherConfig } from "../defaultGrapherConfig"
 import { migrateGrapherConfigToLatestVersion } from "./migrate"
 import { runMigration } from "./migrations"
-import { getSchemaVersion } from "./helpers"
+import { getSchemaVersion, isOutdatedVersion } from "./helpers"
 import { MIGRATION_FIXTURES } from "./migrations.fixture"
 import * as _ from "lodash-es"
 
@@ -62,8 +62,13 @@ it("doesn't mutate the given config", () => {
     })
 })
 
-for (const { before, after } of MIGRATION_FIXTURES) {
-    it(`migrates ${getSchemaVersion(before)} to ${getSchemaVersion(after)}`, () => {
-        expect(runMigration(_.cloneDeep(before))).toEqual(after)
+for (const { name, before, after } of MIGRATION_FIXTURES) {
+    const from = getSchemaVersion(before)
+    const to = getSchemaVersion(after)
+    it(`migrates ${from} to ${to}: ${name}`, () => {
+        assert(isOutdatedVersion(from))
+        const migrated = _.cloneDeep(before)
+        runMigration(migrated, from)
+        expect(migrated).toStrictEqual(after)
     })
 }

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrate.test.ts
@@ -2,12 +2,9 @@ import { expect, it, vi } from "vitest"
 
 import { defaultGrapherConfig } from "../defaultGrapherConfig"
 import { migrateGrapherConfigToLatestVersion } from "./migrate"
-import {
-    migrateFrom006To007,
-    migrateFrom007To008,
-    migrateFrom010To011,
-} from "./migrations"
-import { AnyConfigWithValidSchema } from "./helpers"
+import { runMigration } from "./migrations"
+import { getSchemaVersion } from "./helpers"
+import { MIGRATION_FIXTURES } from "./migrations.fixture"
 import * as _ from "lodash-es"
 
 it("returns a valid config as is", () => {
@@ -65,102 +62,8 @@ it("doesn't mutate the given config", () => {
     })
 })
 
-// Bit of a funky test that ensures the migration function terminates.
-// Not really necessary since the tests above also fail when they encounter
-// an infinite loop, but this one provides context on what's going wrong and gives
-// guidance on what to do about it.
-it("terminates", () => {
-    const outdatedConfig = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.001.json",
-    }
-
-    try {
-        migrateGrapherConfigToLatestVersion(outdatedConfig)
-    } catch (error) {
-        if (error instanceof RangeError) {
-            expect("should terminate, but doesn't").toBe(
-                "check if the config's $schema field is updated to the next version in every migration function"
-            )
-        }
-    }
-})
-
-it("migrates version 006 to 007 correctly", () => {
-    const config: AnyConfigWithValidSchema = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
-        hasMapTab: true,
-        map: {
-            projection: "Europe",
-            time: 2000,
-        },
-    }
-
-    // check that the $schema field is updated
-    expect(migrateFrom006To007(config)).toHaveProperty(
-        "$schema",
-        "https://files.ourworldindata.org/schemas/grapher-schema.007.json"
-    )
-
-    // check that the map.projection field is removed
-    expect(migrateFrom006To007(config)).not.toHaveProperty("map.projection")
-
-    // check that the map.region field is added
-    expect(migrateFrom006To007(config)).toHaveProperty("map.region", "Europe")
-})
-
-it("migrates version 007 to 008 correctly", () => {
-    const config: AnyConfigWithValidSchema = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.007.json",
-        hasMapTab: true,
-        map: {
-            colorScale: {
-                customNumericMinValue: 0,
-                customNumericValues: [1, 2, 3],
-            },
-        },
-    }
-
-    const migrated = migrateFrom007To008(config)
-
-    // check that the $schema field is updated
-    expect(migrated).toHaveProperty(
-        "$schema",
-        "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
-    )
-
-    expect(migrated).not.toHaveProperty("map.colorScale.customNumericMinValue")
-    expect(migrated).toHaveProperty(
-        "map.colorScale.customNumericValues",
-        [0, 1, 2, 3]
-    )
-})
-
-it("migrates version 010 to 011 correctly", () => {
-    const config: AnyConfigWithValidSchema = {
-        $schema:
-            "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
-        dimensions: [
-            { property: "y", variableId: 1, display: { yearIsDay: true } },
-            { property: "y", variableId: 2, display: { yearIsDay: false } },
-            { property: "y", variableId: 3, display: { unit: "%" } },
-        ],
-    }
-
-    const migrated = migrateFrom010To011(config)
-
-    // check that the $schema field is updated
-    expect(migrated).toHaveProperty(
-        "$schema",
-        "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
-    )
-
-    // yearIsDay: true becomes timeInterval: "day"
-    expect(migrated.dimensions[0].display).toEqual({ timeInterval: "day" })
-    // yearIsDay: false is just dropped (year is the default)
-    expect(migrated.dimensions[1].display).toEqual({})
-    // dimensions without yearIsDay are untouched
-    expect(migrated.dimensions[2].display).toEqual({ unit: "%" })
-})
+for (const { before, after } of MIGRATION_FIXTURES) {
+    it(`migrates ${getSchemaVersion(before)} to ${getSchemaVersion(after)}`, () => {
+        expect(runMigration(_.cloneDeep(before))).toEqual(after)
+    })
+}

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrate.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrate.ts
@@ -2,7 +2,12 @@ import * as _ from "lodash-es"
 import { GrapherInterface } from "@ourworldindata/types"
 
 import { defaultGrapherConfig } from "../defaultGrapherConfig"
-import { hasValidSchema, hasOutdatedSchema, type AnyConfig } from "./helpers"
+import {
+    hasValidSchema,
+    getSchemaVersion,
+    isOutdatedVersion,
+    type AnyConfig,
+} from "./helpers"
 import { runMigration } from "./migrations"
 import * as Sentry from "@sentry/browser"
 
@@ -20,10 +25,12 @@ export const migrateGrapherConfigToLatestVersion = (
 ): GrapherInterface => {
     if (config.$schema === undefined) throw new Error("Schema missing")
 
-    const migrated = _.cloneDeep(config)
-    if (hasValidSchema(migrated)) {
-        while (hasOutdatedSchema(migrated)) runMigration(migrated)
-        return migrated
+    const clone = _.cloneDeep(config)
+    if (hasValidSchema(clone)) {
+        let version = getSchemaVersion(clone)
+        while (isOutdatedVersion(version))
+            version = runMigration(clone, version)
+        return clone
     }
 
     /**
@@ -38,7 +45,7 @@ export const migrateGrapherConfigToLatestVersion = (
     console.warn(message)
     Sentry.captureMessage(message, { level: "warning" })
 
-    return migrated
+    return clone
 }
 
 export const migrateGrapherConfigToLatestVersionAndFailOnError = (

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrate.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrate.ts
@@ -2,27 +2,9 @@ import * as _ from "lodash-es"
 import { GrapherInterface } from "@ourworldindata/types"
 
 import { defaultGrapherConfig } from "../defaultGrapherConfig"
-import {
-    getSchemaVersion,
-    hasValidSchema,
-    isLatestVersion,
-    hasOutdatedSchema,
-    type AnyConfig,
-    type AnyConfigWithValidSchema,
-} from "./helpers"
+import { hasValidSchema, hasOutdatedSchema, type AnyConfig } from "./helpers"
 import { runMigration } from "./migrations"
 import * as Sentry from "@sentry/browser"
-
-const recursivelyApplyMigrations = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
-    const version = getSchemaVersion(config)
-    if (isLatestVersion(version)) return config
-    return recursivelyApplyMigrations(runMigration(config))
-}
-
-const migrate = (config: AnyConfigWithValidSchema): GrapherInterface =>
-    recursivelyApplyMigrations(config)
 
 /**
  * Attempts to migrate a config to the latest schema version.
@@ -36,33 +18,27 @@ const migrate = (config: AnyConfigWithValidSchema): GrapherInterface =>
 export const migrateGrapherConfigToLatestVersion = (
     config: AnyConfig
 ): GrapherInterface => {
-    // the config adheres to the latest schema
-    if (config.$schema === defaultGrapherConfig.$schema) return config
+    if (config.$schema === undefined) throw new Error("Schema missing")
 
-    // if the schema version is outdated, migrate it
-    if (hasValidSchema(config) && hasOutdatedSchema(config)) {
-        return migrate(_.cloneDeep(config))
+    const migrated = _.cloneDeep(config)
+    if (hasValidSchema(migrated)) {
+        while (hasOutdatedSchema(migrated)) runMigration(migrated)
+        return migrated
     }
 
-    // throw if the schema is missing
-    if (config.$schema === undefined) {
-        throw new Error("Schema missing")
-    } else {
-        /**
-         * If the schema version is not outdated and not the latest, we have most likely received a
-         * config from a future version of the codebase, that the client code is not yet aware of.
-         * That's not perfect, but in reality, most schema changes are benign changes,
-         * and rendering the config with the current code will result in a better user experience
-         * than just throwing an error and grapher not rendering at all without any explanation.
-         * - @marcelgerber, 2025-07-02
-         */
-        const message = `Received grapher config with unsupported schema ${config.$schema}; this code expects schema ${defaultGrapherConfig.$schema}.`
-        console.warn(message)
-        Sentry.captureMessage(message, {
-            level: "warning",
-        })
-        return config
-    }
+    /**
+     * If the schema version is not outdated and not the latest, we have most likely received a
+     * config from a future version of the codebase, that the client code is not yet aware of.
+     * That's not perfect, but in reality, most schema changes are benign changes,
+     * and rendering the config with the current code will result in a better user experience
+     * than just throwing an error and grapher not rendering at all without any explanation.
+     * - @marcelgerber, 2025-07-02
+     */
+    const message = `Received grapher config with unsupported schema ${config.$schema}; this code expects schema ${defaultGrapherConfig.$schema}.`
+    console.warn(message)
+    Sentry.captureMessage(message, { level: "warning" })
+
+    return migrated
 }
 
 export const migrateGrapherConfigToLatestVersionAndFailOnError = (

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.fixture.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.fixture.ts
@@ -2,10 +2,12 @@ import { AnyConfigWithValidSchema } from "./helpers"
 
 /** Before/after pairs pinning what each migration step rewrites */
 export const MIGRATION_FIXTURES: {
+    name: string
     before: AnyConfigWithValidSchema
     after: AnyConfigWithValidSchema
 }[] = [
     {
+        name: "drops selectedData",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.001.json",
@@ -19,6 +21,7 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "expands hideTitleAnnotation into hideTitleAnnotations",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.002.json",
@@ -31,6 +34,19 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "drops a false hideTitleAnnotation",
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.002.json",
+            hideTitleAnnotation: false,
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.003.json",
+        },
+    },
+    {
+        name: "drops data",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.003.json",
@@ -42,6 +58,7 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "drops hideLinesOutsideTolerance",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.004.json",
@@ -53,6 +70,7 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "turns a non-line type into chartTypes",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
@@ -66,6 +84,33 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "turns a hidden chart tab into empty chartTypes",
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+            type: "ScatterPlot",
+            hasChartTab: false,
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
+            chartTypes: [],
+        },
+    },
+    {
+        name: "leaves the default line chart without chartTypes",
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+            type: "LineChart",
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
+        },
+    },
+    {
+        name: "renames map.projection to map.region",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
@@ -86,6 +131,7 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "folds map.colorScale.customNumericMinValue into customNumericValues",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.007.json",
@@ -109,6 +155,25 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "folds colorScale.customNumericMinValue into customNumericValues",
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.007.json",
+            colorScale: {
+                customNumericMinValue: 10,
+                customNumericValues: [20, 30],
+            },
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
+            colorScale: {
+                customNumericValues: [10, 20, 30],
+            },
+        },
+    },
+    {
+        name: "resets non-manual binningStrategy to auto and drops the bin count",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
@@ -137,6 +202,7 @@ export const MIGRATION_FIXTURES: {
         },
     },
     {
+        name: "replaces yearIsDay with timeInterval",
         before: {
             $schema:
                 "https://files.ourworldindata.org/schemas/grapher-schema.010.json",

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.fixture.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.fixture.ts
@@ -1,0 +1,171 @@
+import { AnyConfigWithValidSchema } from "./helpers"
+
+/** Before/after pairs pinning what each migration step rewrites */
+export const MIGRATION_FIXTURES: {
+    before: AnyConfigWithValidSchema
+    after: AnyConfigWithValidSchema
+}[] = [
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.001.json",
+            selectedData: [{ index: 0, entityId: 1 }],
+            title: "Test",
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.002.json",
+            title: "Test",
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.002.json",
+            hideTitleAnnotation: true,
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.003.json",
+            hideTitleAnnotations: { entity: true, time: true, change: true },
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.003.json",
+            data: { availableEntities: [] },
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.004.json",
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.004.json",
+            hideLinesOutsideTolerance: true,
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+            type: "ScatterPlot",
+            hasChartTab: true,
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
+            chartTypes: ["ScatterPlot"],
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
+            hasMapTab: true,
+            map: {
+                projection: "Europe",
+                time: 2000,
+            },
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.007.json",
+            hasMapTab: true,
+            map: {
+                region: "Europe",
+                time: 2000,
+            },
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.007.json",
+            hasMapTab: true,
+            map: {
+                colorScale: {
+                    customNumericMinValue: 0,
+                    customNumericValues: [1, 2, 3],
+                },
+            },
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
+            hasMapTab: true,
+            map: {
+                colorScale: {
+                    customNumericValues: [0, 1, 2, 3],
+                },
+            },
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.008.json",
+            map: {
+                colorScale: {
+                    binningStrategy: "ckmeans",
+                    binningStrategyBinCount: 5,
+                },
+            },
+            colorScale: {
+                binningStrategy: "manual",
+                binningStrategyBinCount: 3,
+            },
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.009.json",
+            map: {
+                colorScale: {
+                    binningStrategy: "auto",
+                },
+            },
+            colorScale: {
+                binningStrategy: "manual",
+            },
+        },
+    },
+    {
+        before: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+            dimensions: [
+                {
+                    property: "y",
+                    variableId: 1,
+                    display: { yearIsDay: true },
+                },
+                {
+                    property: "y",
+                    variableId: 2,
+                    display: { yearIsDay: false },
+                },
+                { property: "y", variableId: 3, display: { unit: "%" } },
+            ],
+        },
+        after: {
+            $schema:
+                "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
+            dimensions: [
+                {
+                    property: "y",
+                    variableId: 1,
+                    display: { timeInterval: "day" },
+                },
+                { property: "y", variableId: 2, display: {} },
+                { property: "y", variableId: 3, display: { unit: "%" } },
+            ],
+        },
+    },
+]

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
@@ -1,20 +1,18 @@
 // Schema migrations
 //
 // To add a migration: write `migrateFromNNNToMMM`, which rewrites a config's content from
-// version NNN to NNN+1 and nothing else, then add its `"NNN"` entry to `MIGRATION_STEPS`.
-// `runMigration` restamps `$schema`, so a step does not.
+// version NNN to MMM and nothing else, then add its `"NNN"` entry to `MIGRATION_STEPS`.
 
 import {
     type AnyConfigWithValidSchema,
     createSchemaForVersion,
-    getSchemaVersion,
-    isLatestVersion,
     getNextSchemaVersion,
     type OutdatedSchemaVersion,
+    type SchemaVersion,
 } from "./helpers"
 import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
-export type MigrationStep = (config: AnyConfigWithValidSchema) => void
+type MigrationStep = (config: AnyConfigWithValidSchema) => void
 
 // see https://github.com/owid/owid-grapher/commit/26f2a0d1790c71bdda7e12f284ca552945d2f6ef
 const migrateFrom001To002 = (config: AnyConfigWithValidSchema): void => {
@@ -140,14 +138,13 @@ const MIGRATION_STEPS: Record<OutdatedSchemaVersion, MigrationStep> = {
     "010": migrateFrom010To011,
 }
 
+/** Applies the step for `version`, restamps `$schema` and returns the new version */
 export const runMigration = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
-    const version = getSchemaVersion(config)
-    if (isLatestVersion(version)) return config
-
-    const migrateToNextVersion = MIGRATION_STEPS[version]
-    migrateToNextVersion(config)
-    config.$schema = createSchemaForVersion(getNextSchemaVersion(version))
-    return config
+    config: AnyConfigWithValidSchema,
+    version: OutdatedSchemaVersion
+): SchemaVersion => {
+    MIGRATION_STEPS[version](config)
+    const nextVersion = getNextSchemaVersion(version)
+    config.$schema = createSchemaForVersion(nextVersion)
+    return nextVersion
 }

--- a/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
+++ b/packages/@ourworldindata/grapher/src/schema/migrations/migrations.ts
@@ -1,35 +1,28 @@
 // Schema migrations
 //
-// Every breaking change to the schema should be accompanied by a migration.
-//
-// To add a migration, follow these steps:
-//    - Create a new function `migrateXXXToXXX` that migrates a config from one version to the next.
-//      Make sure to update the $schema field to the next version in your migration function,
-//      or else the recursively defined migrate function will not terminate!
-//    - Add a new case to the match statement in `runMigration` that calls the new migration function.
+// To add a migration: write `migrateFromNNNToMMM`, which rewrites a config's content from
+// version NNN to NNN+1 and nothing else, then add its `"NNN"` entry to `MIGRATION_STEPS`.
+// `runMigration` restamps `$schema`, so a step does not.
 
-import { match } from "ts-pattern"
 import {
     type AnyConfigWithValidSchema,
     createSchemaForVersion,
     getSchemaVersion,
     isLatestVersion,
+    getNextSchemaVersion,
+    type OutdatedSchemaVersion,
 } from "./helpers"
 import { GRAPHER_CHART_TYPES } from "@ourworldindata/types"
 
+export type MigrationStep = (config: AnyConfigWithValidSchema) => void
+
 // see https://github.com/owid/owid-grapher/commit/26f2a0d1790c71bdda7e12f284ca552945d2f6ef
-const migrateFrom001To002 = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
+const migrateFrom001To002 = (config: AnyConfigWithValidSchema): void => {
     delete config.selectedData
-    config.$schema = createSchemaForVersion("002")
-    return config
 }
 
 // see https://github.com/owid/owid-grapher/commit/4525ad81fb7064709ffab83677a8b0354b324dfb
-const migrateFrom002To003 = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
+const migrateFrom002To003 = (config: AnyConfigWithValidSchema): void => {
     if (config.hideTitleAnnotation) {
         config.hideTitleAnnotations = {
             entity: true,
@@ -38,32 +31,19 @@ const migrateFrom002To003 = (
         }
     }
     delete config.hideTitleAnnotation
-
-    config.$schema = createSchemaForVersion("003")
-    return config
 }
 
 // see https://github.com/owid/owid-grapher/commit/1776721253cf61d7f1e24ebadeaf7a7ca2f43ced
-const migrateFrom003To004 = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
+const migrateFrom003To004 = (config: AnyConfigWithValidSchema): void => {
     delete config.data
-    config.$schema = createSchemaForVersion("004")
-    return config
 }
 
 // see https://github.com/owid/owid-grapher/commit/1d67de3174764a413bc5055fbdf34efb2b49e079
-const migrateFrom004To005 = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
+const migrateFrom004To005 = (config: AnyConfigWithValidSchema): void => {
     delete config.hideLinesOutsideTolerance
-    config.$schema = createSchemaForVersion("005")
-    return config
 }
 
-const migrateFrom005To006 = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
+const migrateFrom005To006 = (config: AnyConfigWithValidSchema): void => {
     const { type = GRAPHER_CHART_TYPES.LineChart, hasChartTab = true } = config
 
     // add types field
@@ -73,27 +53,17 @@ const migrateFrom005To006 = (
     // remove deprecated fields
     delete config.type
     delete config.hasChartTab
-
-    config.$schema = createSchemaForVersion("006")
-    return config
 }
 
-export const migrateFrom006To007 = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
+const migrateFrom006To007 = (config: AnyConfigWithValidSchema): void => {
     // rename map.projection to map.region
     if (config.map?.projection) {
         config.map.region = config.map.projection
         delete config.map.projection
     }
-
-    config.$schema = createSchemaForVersion("007")
-    return config
 }
 
-export const migrateFrom007To008 = (
-    config: AnyConfigWithValidSchema
-): AnyConfigWithValidSchema => {
+const migrateFrom007To008 = (config: AnyConfigWithValidSchema): void => {
     // remove colorScale.customNumericMinValue, merge it into colorScale.customNumericValues
     if (config.map?.colorScale?.customNumericValues) {
         config.map.colorScale.customNumericValues = [
@@ -114,12 +84,9 @@ export const migrateFrom007To008 = (
     if (config.colorScale?.customNumericMinValue !== undefined) {
         delete config.colorScale.customNumericMinValue
     }
-
-    config.$schema = createSchemaForVersion("008")
-    return config
 }
 
-export const migrateFrom008To009 = (config: AnyConfigWithValidSchema) => {
+const migrateFrom008To009 = (config: AnyConfigWithValidSchema): void => {
     if ((config.map?.colorScale?.binningStrategy ?? "manual") !== "manual") {
         config.map.colorScale.binningStrategy = "auto"
     }
@@ -135,23 +102,17 @@ export const migrateFrom008To009 = (config: AnyConfigWithValidSchema) => {
     if (config.colorScale?.binningStrategyBinCount !== undefined) {
         delete config.colorScale.binningStrategyBinCount
     }
-
-    config.$schema = createSchemaForVersion("009")
-    return config
 }
 
-export const migrateFrom009To010 = (config: AnyConfigWithValidSchema) => {
+const migrateFrom009To010 = (config: AnyConfigWithValidSchema): void => {
     // Rename hideLegend to hideSeriesLabels
     if (config.hideLegend) {
         config.hideSeriesLabels = true
         delete config.hideLegend
     }
-
-    config.$schema = createSchemaForVersion("010")
-    return config
 }
 
-export const migrateFrom010To011 = (config: AnyConfigWithValidSchema) => {
+const migrateFrom010To011 = (config: AnyConfigWithValidSchema): void => {
     // Drop the deprecated yearIsDay flag in favor of timeInterval
     for (const dimension of config.dimensions ?? []) {
         const display = dimension.display
@@ -164,9 +125,19 @@ export const migrateFrom010To011 = (config: AnyConfigWithValidSchema) => {
             display.timeInterval = "day"
         delete display.yearIsDay
     }
+}
 
-    config.$schema = createSchemaForVersion("011")
-    return config
+const MIGRATION_STEPS: Record<OutdatedSchemaVersion, MigrationStep> = {
+    "001": migrateFrom001To002,
+    "002": migrateFrom002To003,
+    "003": migrateFrom003To004,
+    "004": migrateFrom004To005,
+    "005": migrateFrom005To006,
+    "006": migrateFrom006To007,
+    "007": migrateFrom007To008,
+    "008": migrateFrom008To009,
+    "009": migrateFrom009To010,
+    "010": migrateFrom010To011,
 }
 
 export const runMigration = (
@@ -174,16 +145,9 @@ export const runMigration = (
 ): AnyConfigWithValidSchema => {
     const version = getSchemaVersion(config)
     if (isLatestVersion(version)) return config
-    return match(version)
-        .with("001", () => migrateFrom001To002(config))
-        .with("002", () => migrateFrom002To003(config))
-        .with("003", () => migrateFrom003To004(config))
-        .with("004", () => migrateFrom004To005(config))
-        .with("005", () => migrateFrom005To006(config))
-        .with("006", () => migrateFrom006To007(config))
-        .with("007", () => migrateFrom007To008(config))
-        .with("008", () => migrateFrom008To009(config))
-        .with("009", () => migrateFrom009To010(config))
-        .with("010", () => migrateFrom010To011(config))
-        .exhaustive()
+
+    const migrateToNextVersion = MIGRATION_STEPS[version]
+    migrateToNextVersion(config)
+    config.$schema = createSchemaForVersion(getNextSchemaVersion(version))
+    return config
 }


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @sophiamersmann at the wheel._

A migration step now rewrites a config's content from N to N+1 and nothing else. The runner looks the step up in a table keyed by the version it reads and restamps `$schema` itself, so a step that forgot to restamp can no longer loop forever. The table is a `Record` over the generated outdated-version union, so a bump that forgets its entry still fails typecheck, and the exhaustiveness no longer rides on TypeScript inferring a type predicate for `isLatestVersion`.

- **Behaviour change.** `migrateGrapherConfigToLatestVersion` returns a deep clone on every path. Before, a config already on the latest version, or on an unknown one, came back as the very object passed in. No caller relied on the identity.
- The step tests are one table of before/after pairs. There is no 009→010 pair on purpose. That step disagrees with the SQL migration that ran on production, which applied a chart-type condition and deleted `hideLegend` only when true. A later PR fixes the step, with its fixtures landing red first.