### PR TITLE
Test chart editor inheritance and save lifecycles

### DIFF
--- a/adminSiteClient/ChartEditorInheritance.test.ts
+++ b/adminSiteClient/ChartEditorInheritance.test.ts
@@ -1,9 +1,13 @@
 /**
  * @vitest-environment happy-dom
  */
-import { describe, expect, it } from "vitest"
-import { GrapherInterface } from "@ourworldindata/types"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
+import { DimensionProperty, GrapherInterface } from "@ourworldindata/types"
 import { mergeGrapherConfigs } from "@ourworldindata/utils"
+import { createElement } from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { EditorDebugTab } from "./EditorDebugTab.js"
 import { ChartEditor, ChartEditorManager } from "./ChartEditor.js"
 
 // The chart's own ETL-authored layer sits between the indicator config and the
@@ -16,7 +20,10 @@ const etlConfig: GrapherInterface = {
     title: "ETL title",
     hasMapTab: true,
 }
-const patchConfig: GrapherInterface = { title: "Admin title" }
+const patchConfig: GrapherInterface = {
+    title: "Admin title",
+    dimensions: [{ property: DimensionProperty.y, variableId: 101 }],
+}
 
 function makeEditor(): ChartEditor {
     const editor = new ChartEditor({
@@ -73,12 +80,9 @@ describe("ChartEditor parent stack", () => {
         // owned by the ETL layer, so not an admin override
         expect(editor.patchConfig.hasMapTab).toBeUndefined()
 
-        // What `onToggleInheritance` does: capture the admin's overrides, flip
-        // the flag, then rebuild from the whole parent stack.
-        const capturedPatch = editor.patchConfig
-        editor.isInheritanceEnabled = false
-        editor.updateLiveGrapher(
-            mergeGrapherConfigs(editor.activeParentConfig ?? {}, capturedPatch)
+        render(createElement(EditorDebugTab, { editor }))
+        fireEvent.click(
+            screen.getByRole("checkbox", { name: "Enable inheritance" })
         )
 
         // The ETL layer still applies, and — the actual regression — it has not
@@ -92,5 +96,194 @@ describe("ChartEditor parent stack", () => {
         expect(editor.patchConfig.title).toBe("Admin title")
         // the indicator layer is gone, as intended
         expect(editor.fullConfig.note).toBeUndefined()
+    })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+// Actions are real; only API transport and window creation are controlled.
+function loadEditor(
+    patch: GrapherInterface = patchConfig,
+    parent: GrapherInterface = parentConfig,
+    isInheritanceEnabled = true
+): ChartEditor {
+    const editor = new ChartEditor({
+        manager: {
+            admin: {
+                requestJSON: vi.fn(),
+                getJSON: vi.fn(),
+                url: (path: string) => path,
+            },
+            patchConfig: patch,
+            parentConfig: parent,
+            parentVariableId: 101,
+            etlConfig,
+            isInheritanceEnabled,
+            logs: [],
+            references: undefined,
+            redirects: [],
+        } as unknown as ChartEditorManager,
+    })
+    editor.updateLiveGrapher(editor.originalGrapherConfig)
+    editor.savedPatchConfig = patch
+    return editor
+}
+
+describe("ChartEditor action lifecycle", () => {
+    it("saves and reopens a disabled inheritance stack without demoting ETL settings", async () => {
+        const editor = loadEditor({ ...patchConfig, id: 42 })
+        render(createElement(EditorDebugTab, { editor }))
+        fireEvent.click(
+            screen.getByRole("checkbox", { name: "Enable inheritance" })
+        )
+        const savedPatch: GrapherInterface = {
+            $schema: latestGrapherConfigSchema,
+            id: 42,
+            title: "Admin title",
+            dimensions: [{ property: DimensionProperty.y, variableId: 101 }],
+        }
+        vi.mocked(editor.manager.admin.requestJSON).mockResolvedValue({
+            success: true,
+            savedPatch,
+            newLog: {},
+        })
+        await editor.saveGrapher()
+        const [url, payload] = vi.mocked(editor.manager.admin.requestJSON).mock
+            .calls[0]
+        expect(url).toBe(
+            "/api/charts/42?inheritance=disable&forceDatapage=false"
+        )
+        expect(payload).toMatchObject(savedPatch)
+        for (const key of ["note", "subtitle", "hasMapTab"])
+            expect(payload).not.toHaveProperty(key)
+        const reopened = loadEditor(
+            payload as GrapherInterface,
+            parentConfig,
+            false
+        )
+        expect(reopened.fullConfig.title).toBe("Admin title")
+        expect(reopened.fullConfig.hasMapTab).toBe(true)
+        expect(reopened.fullConfig.note).toBeUndefined()
+        expect(reopened.fullConfig.subtitle).toBeUndefined()
+        expect(editor.isModified).toBe(false)
+        editor.dispose()
+        reopened.dispose()
+    })
+
+    it("changes parent, saves only overrides, and reconstructs the saved configuration", async () => {
+        const editor = loadEditor({ ...patchConfig, id: 42 })
+        const newParent = {
+            note: "New indicator note",
+            subtitle: "New indicator subtitle",
+        }
+        vi.mocked(editor.manager.admin.getJSON).mockResolvedValue(newParent)
+        editor.grapherState.updateFromObject({
+            dimensions: [{ property: DimensionProperty.y, variableId: 202 }],
+        })
+        await editor.updateParentConfig()
+        expect(editor.manager.admin.getJSON).toHaveBeenCalledWith(
+            "/api/variables/202.config.json"
+        )
+        expect(editor.fullConfig).toMatchObject({
+            title: "Admin title",
+            note: "New indicator note",
+            subtitle: "New indicator subtitle",
+            hasMapTab: true,
+        })
+        const savedPatch: GrapherInterface = {
+            $schema: latestGrapherConfigSchema,
+            id: 42,
+            title: "Admin title",
+            dimensions: [{ property: DimensionProperty.y, variableId: 202 }],
+        }
+        vi.mocked(editor.manager.admin.requestJSON).mockResolvedValue({
+            success: true,
+            savedPatch,
+            newLog: {},
+        })
+        await editor.saveGrapher()
+        const [url, payload, method] = vi.mocked(
+            editor.manager.admin.requestJSON
+        ).mock.calls[0]
+        expect(url).toBe(
+            "/api/charts/42?inheritance=enable&forceDatapage=false"
+        )
+        expect(method).toBe("PUT")
+        expect(payload).toMatchObject(savedPatch)
+        for (const key of ["note", "subtitle", "hasMapTab"])
+            expect(payload).not.toHaveProperty(key)
+        expect(editor.patchConfig).toEqual({
+            ...savedPatch,
+            version: editor.grapherState.version,
+        })
+        expect(editor.isModified).toBe(false)
+        const reopened = loadEditor(payload as GrapherInterface, newParent)
+        expect(reopened.fullConfig).toMatchObject({
+            title: "Admin title",
+            note: "New indicator note",
+            subtitle: "New indicator subtitle",
+            hasMapTab: true,
+            dimensions: [{ property: DimensionProperty.y, variableId: 202 }],
+        })
+        editor.dispose()
+        reopened.dispose()
+    })
+
+    it("copies effective ETL settings without the original identity or publication", async () => {
+        const editor = loadEditor({
+            ...patchConfig,
+            id: 42,
+            slug: "original",
+            isPublished: true,
+        })
+        const assign = vi.fn()
+        vi.spyOn(window, "open").mockReturnValue({
+            location: { assign },
+        } as unknown as Window)
+        vi.mocked(editor.manager.admin.requestJSON).mockResolvedValue({
+            success: true,
+            chartId: 99,
+        })
+        await editor.saveAsNewGrapher()
+        const [url, payload, method] = vi.mocked(
+            editor.manager.admin.requestJSON
+        ).mock.calls[0]
+        expect(url).toBe("/api/charts?inheritance=enable&forceDatapage=false")
+        expect(method).toBe("POST")
+        expect(payload).toMatchObject({
+            title: "Admin title",
+            hasMapTab: true,
+            note: "Indicator note",
+            subtitle: "Indicator subtitle",
+        })
+        for (const key of ["id", "slug", "isPublished"])
+            expect(payload).not.toHaveProperty(key)
+        expect(assign).toHaveBeenCalledWith("charts/99/edit")
+        expect(editor.grapherState.id).toBe(42)
+        expect(editor.grapherState.isPublished).toBe(true)
+        editor.dispose()
+    })
+
+    it("keeps unsaved changes and the saved baseline when the API rejects a save", async () => {
+        const editor = loadEditor({
+            ...patchConfig,
+            id: 42,
+            isPublished: false,
+        })
+        const baseline = editor.savedPatchConfig
+        const version = editor.grapherState.version
+        editor.grapherState.title = "Unsaved title"
+        vi.mocked(editor.manager.admin.requestJSON).mockResolvedValue({
+            success: false,
+        })
+        const onError = vi.fn()
+        await editor.saveGrapher({ onError })
+        expect(onError).toHaveBeenCalledOnce()
+        expect(editor.savedPatchConfig).toEqual(baseline)
+        expect(editor.isModified).toBe(true)
+        expect(editor.grapherState.version).toBe(version)
+        expect(editor.grapherState.isPublished).toBe(false)
+        expect(editor.logs).toEqual([])
+        editor.dispose()
     })
 })


### PR DESCRIPTION
> _Written by OpenAI GPT-6 — @danyx23 at the wheel._

Exercise chart inheritance through the rendered checkbox and the real parent-update, save, and copy actions. The scenarios protect ETL settings and intentional overrides through save/reopen, and ensure rejected saves retain unsaved changes.

Closes #7199. Based on #7190 (`test-strategy`).

<details><summary>Details</summary>

- Preserves the three existing parent-stack tests and their ETL precedence, disabled inheritance, patch ownership, override, and removed-indicator assertions. The toggle scenario gains a parent dimension to expose the actual UI; its manually reenacted action is replaced by clicking the rendered checkbox. No structural cleanup of unrelated tests.
- Adds disabled-inheritance save/reopen, parent change/save/reopen, effective-configuration copying, and rejected-save scenarios. Reopened editors consume captured request payloads; significant expectations are written independently.
- API transport and new-window creation are controlled; production actions, diffing, serialization and state reconstruction run unchanged. This is in-process evidence, not API persistence or browser evidence.
- Validation: all 7 focused tests pass; typecheck, changed-file lint and formatting pass. Replacing the toggle's effective-parent merge with the indicator-only merge fails two tests; restored and reran the final suite.
- Command: `yarn test run adminSiteClient/ChartEditorInheritance.test.ts --reporter dot`.

</details>
