### PR TITLE
🐛 Stop fuzzy-matching search synonyms against country names

### DIFF
--- a/site/search/searchUtils.test.ts
+++ b/site/search/searchUtils.test.ts
@@ -159,6 +159,34 @@ describe("Fuzzy search in search autocomplete", () => {
             expect(countryResults[0].name).toBe("United States")
         })
 
+        it("should not fuzzy-match synonyms against country names", () => {
+            const synonymMapWithTopicSynonyms: SynonymMap = new Map([
+                ["population", ["people"]],
+                ["price", ["cost"]],
+                ["united nations", ["un"]],
+            ])
+
+            const countryNamesFor = (words: string[]) =>
+                findTopicAndRegionFilters(
+                    words,
+                    regions,
+                    mockTopics,
+                    new Set(),
+                    new Set(),
+                    synonymMapWithTopicSynonyms,
+                    sortOptionsMultiple
+                )
+                    .filter((f) => f.type === FilterType.COUNTRY)
+                    .map((f) => f.name)
+
+            // "people" fuzzy-matches "Yemen People's Republic", "cost" matches
+            // "Costa Rica" and "un" matches "United States" -- none of them
+            // should surface via the synonym.
+            expect(countryNamesFor(["population"])).toEqual([])
+            expect(countryNamesFor(["price"])).toEqual([])
+            expect(countryNamesFor(["united", "nations"])).toEqual([])
+        })
+
         it("should filter out already selected countries and topics", () => {
             const selectedCountries = new Set(["United States"])
             const selectedTopics = new Set(["Artificial Intelligence"])

--- a/site/search/searchUtils.tsx
+++ b/site/search/searchUtils.tsx
@@ -470,11 +470,23 @@ export function findTopicAndRegionFilters(
 ): ScoredFilter[] {
     const searchTerm = words.join(" ")
 
-    const searchCountryTopics = (term: string) => {
+    // A synonym is a rewrite of the query, not a typo of it, so it may only
+    // name a country exactly. Fuzzy matching a synonym against country names
+    // compounds two approximations and produces suggestions like
+    // "population" -> "people" -> "Yemen People's Republic" or
+    // "price" -> "cost" -> "Costa Rica". Country aliases in the synonym map
+    // ("us" -> "united states") are exact by construction, so they still
+    // match. Topics keep fuzzy matching on synonyms: their synonym groups
+    // exist to widen the net ("carbon dioxide" -> "co2" -> "CO2 & Greenhouse
+    // Gas Emissions").
+    const searchCountryTopics = (
+        term: string,
+        { isSynonym }: { isSynonym: boolean }
+    ) => {
         const countryFilters: ScoredFilter[] = FuzzySearch.withKey(
             allRegionsNames,
             _.identity,
-            sortOptions
+            isSynonym ? { ...sortOptions, threshold: 1 } : sortOptions
         )
             .searchResults(term)
             .filter(
@@ -500,7 +512,7 @@ export function findTopicAndRegionFilters(
     }
 
     // 1. Perform original search
-    let filters = searchCountryTopics(searchTerm)
+    let filters = searchCountryTopics(searchTerm, { isSynonym: false })
 
     // 2. Search with synonyms
     const synonyms = synonymMap.get(searchTerm.toLowerCase())
@@ -508,7 +520,9 @@ export function findTopicAndRegionFilters(
     if (synonyms && synonyms.length > 0) {
         // Search with each synonym and combine results
         for (const synonym of synonyms) {
-            const filtersFromSynonym = searchCountryTopics(synonym)
+            const filtersFromSynonym = searchCountryTopics(synonym, {
+                isSynonym: true,
+            })
             filters.push(...filtersFromSynonym)
         }
     }


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @Marigold at the wheel._

Searching for `population` on the site shows **"Did you mean? Yemen People's Republic"**. The query expands to its Algolia synonym `people`, which then fuzzy-matches the country name. Synonyms are rewrites of the query, not typos of it, so a synonym now has to name a country *exactly*; the typed term keeps fuzzy matching, and topics keep fuzzy matching on synonyms. Only the country half of the synonym pass changes.

_Skim: one threshold flip in `findTopicAndRegionFilters` plus a regression test. The examples below are the review._

## Examples

Every synonym in the current map that fuzzy-matched a country the typed term wouldn't. All of them go away, and the "searches affected" column is how often that suggestion was on screen (GA4 site searches, 1 Jun – 3 Sep 2026, bots excluded):

| typed | synonym | suggested before | after | searches affected |
| --- | --- | --- | --- | --- |
| `population` | people | Yemen People's Republic | nothing (topic "Population Growth" still suggested) | 21,838 |
| `price`, `prices`, `pricing`, `costs` | cost | Costa Rica | nothing | 2,655 |
| `united nations`, `onu` | un | United States | nothing | 6 |

The autocomplete dropdown asks for up to 3 country matches rather than 1, so two more synonym groups change there: `us`/`usa` stop *also* offering **United States Virgin Islands**, and `united nations`/`onu` stop offering **United Kingdom** and **United Arab Emirates**. Together, 1,885 searches' worth of dropdown suggestions change — all of them removals.

Everything that should keep working does, because legitimate country aliases score exactly 1.0 by construction:

| typed | synonym | suggested |
| --- | --- | --- |
| `us` | united states | United States |
| `uk` | united kingdom | United Kingdom |
| `ivory coast` | côte d'ivoire | Cote d'Ivoire (fuzzysort scores the accent-stripped match 1.0) |
| `cabo verde` | cape verde | Cape Verde |
| `carbon dioxide` | co2 | topic "CO2 & Greenhouse Gas Emissions" (topics unchanged) |

## Impact

Before this change, **11.9% of text searches showed a "Did you mean?" country pill; after, 6.7%** — i.e. 44% of everything that surface ever showed was one of the artifacts above, and `population` alone accounts for 21,838 searches per quarter.

## No regressions

- **Exhaustive audit of the synonym map** — all 576 keys, at both surfaces' limits. 9 keys change; every change is the removal of one of the countries listed above. Nothing is added anywhere, and no legitimate alias stops matching, which confirms the "aliases score exactly 1.0" argument empirically rather than by construction.
- **Replay over real traffic** — 132,261 distinct search queries (439,322 searches, same window) through both code paths, on master and on this branch. Zero suggestions gained on either surface, and the text left in the search box after clicking a suggestion (`unmatchedQuery`) is byte-identical for every query, so the dropdown's suffix loop is unaffected.
- **Topic suggestions are untouched** in every one of the above, as intended.

## Rejected alternatives

- **Filter "Did you mean?" to current countries only.** Kills this one case but not `price` → Costa Rica, and a real typo of a historical name should still work.
- **Drop the `people` ↔ `population` synonym.** It's correct for Algolia's full-text ranking; the bug is in reusing it for fuzzy country detection.
- **Exact-only for topic synonyms too.** Breaks `carbon dioxide` → CO2 topic, which the existing test asserts.

## Verified

- The new test fails on master (`expected [ 'Yemen People\'s Republic' ] to deeply equal []`) and passes with the fix.
- The tables and counts above come from replaying the real `buildSynonymMap()`, `listedRegionsNames()` and the live topic tag graph through `findTopicAndRegionFilters`, `extractFiltersFromQuery` and `suggestFiltersFromQuerySuffix` before and after, with production arguments.
- Not verified in a browser; the change has no UI surface beyond the suggestion disappearing.

## Aside: this surface has no analytics

`SearchDetectedFilters` fires no event — the "Did you mean?" button is a bare `onClick` — which is why the numbers above needed a code replay rather than a query, and why the bug was invisible in the data. The tracked autocomplete dropdown drops historical entities, so *Yemen People's Republic* could never appear there. *Costa Rica* does leak in: it was on screen for 420 of the 581 autocomplete clicks made on a `price*` query last quarter and was clicked exactly **once** — a 0.2% take-rate against 35.5% for country suggestions overall. Worth a follow-up issue to log clicks (and ideally impressions) on both surfaces.
