### PR TITLE
Express scatter label strategies as explicit cases

### DIFF
--- a/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/ScatterPlotChart.test.ts
@@ -330,34 +330,19 @@ describe("label point strategies", () => {
         table,
     }
 
-    it("year", () => {
+    // Each label source reads a different coordinate from this same point.
+    it.each<[ScatterPointLabelStrategy, string]>([
+        [ScatterPointLabelStrategy.year, "2000"],
+        [ScatterPointLabelStrategy.y, "2"],
+        [ScatterPointLabelStrategy.x, "1"],
+    ])("labels points using the %s strategy", (strategy, expectedLabel) => {
         const chartState = new ScatterPlotChartState({
             manager: {
                 ...manager,
-                scatterPointLabelStrategy: ScatterPointLabelStrategy.year,
+                scatterPointLabelStrategy: strategy,
             },
         })
-        expect(chartState.allPoints[0].label).toEqual("2000")
-    })
-
-    it("y", () => {
-        const chartState = new ScatterPlotChartState({
-            manager: {
-                ...manager,
-                scatterPointLabelStrategy: ScatterPointLabelStrategy.y,
-            },
-        })
-        expect(chartState.allPoints[0].label).toEqual("2")
-    })
-
-    it("x", () => {
-        const chartState = new ScatterPlotChartState({
-            manager: {
-                ...manager,
-                scatterPointLabelStrategy: ScatterPointLabelStrategy.x,
-            },
-        })
-        expect(chartState.allPoints[0].label).toEqual("1")
+        expect(chartState.allPoints[0].label).toEqual(expectedLabel)
     })
 })
 


### PR DESCRIPTION
> _Written by OpenAI GPT-6 — @danyx23 at the wheel._

Replace three identical scatter-label test bodies with a typed table that keeps all three strategies and their exact expected labels visible. Each row still runs as a separate named test.

Stacked on #7196. This is the small mechanical example from the testing strategy.

<details><summary>Details</summary>

| Old case | New table row | Preserved assertion |
| --- | --- | --- |
| year | year / 2000 | first point label equals the string "2000" |
| y | y / 2 | first point label equals the string "2" |
| x | x / 1 | first point label equals the string "1" |

The table, manager, chart constructor, observed point, matcher, and exact values are unchanged. No additional permutations or conditional assertions. Three old cases become three generated cases, not one combined test.

Validation: all 37 scatter tests passed before and after; formatting, repository typecheck, changed-file lint, and whitespace checks passed. No production or rendering changes.

</details>
