### PR TITLE
Clarify the PointVector magnitude contract

### DIFF
--- a/packages/@ourworldindata/utils/src/PointVector.test.ts
+++ b/packages/@ourworldindata/utils/src/PointVector.test.ts
@@ -2,7 +2,9 @@ import { expect, it } from "vitest"
 
 import { PointVector } from "./PointVector.js"
 
-it("can report the center", () => {
+// Geometry calculations rely on magnitude preserving Euclidean distance. A
+// 6-8-10 triangle makes both coordinates' contribution easy to verify.
+it("computes the Euclidean magnitude from both coordinates", () => {
     const point = new PointVector(6, 8)
-    expect(point.magnitude).toEqual(10)
+    expect(point.magnitude).toBe(10)
 })


### PR DESCRIPTION
> _Written by OpenAI GPT-5 — @danyx23 at the wheel._

Clarifies the sole PointVector test so a reviewer can see the geometric contract it protects. The previous name referred to a “center” even though the assertion exercises Euclidean magnitude.

<details><summary>Details</summary>

- Adds a terse rationale for the 6–8–10 fixture.
- Renames the test around its observable result.
- Uses the stricter primitive equality matcher.
- Keeps the existing unit-test boundary and scenario.

Checks: `yarn test run packages/@ourworldindata/utils/src/PointVector.test.ts --reporter dot`, `yarn typecheck`, `yarn testLintChanged`, `yarn fixFormatChanged`.

</details>
