### PR TITLE
Test authored CMS output and publication persistence

### DIFF
--- a/adminSiteServer/test-files/publication-fixture.json
+++ b/adminSiteServer/test-files/publication-fixture.json
@@ -1,0 +1,21 @@
+{
+    "data": {
+        "documentId": "publication-fixture",
+        "revisionId": "fixture-revision",
+        "body": {
+            "content": [
+                {
+                    "paragraph": {
+                        "elements": [
+                            {
+                                "textRun": {
+                                    "content": "title: Publication fixture\ntype: article\n[+body]\nDraft words.\n[]\n"
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/adminSiteServer/tests/gdoc-pipeline.test.ts
+++ b/adminSiteServer/tests/gdoc-pipeline.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { load } from "cheerio"
+import { docs_v1 } from "@googleapis/docs"
+import { OwidGdocType } from "@ourworldindata/types"
+import {
+    extractGdocPageData,
+    deserializeOwidGdocPageData,
+} from "@ourworldindata/utils"
+import { latestGrapherConfigSchema } from "@ourworldindata/grapher"
+import { getAdminTestEnv } from "./testEnv.js"
+import { knexReadWriteTransaction } from "../../db/db.js"
+import { GdocPost } from "../../db/model/Gdoc/GdocPost.js"
+import { gdocToArchie } from "../../db/model/Gdoc/gdocToArchie.js"
+import { archieToEnriched } from "../../db/model/Gdoc/archieToEnriched.js"
+import { OwidGdoc } from "../../site/gdocs/OwidGdoc.js"
+
+vi.mock(import("../../baker/GrapherBakingUtils.js"), async (original) => ({
+    ...(await original()),
+    triggerStaticBuild: vi.fn(async () => undefined),
+}))
+const env = getAdminTestEnv()
+beforeEach(async () => {
+    await env.testKnex("images").where({ filename: "fixture.png" }).delete()
+})
+afterEach(async () => {
+    await env.testKnex("images").where({ filename: "fixture.png" }).delete()
+})
+
+// One small attachment graph: article -> author, image, standalone chart.
+// A second corpus row omits the image to exercise the reader-facing fallback.
+const source: docs_v1.Schema$Document = {
+    documentId: "pipeline-article",
+    revisionId: "revision-1",
+    body: {
+        content: [
+            {
+                paragraph: {
+                    elements: [
+                        {
+                            textRun: {
+                                content:
+                                    "title: Pipeline article\ntype: article\nauthors: Fixture Author\n[+body]\n",
+                            },
+                        },
+                    ],
+                },
+            },
+            {
+                paragraph: {
+                    paragraphStyle: { namedStyleType: "HEADING_2" },
+                    elements: [
+                        { textRun: { content: "Evidence and sources\n" } },
+                    ],
+                },
+            },
+            {
+                paragraph: {
+                    elements: [
+                        {
+                            textRun: {
+                                content:
+                                    "A result with a source.{ref}A precise source note.{/ref}\n\n{.image}\nfilename: fixture.png\ncaption: Fixture caption\n{}\n\n{.chart}\nurl: https://ourworldindata.org/grapher/pipeline-chart\n{}\n[]\n",
+                            },
+                        },
+                    ],
+                },
+            },
+        ],
+    },
+}
+
+describe("Authored content to rendered page", () => {
+    it.each([
+        { name: "resolved image", withImage: true },
+        { name: "missing image fallback", withImage: false },
+    ])(
+        "preserves semantic targets and attachments: $name",
+        async ({ withImage }) => {
+            await env.testKnex("posts_gdocs").insert({
+                id: "pipeline-author",
+                slug: "fixture-author",
+                published: true,
+                content: JSON.stringify({
+                    type: OwidGdocType.Author,
+                    title: "Fixture Author",
+                    body: [],
+                    authors: [],
+                }),
+            })
+            if (withImage)
+                await env.testKnex("images").insert({
+                    filename: "fixture.png",
+                    cloudflareId: "fixture-image",
+                    hash: "fixture-hash",
+                    defaultAlt: "A locally resolved diagram",
+                    originalWidth: 800,
+                    originalHeight: 400,
+                    userId: env.userId,
+                })
+            await env.request({
+                method: "POST",
+                path: "/charts",
+                body: JSON.stringify({
+                    $schema: latestGrapherConfigSchema,
+                    title: "Resolved chart title",
+                    slug: "pipeline-chart",
+                    isPublished: true,
+                }),
+            })
+            const gdoc = new GdocPost("pipeline-article")
+            const { text } = await gdocToArchie(source)
+            gdoc.content = archieToEnriched(text, gdoc._enrichSubclassContent)
+            gdoc.slug = "pipeline-article"
+            gdoc.published = true
+            gdoc.publishedAt = new Date("2024-01-01T00:00:00Z")
+            await knexReadWriteTransaction(async (trx) => {
+                await gdoc.loadState(trx)
+            })
+            const pageData = extractGdocPageData(gdoc.toJSON())
+            const serialized = JSON.parse(JSON.stringify(pageData))
+            expect(serialized.linkedAuthors).toMatchObject([
+                { slug: "fixture-author", name: "Fixture Author" },
+            ])
+            expect(serialized.linkedCharts["pipeline-chart"]).toMatchObject({
+                title: "Resolved chart title",
+            })
+            const $ = load(
+                renderToStaticMarkup(
+                    createElement(
+                        OwidGdoc,
+                        deserializeOwidGdocPageData(serialized)
+                    )
+                )
+            )
+            expect($("h2#evidence-and-sources").text()).toBe(
+                "Evidence and sources"
+            )
+            const footnoteLink = $("a.ref").attr("href")
+            expect(footnoteLink).toMatch(/^#note-/)
+            expect($(footnoteLink).text()).toContain("A precise source note.")
+            expect($('a[href="/team/fixture-author"]').text()).toContain(
+                "Fixture Author"
+            )
+            expect($(".GrapherWithFallback img").attr("src")).toContain(
+                "/grapher/pipeline-chart"
+            )
+            if (withImage) {
+                expect(
+                    serialized.imageMetadata["fixture.png"].cloudflareId
+                ).toBe("fixture-image")
+                expect(
+                    $('img[alt="A locally resolved diagram"]').attr("src")
+                ).toContain("fixture-image")
+                expect($("figcaption").text()).toContain("Fixture caption")
+            } else {
+                expect(serialized.imageMetadata).not.toHaveProperty(
+                    "fixture.png"
+                )
+                expect($("figcaption").text()).toContain("Fixture caption")
+                expect($('img[alt="A locally resolved diagram"]')).toHaveLength(
+                    0
+                )
+            }
+        }
+    )
+})

--- a/adminSiteServer/tests/gdoc-publication.test.ts
+++ b/adminSiteServer/tests/gdoc-publication.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { SearchClient } from "@algolia/client-search"
+import { OwidGdocType, type OwidGdocPostInterface } from "@ourworldindata/types"
+import { getAdminTestEnv } from "./testEnv.js"
+
+const transport = vi.hoisted(() => ({
+    getSettings: vi.fn(async () => ({ attributesForFaceting: ["path"] })),
+    browseObjects: vi.fn(async () => undefined),
+    saveObjects: vi.fn(async () => undefined),
+    deleteObjects: vi.fn(async () => undefined),
+}))
+vi.mock(import("../../settings/serverSettings.js"), async (original) => ({
+    ...(await original()),
+    ALGOLIA_INDEXING: true,
+}))
+vi.mock(
+    import("../../baker/algolia/configureAlgolia.js"),
+    async (original) => ({
+        ...(await original()),
+        getAlgoliaClient: () => transport as unknown as SearchClient,
+    })
+)
+vi.mock(import("../../baker/GrapherBakingUtils.js"), async (original) => ({
+    ...(await original()),
+    triggerStaticBuild: vi.fn(async () => undefined),
+}))
+const env = getAdminTestEnv()
+beforeEach(async () => {
+    vi.clearAllMocks()
+    await env.testKnex("tags").insert({ name: "tag-graph-root" })
+    await env
+        .testKnex("redirects")
+        .whereIn("source", ["/first-slug", "/second-slug"])
+        .delete()
+})
+
+afterEach(async () => {
+    await env
+        .testKnex("redirects")
+        .whereIn("source", ["/first-slug", "/second-slug"])
+        .delete()
+})
+
+async function draft(): Promise<OwidGdocPostInterface> {
+    await env.request({ method: "PUT", path: "/gdocs/publication-fixture" })
+    const base = await env.fetchJson("/gdocs/publication-fixture")
+    return {
+        ...base,
+        slug: "first-slug",
+        published: true,
+        publishedAt: new Date("2024-01-01T00:00:00Z"),
+        content: {
+            ...base.content,
+            type: OwidGdocType.Article,
+            title: "Saved author content",
+            authors: [],
+            body: [
+                {
+                    type: "text",
+                    value: [
+                        {
+                            spanType: "span-simple-text",
+                            text: "The author's saved words.",
+                        },
+                    ],
+                    parseErrors: [],
+                },
+            ],
+        },
+    }
+}
+async function save(gdoc: OwidGdocPostInterface): Promise<void> {
+    await env.request({
+        method: "PUT",
+        path: `/gdocs/${gdoc.id}`,
+        body: JSON.stringify(gdoc),
+    })
+}
+
+describe("CMS publication persistence", () => {
+    it("publishes, redirects renamed slugs without chains, and unpublishes saved content", async () => {
+        const gdoc = await draft()
+        await save(gdoc)
+        expect((await env.fetchJson(`/gdocs/${gdoc.id}`)).published).toBe(true)
+        expect(transport.saveObjects).toHaveBeenCalled()
+        await save({ ...gdoc, slug: "second-slug" })
+        await save({ ...gdoc, slug: "final-slug" })
+        expect(
+            await env
+                .testKnex("redirects")
+                .whereIn("source", ["/first-slug", "/second-slug"])
+                .select("source", "target")
+                .orderBy("source")
+        ).toEqual([
+            { source: "/first-slug", target: "/final-slug" },
+            { source: "/second-slug", target: "/final-slug" },
+        ])
+        await save({ ...gdoc, slug: "final-slug", published: false })
+        const row = await env
+            .testKnex("posts_gdocs")
+            .where({ id: gdoc.id })
+            .first()
+        expect(Boolean(row.published)).toBe(false)
+        expect(row.markdown).toContain("The author's saved words.")
+        expect(JSON.parse(row.content).title).toBe("Saved author content")
+    })
+
+    it("commits the author's edit when enabled Algolia indexing fails", async () => {
+        const gdoc = await draft()
+        await save(gdoc)
+        transport.saveObjects.mockClear()
+        transport.saveObjects.mockRejectedValueOnce(
+            new Error("Controlled indexing outage")
+        )
+        await save({
+            ...gdoc,
+            content: {
+                ...gdoc.content,
+                title: "New saved title",
+                body: [
+                    {
+                        type: "text",
+                        value: [
+                            {
+                                spanType: "span-simple-text",
+                                text: "New words survive indexing failure.",
+                            },
+                        ],
+                        parseErrors: [],
+                    },
+                ],
+            },
+        })
+        await expect(
+            transport.saveObjects.mock.results[0].value
+        ).rejects.toThrow("Controlled indexing outage")
+        const row = await env
+            .testKnex("posts_gdocs")
+            .where({ id: gdoc.id })
+            .first()
+        expect(Boolean(row.published)).toBe(true)
+        expect(JSON.parse(row.content).title).toBe("New saved title")
+        expect(row.markdown).toContain("New words survive indexing failure.")
+        expect(row.markdown).not.toContain("The author's saved words.")
+    })
+})


### PR DESCRIPTION
> _Written by OpenAI GPT-6 — @danyx23 at the wheel._

Add CMS contracts from authored Google Docs content through resolved attachments and rendered page output, plus publication, rename, unpublication and indexing-failure saves against MySQL. Enabled Algolia indexing uses a controlled client failure and must preserve the author's saved edit.

Closes #7202. Based on #7190 (`test-strategy`).

<details><summary>Details</summary>

- Separate files keep rendering/attachment evidence and save-boundary evidence reviewable independently. Existing parser round trips and markdown tests remain unchanged.
- A small Google Docs AST passes through `gdocToArchie`, subclass enrichment, real `loadState` SQL attachment resolution, page-data extraction, JSON serialization, production deserialization and OwidGdoc rendering. Checks heading/footnote targets, author path, image alt/delivery URL, chart fallback URL, and missing-image caption retention.
- Publication tests invoke the actual admin endpoint, check first publication, two slug changes with flattened redirects, unpublication retaining content, and a confirmed rejected Algolia write while the edited title/markdown commit.
- `ALGOLIA_INDEXING` is explicitly enabled in this test module; a fake Algolia client supplies every transport operation. Nothing writes to live Algolia. Images and redirect fixtures receive scoped cleanup because those tables outlive the admin test helper's usual cleanup.
- Targeted defects: omitting image attachment loading, omitting redirect persistence and rethrowing the caught indexing failure each fail the corresponding test. Restored all defects and reran successfully.
- Validation: 4 focused tests pass; clean `make dbtest` passes; typecheck, changed-file lint and formatting pass. A direct full rerun against an already-used DB encountered old redirect fixtures; the normal runner recreated its dedicated database and passed.
- Focused command with a prepared test DB: `ALGOLIA_INDEXING=false ENV=production yarn vitest run -c vitest.db.config.ts adminSiteServer/tests/gdoc-pipeline.test.ts adminSiteServer/tests/gdoc-publication.test.ts`. Both run in the existing test-db CI regime.

</details>
