### PR TITLE
Fix the silently broken owid/etl schema dispatch

### DIFF
--- a/.github/workflows/sync-grapher-schema-to-r2.yml
+++ b/.github/workflows/sync-grapher-schema-to-r2.yml
@@ -39,15 +39,22 @@ jobs:
       # fails on a change made here. Telling etl the moment we publish gets its sync PR opened
       # in minutes; it also polls daily, but that left a Friday publish red until Monday.
       # Needs a token with contents:write on owid/etl — GITHUB_TOKEN cannot dispatch across
-      # repos. A failure here must not fail the upload that already succeeded.
+      # repos. A missing token is a misconfiguration and must fail loudly; a dispatch that
+      # merely doesn't land is covered by etl's daily poll and must not fail an upload that
+      # already succeeded.
       - name: Tell owid/etl the schema was published
-        continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.ETL_SCHEMA_SYNC_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_OWIDBOT_ACCESS_TOKEN }}
         run: |
-          gh api repos/owid/etl/dispatches --input - <<EOF
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::GH_OWIDBOT_ACCESS_TOKEN is missing — etl cannot be notified"
+            exit 1
+          fi
+          cat > "$RUNNER_TEMP/dispatch.json" <<EOF
           {
             "event_type": "grapher-schema-published",
             "client_payload": { "commit": "$GITHUB_SHA" }
           }
           EOF
+          gh api repos/owid/etl/dispatches --input "$RUNNER_TEMP/dispatch.json" \
+            || echo "::warning::dispatching owid/etl failed; its daily poll will catch up"


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @Marigold at the wheel._

The "Tell owid/etl the schema was published" step added in #7037 has never worked. It reads `secrets.ETL_SCHEMA_SYNC_TOKEN`, which was never created — the commit body flagged it as a prerequisite and it was never done — so `GH_TOKEN` expanded to an empty string and `gh` refused to run. `continue-on-error: true` then rewrote the step's conclusion to `success`, so [every run since](https://github.com/owid/owid-grapher/actions/runs/33866049277/job/101001045151) has been fully green while etl was never notified and quietly fell back on its daily poll.

Two changes:

- Use the existing `GH_OWIDBOT_ACCESS_TOKEN` instead. owidbot has `write` on `owid/etl` and the secret is already used by `update-regions.yml`, so there's no new secret and no second PAT expiry to keep track of.
- Replace the blanket `continue-on-error` with a split: a missing token is a misconfiguration and fails the job; a dispatch that doesn't land only emits a `::warning::`, because etl's daily poll covers it and the R2 upload has already succeeded by that point.

An expired-token 401 still only warns. Making that loud too would mean dropping the `||` — happy to, since `aws s3 sync` is idempotent and a re-run costs nothing, but it seemed like more noise than it's worth.

<details><summary>Details</summary>

**The heredoc change.** The payload now goes to `$RUNNER_TEMP/dispatch.json` instead of `gh api --input -`. Writing `gh api --input - <<EOF ||` + a continuation line leaves it genuinely ambiguous where the heredoc body starts, since the newline after `||` is a line continuation rather than the NEWLINE token that begins heredoc collection. A temp file sidesteps it.

**Verification.** The workflow's `run:` block was extracted with a YAML parser and exercised under `bash -e` against a stub `gh` on `PATH`:

| case | result |
| --- | --- |
| `GH_TOKEN=""` | `::error::…is missing` , exit 1 |
| token set, `gh` exits 0 | `gh api repos/owid/etl/dispatches --input …/dispatch.json`, payload parses as `{"event_type": "grapher-schema-published", "client_payload": {"commit": "deadbeef"}}`, exit 0 |
| token set, `gh` exits 1 | `::warning::dispatching owid/etl failed…`, exit 0 |

`owidbot`'s permission was confirmed via `gh api repos/owid/etl/collaborators/owidbot/permission` → `{"permission": "write", "user": "owidbot"}`. `repository_dispatch` requires `contents: write`.

**Not verified end-to-end.** The workflow only fires on pushes touching `packages/@ourworldindata/grapher/src/schema/**` or `devTools/schema/**` (plus `workflow_dispatch`), so the real dispatch won't be exercised until this lands on master and a schema change follows. Worth a manual `workflow_dispatch` run after merge to confirm etl actually receives it.

</details>
