### PR TITLE
Explain equal-size binning invariants

### DIFF
--- a/packages/@ourworldindata/grapher/src/color/BinningStrategyEqualSizeBins.test.ts
+++ b/packages/@ourworldindata/grapher/src/color/BinningStrategyEqualSizeBins.test.ts
@@ -1,377 +1,314 @@
+import type { EqualSizeBinningStrategy } from "@ourworldindata/types"
 import { describe, expect, it } from "vitest"
 import {
     createEqualSizeBins,
     runEqualSizeBinningStrategy,
 } from "./BinningStrategyEqualSizeBins.js"
 
+function expectBinsCoverRange(
+    bins: number[],
+    minValue: number,
+    maxValue: number
+): void {
+    expect(
+        bins[0],
+        "first edge should include the minimum"
+    ).toBeLessThanOrEqual(minValue)
+    expect(
+        bins.at(-1),
+        "last edge should include the maximum"
+    ).toBeGreaterThanOrEqual(maxValue)
+}
+
+function runStrategy({
+    strategy,
+    minValue,
+    maxValue,
+    hasMidpoint = false,
+}: {
+    strategy: EqualSizeBinningStrategy
+    minValue: number
+    maxValue: number
+    hasMidpoint?: boolean
+}): number[] {
+    return runEqualSizeBinningStrategy(
+        {
+            strategy,
+            minValue,
+            maxValue,
+            sortedValues: [],
+            midpointMode: "none",
+            midpoint: 0,
+        },
+        { hasMidpoint }
+    )
+}
+
 describe(runEqualSizeBinningStrategy, () => {
-    describe("few-bins strategy", () => {
-        it("should create 2-5 bins when hasMidpoint is false", () => {
-            const bins = runEqualSizeBinningStrategy({
+    // Strategy names express a desired density rather than an exact count.
+    // These cases protect each density band and the deliberate reduction made
+    // when a midpoint may cause the final bin set to be mirrored.
+    describe("strategy density", () => {
+        const cases: {
+            label: string
+            strategy: EqualSizeBinningStrategy
+            minValue: number
+            maxValue: number
+            hasMidpoint?: boolean
+            expectedBinCount: readonly [number, number]
+        }[] = [
+            {
+                label: "few bins",
                 strategy: "equalSizeBins-few-bins",
                 minValue: 0,
                 maxValue: 10,
-                sortedValues: [],
-                midpointMode: "none",
-                midpoint: 0,
-            })
-            expect(bins.length).toBeGreaterThanOrEqual(3) // 2 bins = 3 bin edges
-            expect(bins.length).toBeLessThanOrEqual(6) // 5 bins = 6 bin edges
-            expect(bins[0]).toBe(0)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(10)
-        })
-
-        it("should create 1-3 bins when hasMidpoint is true", () => {
-            const bins = runEqualSizeBinningStrategy(
-                {
-                    strategy: "equalSizeBins-few-bins",
-                    minValue: 0,
-                    maxValue: 10,
-                    sortedValues: [],
-                    midpointMode: "none",
-                    midpoint: 0,
-                },
-                { hasMidpoint: true }
-            )
-            expect(bins.length).toBeGreaterThanOrEqual(2) // 1 bin = 2 bin edges
-            expect(bins.length).toBeLessThanOrEqual(4) // 3 bins = 4 bin edges
-        })
-    })
-
-    describe("normal strategy", () => {
-        it("should create 5-9 bins when hasMidpoint is false", () => {
-            const bins = runEqualSizeBinningStrategy({
+                expectedBinCount: [2, 5],
+            },
+            {
+                label: "few bins with a midpoint",
+                strategy: "equalSizeBins-few-bins",
+                minValue: 0,
+                maxValue: 10,
+                hasMidpoint: true,
+                expectedBinCount: [1, 3],
+            },
+            {
+                label: "normal density",
                 strategy: "equalSizeBins-normal",
                 minValue: 0,
                 maxValue: 100,
-                sortedValues: [],
-                midpointMode: "none",
-                midpoint: 0,
-            })
-            expect(bins.length).toBeGreaterThanOrEqual(6) // 5 bins = 6 bin edges
-            expect(bins.length).toBeLessThanOrEqual(10) // 9 bins = 10 bin edges
-            expect(bins[0]).toBe(0)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(100)
-        })
-
-        it("should create 3-6 bins when hasMidpoint is true", () => {
-            const bins = runEqualSizeBinningStrategy(
-                {
-                    strategy: "equalSizeBins-normal",
-                    minValue: 0,
-                    maxValue: 100,
-                    sortedValues: [],
-                    midpointMode: "none",
-                    midpoint: 0,
-                },
-                { hasMidpoint: true }
-            )
-            expect(bins.length).toBeGreaterThanOrEqual(4) // 3 bins = 4 bin edges
-            expect(bins.length).toBeLessThanOrEqual(7) // 6 bins = 7 bin edges
-        })
-    })
-
-    describe("many-bins and percent strategies", () => {
-        it("should create 8-12 bins for many-bins when hasMidpoint is false", () => {
-            const bins = runEqualSizeBinningStrategy({
+                expectedBinCount: [5, 9],
+            },
+            {
+                label: "normal density with a midpoint",
+                strategy: "equalSizeBins-normal",
+                minValue: 0,
+                maxValue: 100,
+                hasMidpoint: true,
+                expectedBinCount: [3, 6],
+            },
+            {
+                label: "many bins",
                 strategy: "equalSizeBins-many-bins",
                 minValue: 0,
                 maxValue: 1000,
-                sortedValues: [],
-                midpointMode: "none",
-                midpoint: 0,
-            })
-            expect(bins.length).toBeGreaterThanOrEqual(9) // 8 bins = 9 bin edges
-            expect(bins.length).toBeLessThanOrEqual(13) // 12 bins = 13 bin edges
-        })
-
-        it("should create 8-12 bins for percent when hasMidpoint is false", () => {
-            const bins = runEqualSizeBinningStrategy({
+                expectedBinCount: [8, 12],
+            },
+            {
+                label: "percent bins",
                 strategy: "equalSizeBins-percent",
+                minValue: 0,
+                maxValue: 100,
+                expectedBinCount: [8, 12],
+            },
+            {
+                label: "many bins with a midpoint",
+                strategy: "equalSizeBins-many-bins",
+                minValue: 0,
+                maxValue: 1000,
+                hasMidpoint: true,
+                expectedBinCount: [4, 8],
+            },
+        ]
+
+        it.each(cases)(
+            "$label stays within its target density and covers the data",
+            ({ expectedBinCount, ...config }) => {
+                const bins = runStrategy(config)
+                const binCount = bins.length - 1
+
+                expect(binCount).toBeGreaterThanOrEqual(expectedBinCount[0])
+                expect(binCount).toBeLessThanOrEqual(expectedBinCount[1])
+                expectBinsCoverRange(bins, config.minValue, config.maxValue)
+            }
+        )
+    })
+
+    it("rejects a strategy from a different binning family", () => {
+        expect(() => {
+            runEqualSizeBinningStrategy({
+                strategy: "log-auto",
                 minValue: 0,
                 maxValue: 100,
                 sortedValues: [],
                 midpointMode: "none",
                 midpoint: 0,
             })
-            expect(bins.length).toBeGreaterThanOrEqual(9) // 8 bins = 9 bin edges
-            expect(bins.length).toBeLessThanOrEqual(13) // 12 bins = 13 bin edges
-        })
-
-        it("should create 4-8 bins when hasMidpoint is true", () => {
-            const bins = runEqualSizeBinningStrategy(
-                {
-                    strategy: "equalSizeBins-many-bins",
-                    minValue: 0,
-                    maxValue: 1000,
-                    sortedValues: [],
-                    midpointMode: "none",
-                    midpoint: 0,
-                },
-                { hasMidpoint: true }
-            )
-            expect(bins.length).toBeGreaterThanOrEqual(5) // 4 bins = 5 bin edges
-            expect(bins.length).toBeLessThanOrEqual(9) // 8 bins = 9 bin edges
-        })
+        }).toThrow("Invalid strategy")
     })
 
-    describe("error handling", () => {
-        it("should throw error for invalid strategy", () => {
-            expect(() => {
-                runEqualSizeBinningStrategy({
-                    strategy: "log-auto",
-                    minValue: 0,
-                    maxValue: 100,
-                    sortedValues: [],
-                    midpointMode: "none",
-                    midpoint: 0,
-                })
-            }).toThrow("Invalid strategy")
-        })
-    })
-
-    describe("edge cases", () => {
-        it("should handle very small ranges", () => {
-            const bins = runEqualSizeBinningStrategy({
-                strategy: "equalSizeBins-normal",
-                minValue: 0.001,
-                maxValue: 0.002,
-                sortedValues: [],
-                midpointMode: "none",
-                midpoint: 0,
-            })
-            expect(bins.length).toBeGreaterThan(1)
-            expect(bins[0]).toBeLessThanOrEqual(0.001)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(0.002)
+    // The strategy wrapper must preserve range coverage across changes in
+    // scale and sign. These are representative numeric partitions; the
+    // underlying edge-generation contract is tested in more detail below.
+    it.each([
+        { label: "a sub-unit range", minValue: 0.001, maxValue: 0.002 },
+        { label: "a million-unit range", minValue: 0, maxValue: 1_000_000 },
+        { label: "an entirely negative range", minValue: -100, maxValue: -10 },
+    ])("covers $label", ({ minValue, maxValue }) => {
+        const bins = runStrategy({
+            strategy: "equalSizeBins-normal",
+            minValue,
+            maxValue,
         })
 
-        it("should handle large ranges", () => {
-            const bins = runEqualSizeBinningStrategy({
-                strategy: "equalSizeBins-normal",
-                minValue: 0,
-                maxValue: 1000000,
-                sortedValues: [],
-                midpointMode: "none",
-                midpoint: 0,
-            })
-            expect(bins.length).toBeGreaterThan(1)
-            expect(bins[0]).toBe(0)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(1000000)
-        })
-
-        it("should handle negative ranges", () => {
-            const bins = runEqualSizeBinningStrategy({
-                strategy: "equalSizeBins-normal",
-                minValue: -100,
-                maxValue: -10,
-                sortedValues: [],
-                midpointMode: "none",
-                midpoint: 0,
-            })
-            expect(bins.length).toBeGreaterThan(1)
-            expect(bins[0]).toBeLessThanOrEqual(-100)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(-10)
-        })
+        expect(bins.length).toBeGreaterThan(1)
+        expectBinsCoverRange(bins, minValue, maxValue)
     })
 })
 
 describe(createEqualSizeBins, () => {
-    describe("basic functionality", () => {
-        it("should create bins with equal step sizes", () => {
-            const bins = createEqualSizeBins({
-                minValue: 0,
-                maxValue: 10,
-                targetBinCount: [5, 9],
-            })
-
-            // Check that bins are sorted
-            for (let i = 1; i < bins.length; i++) {
-                expect(bins[i]).toBeGreaterThan(bins[i - 1])
-            }
-
-            // Check that first bin covers minValue
-            expect(bins[0]).toBeLessThanOrEqual(0)
-
-            // Check that last bin covers maxValue
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(10)
-
-            // Check that we have the expected number of bins
-            const numBins = bins.length - 1
-            expect(numBins).toBeGreaterThanOrEqual(5)
-            expect(numBins).toBeLessThanOrEqual(9)
+    // Equal-size bins must be ordered, uniformly spaced, cover the requested
+    // domain, and normally remain inside the requested count range.
+    it("creates uniformly spaced bins that cover the domain", () => {
+        const bins = createEqualSizeBins({
+            minValue: 0,
+            maxValue: 10,
+            targetBinCount: [5, 9],
         })
+        const stepSizes = bins.slice(1).map((bin, index) => bin - bins[index])
 
-        it("should use nice step sizes", () => {
-            const bins = createEqualSizeBins({
-                minValue: 0,
-                maxValue: 100,
-                targetBinCount: [5, 9],
-            })
-
-            // Calculate step sizes between consecutive bins
-            const stepSizes = []
-            for (let i = 1; i < bins.length; i++) {
-                stepSizes.push(bins[i] - bins[i - 1])
-            }
-
-            // All step sizes should be approximately equal (allowing for floating point precision)
-            const firstStep = stepSizes[0]
-            stepSizes.forEach((step) => {
-                expect(Math.abs(step - firstStep)).toBeLessThan(0.001)
-            })
-
-            // Step size should be a "nice" number (power of 10 times 1, 2, or 5)
-            const normalizedStep =
-                firstStep / Math.pow(10, Math.floor(Math.log10(firstStep)))
-            const niceNumbers = [1, 2, 5, 0.1, 0.2, 0.5, 0.3, 0.75, 0.25, 3]
-            expect(
-                niceNumbers.some(
-                    (nice) => Math.abs(normalizedStep - nice) < 0.001
-                )
-            ).toBe(true)
-        })
+        expectBinsCoverRange(bins, 0, 10)
+        expect(bins.length - 1).toBeGreaterThanOrEqual(5)
+        expect(bins.length - 1).toBeLessThanOrEqual(9)
+        expect(stepSizes.every((step) => step === stepSizes[0])).toBe(true)
     })
 
-    describe("error handling", () => {
-        it("should throw error when minValue > maxValue", () => {
-            expect(() => {
-                createEqualSizeBins({
-                    minValue: 10,
-                    maxValue: 5,
-                    targetBinCount: [5, 9],
-                })
-            }).toThrow("minValue must be less than maxValue")
+    it("chooses a human-readable step size", () => {
+        const bins = createEqualSizeBins({
+            minValue: 0,
+            maxValue: 100,
+            targetBinCount: [5, 9],
         })
+        const firstStep = bins[1] - bins[0]
+        const normalizedStep =
+            firstStep / Math.pow(10, Math.floor(Math.log10(firstStep)))
+        const supportedNormalizedSteps = [
+            1, 2, 5, 0.1, 0.2, 0.5, 0.3, 0.75, 0.25, 3,
+        ]
 
-        it("should handle cases where targetBinCount cannot be honored", () => {
-            expect(
-                createEqualSizeBins({
-                    minValue: 0,
-                    maxValue: 1,
-                    targetBinCount: [100, 200], // Impossible to achieve with nice step sizes directly; have to instead create way fewer bins than targetBinCount requests
-                })
-            ).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1])
-        })
+        expect(
+            supportedNormalizedSteps.some(
+                (candidate) => Math.abs(normalizedStep - candidate) < 0.001
+            )
+        ).toBe(true)
     })
 
-    describe("edge cases", () => {
-        it("should handle zero range", () => {
-            const bins = createEqualSizeBins({
-                minValue: 5,
+    it("rejects a reversed domain", () => {
+        expect(() => {
+            createEqualSizeBins({
+                minValue: 10,
                 maxValue: 5,
-                targetBinCount: [2, 5],
-            })
-            expect(bins).toContain(5)
-        })
-
-        it("should handle very small ranges", () => {
-            const bins = createEqualSizeBins({
-                minValue: 0.0001,
-                maxValue: 0.0002,
-                targetBinCount: [2, 5],
-            })
-            expect(bins.length).toBeGreaterThan(1)
-            expect(bins[0]).toBeLessThanOrEqual(0.0001)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(0.0002)
-        })
-
-        it("should handle large ranges", () => {
-            const bins = createEqualSizeBins({
-                minValue: 1000000,
-                maxValue: 10000000,
                 targetBinCount: [5, 9],
             })
-            expect(bins.length).toBeGreaterThan(1)
-            expect(bins[0]).toBeLessThanOrEqual(1000000)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(10000000)
-        })
-
-        it("should handle negative ranges", () => {
-            const bins = createEqualSizeBins({
-                minValue: -100,
-                maxValue: -10,
-                targetBinCount: [5, 9],
-            })
-            expect(bins.length).toBeGreaterThan(1)
-            expect(bins[0]).toBeLessThanOrEqual(-100)
-            expect(bins[bins.length - 1]).toBeGreaterThanOrEqual(-10)
-        })
-
-        it("should handle ranges crossing zero", () => {
-            const bins = createEqualSizeBins({
-                minValue: -50,
-                maxValue: 50,
-                targetBinCount: [5, 9],
-            })
-            expect(bins.length).toBeGreaterThan(1)
-            expect(bins[0]).toBeLessThanOrEqual(-50)
-            expect(bins[bins.length - 1]).toBeGreaterThan(50) // Should extend beyond maxValue
-
-            // Should include zero or values close to zero
-            const hasZeroOrNear = bins.some((bin) => Math.abs(bin) < 0.001)
-            expect(hasZeroOrNear).toBe(true)
-        })
+        }).toThrow("minValue must be less than maxValue")
     })
 
-    describe("target bin count behavior", () => {
-        it("should respect minimum target bin count", () => {
-            const bins = createEqualSizeBins({
-                minValue: 0,
-                maxValue: 10,
-                targetBinCount: [3, 10],
-            })
-            const numBins = bins.length - 1
-            expect(numBins).toBeGreaterThanOrEqual(3)
-        })
-
-        it("should respect maximum target bin count", () => {
-            const bins = createEqualSizeBins({
-                minValue: 0,
-                maxValue: 10,
-                targetBinCount: [2, 4],
-            })
-            const numBins = bins.length - 1
-            expect(numBins).toBeLessThanOrEqual(4)
-        })
-
-        it("should handle single target bin count", () => {
-            const bins = createEqualSizeBins({
-                minValue: 0,
-                maxValue: 10,
-                targetBinCount: [5, 5],
-            })
-            const numBins = bins.length - 1
-            expect(numBins).toBe(5)
-        })
-    })
-
-    describe("floating point precision", () => {
-        it("should handle floating point arithmetic correctly", () => {
-            const bins = createEqualSizeBins({
-                minValue: 0.1,
-                maxValue: 0.9,
-                targetBinCount: [4, 8],
-            })
-
-            // Check that no two consecutive bins are equal due to floating point errors
-            for (let i = 1; i < bins.length; i++) {
-                expect(bins[i]).toBeGreaterThan(bins[i - 1])
-            }
-        })
-
-        it("should round values to avoid floating point issues", () => {
-            const bins = createEqualSizeBins({
+    it("chooses the closest supported density when the target is impossible", () => {
+        expect(
+            createEqualSizeBins({
                 minValue: 0,
                 maxValue: 1,
-                targetBinCount: [5, 9],
+                targetBinCount: [100, 200],
             })
+        ).toEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1])
+    })
 
-            // All bin values should be reasonable numbers without excessive decimal places
-            bins.forEach((bin) => {
-                const decimalPlaces = (bin.toString().split(".")[1] || "")
-                    .length
-                expect(decimalPlaces).toBeLessThanOrEqual(10) // Reasonable precision limit
-            })
+    // Scale and sign should not change the core coverage contract. Crossing
+    // zero is kept separate because zero itself becomes a meaningful edge.
+    it.each([
+        { label: "sub-unit values", minValue: 0.0001, maxValue: 0.0002 },
+        {
+            label: "million-scale values",
+            minValue: 1_000_000,
+            maxValue: 10_000_000,
+        },
+        { label: "negative values", minValue: -100, maxValue: -10 },
+    ])("covers a domain with $label", ({ minValue, maxValue }) => {
+        const bins = createEqualSizeBins({
+            minValue,
+            maxValue,
+            targetBinCount: [2, 9],
         })
+
+        expect(bins.length).toBeGreaterThan(1)
+        expectBinsCoverRange(bins, minValue, maxValue)
+    })
+
+    it("keeps zero as an edge when the domain crosses zero", () => {
+        const bins = createEqualSizeBins({
+            minValue: -50,
+            maxValue: 50,
+            targetBinCount: [5, 9],
+        })
+
+        expectBinsCoverRange(bins, -50, 50)
+        expect(bins).toContain(0)
+    })
+
+    it("represents a zero-width domain without losing its value", () => {
+        const bins = createEqualSizeBins({
+            minValue: 5,
+            maxValue: 5,
+            targetBinCount: [2, 5],
+        })
+
+        expect(bins).toContain(5)
+    })
+
+    // Count ranges are soft only when no supported step can satisfy them. The
+    // representative cases below establish the lower, upper, and exact forms.
+    it.each([
+        {
+            label: "a minimum",
+            targetBinCount: [3, 10] as const,
+            expectedBinCount: [3, 10] as const,
+        },
+        {
+            label: "a maximum",
+            targetBinCount: [2, 4] as const,
+            expectedBinCount: [2, 4] as const,
+        },
+        {
+            label: "an exact count",
+            targetBinCount: [5, 5] as const,
+            expectedBinCount: [5, 5] as const,
+        },
+    ])("respects $label target", ({ targetBinCount, expectedBinCount }) => {
+        const bins = createEqualSizeBins({
+            minValue: 0,
+            maxValue: 10,
+            targetBinCount,
+        })
+        const binCount = bins.length - 1
+
+        expect(binCount).toBeGreaterThanOrEqual(expectedBinCount[0])
+        expect(binCount).toBeLessThanOrEqual(expectedBinCount[1])
+    })
+
+    // Floating-point rounding must never collapse adjacent edges or expose
+    // machine-noise tails in serialized chart configuration.
+    it("keeps fractional edges strictly increasing", () => {
+        const bins = createEqualSizeBins({
+            minValue: 0.1,
+            maxValue: 0.9,
+            targetBinCount: [4, 8],
+        })
+
+        for (let index = 1; index < bins.length; index++) {
+            expect(bins[index]).toBeGreaterThan(bins[index - 1])
+        }
+    })
+
+    it("limits decimal noise in fractional edges", () => {
+        const bins = createEqualSizeBins({
+            minValue: 0,
+            maxValue: 1,
+            targetBinCount: [5, 9],
+        })
+
+        for (const bin of bins) {
+            const decimalPlaces = (bin.toString().split(".")[1] || "").length
+            expect(decimalPlaces).toBeLessThanOrEqual(10)
+        }
     })
 })


### PR DESCRIPTION
> _Written by OpenAI GPT-5 — @danyx23 at the wheel._

Reframes the equal-size binning tests around density, range coverage, numeric partitions, and floating-point stability. All 25 existing scenarios remain represented, while repeated setup and implementation-narrating comments are reduced.

<details><summary>Details</summary>

- Introduces focused helpers for invoking a strategy and asserting range coverage.
- Expresses the strategy/midpoint matrix as a readable table of distinct density contracts.
- Groups scale and sign cases as representative partitions.
- Gives the target-count, impossible-target, zero-crossing, and floating-point cases explicit rationale.
- Strengthens repeated edge assertions with diagnostic messages.
- Changes only `BinningStrategyEqualSizeBins.test.ts`.

Checks: focused Vitest file (25 tests), `yarn typecheck`, `yarn testLintChanged`, `yarn fixFormatChanged`.

</details>
