### PR TITLE
Make autocomplete assertions prove score and limit behavior

### DIFF
--- a/site/search/searchUtils.test.ts
+++ b/site/search/searchUtils.test.ts
@@ -122,11 +122,12 @@ describe("Fuzzy search in search autocomplete", () => {
                 sortOptions: limitedSortOptions,
             })
 
-            // Should not exceed the limit even with multiple synonym matches
+            // Enough distinct matches exist to fill the limit; returning nothing
+            // would satisfy an upper-bound-only assertion.
             const topicResults = result.filter(
                 (f) => f.type === FilterType.TOPIC
             )
-            expect(topicResults.length).toBeLessThanOrEqual(2)
+            expect(topicResults).toHaveLength(2)
         })
 
         it("should deduplicate results and keep highest scores", () => {
@@ -145,6 +146,8 @@ describe("Fuzzy search in search autocomplete", () => {
                 (r) => r.name === "Artificial Intelligence"
             )
             expect(aiResults).toHaveLength(1)
+            // The exact synonym must beat the original partial match.
+            expect(aiResults[0].score).toBe(1)
         })
 
         it("should expand country synonyms (variant names)", () => {


### PR DESCRIPTION
> _Written by OpenAI GPT-6 — @danyx23 at the wheel._

Make two autocomplete assertions establish the behavior their scenarios claim: deduplication retains the exact-match score, and enough available matches fill the requested limit. Inputs and production behavior are unchanged.

Stacked on #7191, which only simplifies setup.

<details><summary>Details</summary>

| Existing evidence | New evidence |
| --- | --- |
| Duplicate topic occurs once | Same count plus exact score 1 from the full synonym match |
| Topic count is at most 2 | Exactly 2 topics for the existing five-synonym fixture; implies the old bound and rejects empty output |

Targeted defect checks (each run against the affected named test, not a claim about the whole suite):
- Sorting scores ascending: old dedup test passed; new assertion failed with score 0.8341638066812839 instead of 1.
- Taking zero results: old limit test passed; new assertion failed with length 0 instead of 2.
- Restored both temporary production mutations; all 40 search tests passed.

Formatting, typecheck, changed-file lint, and whitespace checks passed. No tests removed; no production changes.

</details>
