### PR TITLE
Test Grapher browser journeys and guard stale view data

### DIFF
--- a/features/grapher/README.md
+++ b/features/grapher/README.md
@@ -1,0 +1,28 @@
+# Grapher browser workflow contracts
+
+Run `yarn playwright install chromium`, then `yarn testGrapherBrowser`.
+The command builds the actual Grapher, MultiDim, MultiEmbedder and site SCSS using
+our shared Vite plugins and browser target, then serves the bundle on port 8791.
+It needs no database or baked production content. All indicator/config responses
+are small local fixtures; other external requests are blocked.
+
+The four scenarios protect tab/time/entity URL restoration, independent hydrated
+embeds, late multidimensional data responses, and pinned touch legend selection.
+The loading test releases an older response only after the newer view's values
+are visible. Expected table values are independent of the implementation.
+The touch test verifies the visible highlighted swatch remains after pointer
+release/mouse movement and clears on an outside touch.
+
+Initial execution policy: opt-in locally or manually in CI, desktop Chromium
+plus a touch-enabled Chromium context. This adds no required merge check and
+leaves the existing BDD browser matrix unchanged. The checked-in CI workflow
+runs no browser suite; the checked-in Buildkite workflow only handles staging
+cleanup. External Buildkite browser coverage is not established by this checkout.
+Confirm external coverage and agree ownership/runtime budgets before making this
+suite required or expanding its browser matrix.
+
+Failures retain screenshots and traces under `test-results/`; the HTML report is
+`playwright-report/grapher/`. Use `yarn playwright show-report playwright-report/grapher`
+or `yarn playwright show-trace <trace.zip>`. Retries are disabled so failures remain
+visible. Config/data routing is test infrastructure; production callbacks and
+renderers are not replaced.

--- a/features/grapher/assets.d.ts
+++ b/features/grapher/assets.d.ts
@@ -1,0 +1,1 @@
+declare module "*.scss"

--- a/features/grapher/fixture.scss
+++ b/features/grapher/fixture.scss
@@ -1,0 +1,12 @@
+body {
+    margin: 0;
+}
+#fixture {
+    max-width: 1000px;
+    margin: 20px auto;
+}
+#fixture figure {
+    width: 100%;
+    height: 600px;
+    margin: 0 0 32px;
+}

--- a/features/grapher/fixture.tsx
+++ b/features/grapher/fixture.tsx
@@ -1,0 +1,71 @@
+import { createRoot } from "react-dom/client"
+import {
+    renderSingleGrapherOnGrapherPage,
+    latestGrapherConfigSchema,
+} from "@ourworldindata/grapher"
+import { DimensionProperty, EntitySelectionMode } from "@ourworldindata/types"
+import { MultiDimDataPageConfig } from "@ourworldindata/utils"
+import { MultiEmbedderSingleton } from "../../site/multiembedder/MultiEmbedder.js"
+import MultiDim from "../../site/multiDim/MultiDim.js"
+import "../../site/owid.scss"
+import "./fixture.scss"
+
+const mode = new URLSearchParams(location.search).get("fixture") ?? "standalone"
+const root = document.getElementById("fixture")!
+if (mode === "multi") {
+    createRoot(root).render(
+        <MultiDim
+            config={MultiDimDataPageConfig.fromObject({
+                title: { title: "Fixture views" },
+                dimensions: [
+                    {
+                        slug: "metric",
+                        name: "Metric",
+                        choices: [
+                            { slug: "first", name: "First metric" },
+                            { slug: "second", name: "Second metric" },
+                        ],
+                    },
+                ],
+                views: [
+                    {
+                        dimensions: { metric: "first" },
+                        indicators: { y: [{ id: 101 }] },
+                        fullConfigId: "first",
+                    },
+                    {
+                        dimensions: { metric: "second" },
+                        indicators: { y: [{ id: 202 }] },
+                        fullConfigId: "second",
+                    },
+                ],
+            })}
+            slug="fixture"
+            queryStr={location.search}
+        />
+    )
+} else {
+    for (let i = 0; i < (mode === "embeds" ? 2 : 1); i++) {
+        const figure = document.createElement("figure")
+        figure.id = `chart-${i}`
+        figure.setAttribute("data-grapher-src", "/grapher/fixture")
+        root.append(figure)
+    }
+    if (mode === "embeds") MultiEmbedderSingleton.embedAll()
+    else
+        renderSingleGrapherOnGrapherPage({
+            config: {
+                $schema: latestGrapherConfigSchema,
+                title: "Fixture chart",
+                slug: "fixture",
+                dimensions: [
+                    { property: DimensionProperty.y, variableId: 101 },
+                ],
+                selectedEntityNames: ["France", "Germany"],
+                hasMapTab: true,
+                addCountryMode: EntitySelectionMode.MultipleEntities,
+            },
+            dataApiUrl: "/v1/indicators",
+            catalogUrl: "/catalog",
+        })
+}

--- a/features/grapher/grapher.test.ts
+++ b/features/grapher/grapher.test.ts
@@ -1,0 +1,188 @@
+import {
+    DimensionProperty,
+    type GrapherInterface,
+    type OwidVariableDataMetadataDimensions,
+} from "@ourworldindata/types"
+import { expect, test, type Page, type Route } from "@playwright/test"
+
+const config = (id = 101): GrapherInterface => ({
+    $schema: "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
+    title: id === 101 ? "First metric" : "Second metric",
+    slug: "fixture",
+    dimensions: [{ property: DimensionProperty.y, variableId: id }],
+    selectedEntityNames: ["France", "Germany"],
+})
+const data = (id: number): OwidVariableDataMetadataDimensions["data"] => ({
+    years: [2000, 2010, 2000, 2010],
+    entities: [1, 1, 2, 2],
+    values: id === 101 ? [10, 20, 30, 40] : [100, 200, 300, 400],
+})
+const metadata = (
+    id: number
+): OwidVariableDataMetadataDimensions["metadata"] => ({
+    id,
+    name: id === 101 ? "First metric" : "Second metric",
+    unit: "units",
+    display: { numDecimalPlaces: 0 },
+    source: { name: "Local fixture" },
+    dimensions: {
+        years: { values: [{ id: 2000 }, { id: 2010 }] },
+        entities: {
+            values: [
+                { id: 1, name: "France", code: "FRA" },
+                { id: 2, name: "Germany", code: "DEU" },
+            ],
+        },
+    },
+})
+async function localData(page: Page): Promise<void> {
+    await page.route("**/*", async (route) => {
+        const url = new URL(route.request().url())
+        const match = url.pathname.match(/(101|202)\.(data|metadata)\.json/)
+        if (match)
+            return route.fulfill({
+                json:
+                    match[2] === "data"
+                        ? data(Number(match[1]))
+                        : metadata(Number(match[1])),
+            })
+        if (url.pathname.endsWith(".config.json"))
+            return route.fulfill({
+                json: config(url.pathname.includes("second") ? 202 : 101),
+            })
+        if (url.hostname !== "127.0.0.1") return route.abort()
+        return route.continue()
+    })
+}
+
+test.beforeEach(async ({ page }) => {
+    await localData(page)
+})
+test("standalone tab and share state survive reload", async ({ page }) => {
+    await page.goto("/")
+    await expect(
+        page.getByText("France", { exact: true }).first()
+    ).toBeVisible()
+    await page
+        .getByRole("button", {
+            name: "Edit countries and regions",
+            exact: true,
+        })
+        .click()
+    await page.getByRole("checkbox", { name: "Germany", exact: true }).uncheck()
+    await page.getByRole("button", { name: "Close", exact: true }).click()
+    await page
+        .getByRole("slider", { name: "Start time: 2000", exact: true })
+        .press("End")
+    await page.getByRole("tab", { name: "Table", exact: true }).click()
+    await expect(page).toHaveURL(/time=latest/)
+    expect(new URL(page.url()).searchParams.get("country")).toBe("~FRA")
+    await expect(
+        page.getByRole("tab", { name: "Table", exact: true })
+    ).toHaveAttribute("aria-selected", "true")
+    const shareUrl = page.url()
+    await page.goto(shareUrl)
+    await expect(
+        page.getByRole("tab", { name: "Table", exact: true })
+    ).toHaveAttribute("aria-selected", "true")
+    await expect(
+        page.getByRole("columnheader", { name: "2010", exact: true })
+    ).toBeVisible()
+    await page.getByRole("tab", { name: "Line", exact: true }).click()
+    await page
+        .getByRole("button", {
+            name: "Edit countries and regions",
+            exact: true,
+        })
+        .click()
+    await expect(
+        page.getByRole("checkbox", { name: "France", exact: true }).first()
+    ).toBeChecked()
+    await expect(
+        page.getByRole("checkbox", { name: "Germany", exact: true })
+    ).not.toBeChecked()
+})
+
+test("multiple embeds hydrate and keep independent tabs", async ({ page }) => {
+    await page.goto("/?fixture=embeds")
+    const first = page.locator("#chart-0")
+    const second = page.locator("#chart-1")
+    await first.getByRole("tab", { name: "Table", exact: true }).click()
+    await expect(
+        first.getByRole("tab", { name: "Table", exact: true })
+    ).toHaveAttribute("aria-selected", "true")
+    await expect(
+        second.getByRole("tab", { name: "Line", exact: true })
+    ).toHaveAttribute("aria-selected", "true")
+})
+
+// Keep the old data request pending until the user has selected and loaded another view.
+test("the newest multidimensional view keeps matching data when an older request finishes last", async ({
+    page,
+}) => {
+    let releaseOld!: () => Promise<void>
+    const oldRequested = new Promise<void>((resolve) => {
+        void page.route("**/101.data.json*", async (route: Route) => {
+            releaseOld = async () => {
+                await route.fulfill({ json: data(101) })
+            }
+            resolve()
+        })
+    })
+    await page.goto("/?fixture=multi")
+    await oldRequested
+    await page.getByRole("button", { name: "Metric", exact: true }).click()
+    await page
+        .getByRole("option", { name: "Second metric", exact: true })
+        .click()
+    await expect(
+        page.getByRole("heading", { name: /Second metric/ })
+    ).toBeVisible()
+    await page.getByRole("tab", { name: "Table", exact: true }).click()
+    await expect(
+        page.getByRole("row", { name: /France 100 200/ })
+    ).toBeVisible()
+    const oldResponse = page.waitForResponse((response) =>
+        response.url().includes("101.data.json")
+    )
+    await releaseOld()
+    await oldResponse
+    await page.evaluate(
+        () =>
+            new Promise<void>((resolve) =>
+                requestAnimationFrame(() =>
+                    requestAnimationFrame(() => resolve())
+                )
+            )
+    )
+    await expect(
+        page.getByRole("heading", { name: /Second metric/ })
+    ).toBeVisible()
+    await expect(
+        page.getByRole("row", { name: /France 100 200/ })
+    ).toBeVisible()
+    await expect(
+        page.getByRole("row", { name: /Germany 300 400/ })
+    ).toBeVisible()
+})
+
+test.describe("touch map legend", () => {
+    test.use({ hasTouch: true })
+    test("pins the visible bin highlight after touch release and clears it on the next outside touch", async ({
+        page,
+    }) => {
+        await page.goto("/?tab=map")
+        const swatches = page.locator(".numericColorLegend #swatches rect")
+        await expect(swatches).toHaveCount(7)
+        await page
+            .locator(".numericColorLegend #swatch-hit-areas rect")
+            .nth(3)
+            .tap()
+        // A highlighted swatch is painted on top with its own stroke.
+        await expect(swatches).toHaveCount(8)
+        await page.mouse.move(0, 0)
+        await expect(swatches).toHaveCount(8)
+        await page.getByRole("heading", { name: /Fixture chart/ }).tap()
+        await expect(swatches).toHaveCount(7)
+    })
+})

--- a/features/grapher/index.html
+++ b/features/grapher/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Grapher workflow fixture</title>
+    </head>
+    <body>
+        <main id="fixture"></main>
+        <script type="module" src="./fixture.tsx"></script>
+    </body>
+</html>

--- a/features/grapher/tsconfig.json
+++ b/features/grapher/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "extends": "../../devTools/tsconfigs/tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "outDir": "../../itsJustJavascript/features/grapher"
+    },
+    "include": ["*.ts", "*.tsx"],
+    "references": [
+        { "path": "../../packages/@ourworldindata/types" },
+        { "path": "../../packages/@ourworldindata/utils" },
+        { "path": "../../packages/@ourworldindata/grapher" },
+        { "path": "../../site" }
+    ]
+}

--- a/features/grapher/vite.config.mts
+++ b/features/grapher/vite.config.mts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite"
+import { commonPlugins, defineViteConfigForEntrypoint } from "../../vite.config-common.mts"
+import { ViteEntryPoint } from "../../site/viteConstants.js"
+
+const site = defineViteConfigForEntrypoint(ViteEntryPoint.Site)
+export default defineConfig({
+    ...site,
+    plugins: commonPlugins(),
+    root: "features/grapher",
+    publicDir: "../../public",
+    build: {
+        ...site.build,
+        outDir: "../../dist/grapher-browser-tests",
+        rolldownOptions: { input: "features/grapher/index.html" },
+    },
+    preview: { host: "127.0.0.1", port: 8791, strictPort: true },
+})

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
         "query": "tsx --tsconfig tsconfig.tsx.json devTools/db-ai-helpers/query.ts",
         "regenerateGdocMarkdown": "tsx --tsconfig tsconfig.tsx.json devTools/regenerateGdocMarkdown.ts",
         "addIncomingForeignKeys": "tsx --tsconfig tsconfig.tsx.json devTools/db-ai-helpers/addIncomingForeignKeys.ts",
-        "compareArchiveR2WithDb": "tsx --tsconfig tsconfig.tsx.json devTools/compareArchiveR2WithDb.ts"
+        "compareArchiveR2WithDb": "tsx --tsconfig tsconfig.tsx.json devTools/compareArchiveR2WithDb.ts",
+        "testGrapherBrowser": "playwright test -c playwright.grapher.config.ts"
     },
     "dependencies": {
         "@algolia/autocomplete-js": "^1.19.9",

--- a/playwright.grapher.config.ts
+++ b/playwright.grapher.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from "@playwright/test"
+export default defineConfig({
+    testDir: "./features/grapher",
+    testMatch: "*.test.ts",
+    fullyParallel: true,
+    retries: 0,
+    reporter: [
+        ["list"],
+        ["html", { outputFolder: "playwright-report/grapher", open: "never" }],
+    ],
+    use: {
+        baseURL: "http://127.0.0.1:8791",
+        trace: "retain-on-failure",
+        screenshot: "only-on-failure",
+    },
+    webServer: {
+        command:
+            "yarn vite build --config features/grapher/vite.config.mts && yarn vite preview --config features/grapher/vite.config.mts",
+        url: "http://127.0.0.1:8791",
+        reuseExistingServer: !process.env.CI,
+        timeout: 180000,
+    },
+    projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+})

--- a/site/multiDim/MultiDim.tsx
+++ b/site/multiDim/MultiDim.tsx
@@ -222,12 +222,15 @@ export default function MultiDim({
                         grapherConfig.selectedEntityColors
                     )
                     .then((table) => {
+                        if (ignoreFetchedData) return
                         if (table) {
                             runInAction(() => {
                                 grapherState.inputTable = table
                             })
                         }
                     })
+
+                if (ignoreFetchedData) return
 
                 // The below code needs to run after the data has been loaded, so that it has access
                 // to the table and its time range

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
         { "path": "./devTools/svgTester" },
         { "path": "./devTools/syncGraphersToR2" },
         { "path": "./settings" },
-        { "path": "./site" }
+        { "path": "./site" },
+        { "path": "./features/grapher" }
     ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
             "adminSiteServer/app.test.ts",
             "adminSiteServer/tests/**",
             "bespoke/**",
+            "features/grapher/**",
         ],
         pool: "threads",
         setupFiles: ["devTools/vitest-setup.ts"],


### PR DESCRIPTION
> _Written by OpenAI GPT-6 — @danyx23 at the wheel._

Add four deterministic browser journeys for Grapher URL restoration, independent embeds, touch legend selection, and multidimensional loading. The loading test exposed a race where an older view's data replaced the newly selected view; extend the existing stale-request guard through data completion and tab adjustment.

Closes #7201. Based on #7190 (`test-strategy`). The suite initially runs opt-in in Chromium, including a touch-enabled context, rather than becoming a required merge check before CI ownership is agreed.

<details><summary>Details</summary>

- `yarn playwright install chromium && yarn testGrapherBrowser` builds actual Grapher/site JS and SCSS with shared Vite plugins and serves local fixtures on port 8791. All config/indicator responses are controlled; external requests are blocked.
- Restore tab, latest-year and entity selection from the generated URL; assert visible controls and table year. This respects URL replacement and the supported `time=latest` representation.
- Hydrate two figures through MultiEmbedder and change only one tab.
- Touch a real map legend hit area, assert its visible highlight persists after release/mouse movement, then clears on outside touch.
- Resolve an old indicator response after the second multidimensional view renders, and assert the second title and exact table values remain. Before the fix, the title remained but the chart/table disappeared; after the fix the journey passes.
- 4 browser tests pass. Repository typecheck includes the fixture/test project; changed-file lint and formatting pass. New browser files are excluded from the default Vitest inventory.
- README documents local commands, failure screenshots/traces, no retries, initial matrix and execution policy. Existing BDD and main CI policy remain unchanged. Checked-in CI has no browser job; external Buildkite coverage remains unverified and should be confirmed before promoting this suite to a gate.
- This uses the real MultiDim embed boundary; it does not claim to cover every full data-page metadata panel or every browser.

</details>
