### PR TITLE
Test search response contracts deterministically and strip ranking metadata

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -220,11 +220,13 @@ tests and repository typechecking cannot prove.
 
 ### Runtime-specific and external-service tests
 
-The `functions/test` area includes Node-level integration tests and opt-in E2E
-tests that run handlers in a real Workers runtime or contact services such as
-Algolia and R2. They protect compatibility and integration assumptions that a
-mock cannot establish, but external state makes them slower and less
-deterministic. They should be narrowly scoped, clearly labelled, and kept out
+The `functions/test` area includes tests that run handlers in a real Workers
+runtime, including local R2 tests and live Algolia search tests. The Node-level
+`functions/api/search/searchApi.integration.test.ts` also contacts live Algolia.
+These search and local R2 files are currently included in default Vitest discovery
+and the main CI `test` job; dedicated scripts do not make them opt-in. They protect
+compatibility and integration assumptions that a mock cannot establish, but
+external state makes them slower and less deterministic. They should be narrowly scoped, clearly labelled, and kept out
 of the fast suite unless their environment can be made reliable.
 
 ### Bespoke project tests and builds

--- a/functions/api/search/TESTING.md
+++ b/functions/api/search/TESTING.md
@@ -1,0 +1,52 @@
+# Search response contracts
+
+`yarn test run functions/api/search/searchApi.test.ts` runs deterministic API
+contracts. The real search implementation and Algolia lite client run against a
+stubbed HTTP transport. Fixtures explicitly contain all three chart result types
+and eight public page types, including internal fields that must not escape.
+Tests cover canonical/custom-base URLs, query parameters, page/offset forwarding,
+response metadata, empty results and invalid-versus-empty topics with the full
+facet limit. The lower-level facet/matching tests remain separate.
+
+`yarn test run functions/api/search/searchApi.integration.test.ts` runs seven live
+Algolia/index contracts: country filtering, all-country filtering, topic filtering,
+rare valid topics with empty results, chart pagination, page pagination and page
+type filtering. Their unchanged assertions retain evidence about the real index
+that a controlled response cannot establish. They use the existing public search
+credentials and must have network access.
+
+`yarn test run functions/test/search.e2e.test.ts` retains real Workers plus live
+Algolia compatibility. `yarn test run functions/test/grapher-config-r2.e2e.test.ts`
+is different: it uses local Workers/R2 and is deterministic. It remains untouched.
+
+All four files are currently in the default Vitest inventory and run in the main
+CI workflow's `test` job. The live files are **not opt-in** merely because dedicated
+scripts also exist. This PR does not change execution policy or exclude local R2
+coverage. Use the focused deterministic command when working offline.
+
+## Preservation mapping
+
+No retained live test is structurally rewritten. Removed response assertions move
+to the following explicit, controlled scenarios; input query words in the old
+smoke tests were examples, not promises of specific index records.
+
+| Existing live assertions                                                                 | Retained evidence                                                                                               |
+| ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Chart query echo, nonempty bounded results, required fields and chart/explorer URL shape | Exact three-type deterministic response; real-index nonempty/filter/pagination checks remain live               |
+| One-country and all-country positive results; topic results                              | Same live tests, unchanged; existing deterministic facet tests still cover request rules                        |
+| Unknown topic throws with available-topic guidance                                       | Exact deterministic validation error and full facet request                                                     |
+| Polio is valid even when the query finds no hits                                         | Same live test plus deterministic rare-topic/empty response                                                     |
+| Chart pages 0/1, page size, exact lengths, distinct first slugs                          | Same live pagination test plus deterministic request/response metadata                                          |
+| Conditional chart/explorer URLs                                                          | Both types are mandatory in the fixture; multi-dimensional query URLs added                                     |
+| Chart internal-field removal and required fields                                         | Exact deterministic response includes internal fields in the input and excludes them from every output          |
+| Empty chart query and query echo                                                         | Deterministic empty response, also rejects a spurious closest-matches flag                                      |
+| Custom chart base URL                                                                    | Exact deterministic pagination result URL                                                                       |
+| Banana/climate page query echo, bounded positive results, required fields and URL        | Explicit typed page fixture and exact output; live page-filter and pagination checks retain real-index evidence |
+| Page offsets, page sizes, exact lengths, distinct first slugs                            | Same live pagination test plus deterministic SDK offset/length assertions                                       |
+| About-page results are nonempty and have the requested type                              | Same live test, unchanged; deterministic request filters and output type assertions                             |
+| Data-insight URL prefix                                                                  | Mandatory data-insight fixture, with seven other canonical page-type paths                                      |
+| Page internal-field removal                                                              | Exact output for all eight page types; additionally reject leaked ranking metadata                              |
+| Empty page query and custom base URL                                                     | Deterministic empty scenario and exact custom-base page URLs                                                    |
+
+This separates reproducible response behavior from live service evidence; it is
+not based on an observed search outage or measured performance regression.

--- a/functions/api/search/searchApi.integration.test.ts
+++ b/functions/api/search/searchApi.integration.test.ts
@@ -11,35 +11,6 @@ describe("searchCharts with real Algolia", () => {
         indexPrefix: undefined, // Production index (no prefix)
     }
 
-    it("performs basic search with query", async () => {
-        const result = await searchCharts(
-            algoliaConfig,
-            {
-                query: "population",
-                filters: [],
-                requireAllCountries: false,
-            },
-            0,
-            5 // Small page size for testing
-        )
-
-        expect(result.query).toBe("population")
-        expect(result.results.length).toBeGreaterThan(0)
-        expect(result.results.length).toBeLessThanOrEqual(5)
-        expect(result.nbHits).toBeGreaterThan(0)
-
-        // Check first result has required fields
-        expect(result.results[0]).toHaveProperty("title")
-        expect(result.results[0]).toHaveProperty("slug")
-        expect(result.results[0]).toHaveProperty("type")
-        expect(result.results[0]).toHaveProperty("url")
-
-        // URL should be properly constructed
-        expect(result.results[0].url).toMatch(
-            /^https:\/\/ourworldindata\.org\/(grapher|explorers)\//
-        )
-    })
-
     it("returns results with country filter", async () => {
         const result = await searchCharts(
             algoliaConfig,
@@ -89,23 +60,6 @@ describe("searchCharts with real Algolia", () => {
         )
 
         expect(result.results.length).toBeGreaterThan(0)
-    })
-
-    it("throws helpful error for invalid topic when no results found", async () => {
-        await expect(
-            searchCharts(
-                algoliaConfig,
-                {
-                    query: "",
-                    filters: [
-                        { type: FilterType.TOPIC, name: "InvalidTopicName123" },
-                    ],
-                    requireAllCountries: false,
-                },
-                0,
-                5
-            )
-        ).rejects.toThrow(/does not exist. Available topics:/)
     })
 
     it("does not claim a valid topic doesn't exist just because the search found nothing", async () => {
@@ -163,104 +117,6 @@ describe("searchCharts with real Algolia", () => {
         // Pages should have different results
         expect(page0.results[0].slug).not.toBe(page1.results[0].slug)
     })
-
-    it("constructs correct URLs for different chart types", async () => {
-        const result = await searchCharts(
-            algoliaConfig,
-            {
-                query: "covid",
-                filters: [],
-                requireAllCountries: false,
-            },
-            0,
-            20
-        )
-
-        expect(result.results.length).toBeGreaterThan(0)
-
-        // Find examples of different types if they exist
-        const chartResult = result.results.find((r) => r.type === "chart")
-        const explorerResult = result.results.find(
-            (r) => r.type === "explorerView"
-        )
-
-        if (chartResult) {
-            expect(chartResult.url).toBe(
-                `https://ourworldindata.org/grapher/${chartResult.slug}`
-            )
-        }
-
-        if (explorerResult) {
-            expect(explorerResult.url).toMatch(
-                /^https:\/\/ourworldindata\.org\/explorers\//
-            )
-        }
-    })
-
-    it("removes internal Algolia fields from results", async () => {
-        const result = await searchCharts(
-            algoliaConfig,
-            {
-                query: "population",
-                filters: [],
-                requireAllCountries: false,
-            },
-            0,
-            1
-        )
-
-        expect(result.results.length).toBeGreaterThan(0)
-
-        // Internal Algolia fields should be removed
-        expect(result.results[0]).not.toHaveProperty("objectID")
-        expect(result.results[0]).not.toHaveProperty("_highlightResult")
-        expect(result.results[0]).not.toHaveProperty("_snippetResult")
-
-        // Required fields should be present
-        expect(result.results[0]).toHaveProperty("title")
-        expect(result.results[0]).toHaveProperty("slug")
-        expect(result.results[0]).toHaveProperty("type")
-        expect(result.results[0]).toHaveProperty("url")
-    })
-
-    it("returns empty results for nonsense query", async () => {
-        const result = await searchCharts(
-            algoliaConfig,
-            {
-                query: "xyzabc123nonsense456",
-                filters: [],
-                requireAllCountries: false,
-            },
-            0,
-            20
-        )
-
-        expect(result.query).toBe("xyzabc123nonsense456")
-        expect(result.results.length).toBe(0)
-        expect(result.nbHits).toBe(0)
-    })
-
-    it("uses custom base URL for staging deployments", async () => {
-        const stagingUrl = "https://staging-pr-123.owid.io"
-        const result = await searchCharts(
-            algoliaConfig,
-            {
-                query: "population",
-                filters: [],
-                requireAllCountries: false,
-            },
-            0,
-            3,
-            stagingUrl
-        )
-
-        expect(result.results.length).toBeGreaterThan(0)
-
-        // All URLs should use the staging base URL
-        result.results.forEach((hit) => {
-            expect(hit.url).toMatch(/^https:\/\/staging-pr-123\.owid\.io\//)
-        })
-    })
 })
 
 describe("searchPages with real Algolia", () => {
@@ -269,51 +125,6 @@ describe("searchPages with real Algolia", () => {
         apiKey: "bafe9c4659e5657bf750a38fbee5c269",
         indexPrefix: undefined,
     }
-
-    it("searches for 'banana production' pages", async () => {
-        const result = await searchPages(
-            algoliaConfig,
-            "banana production",
-            0,
-            5
-        )
-
-        expect(result.query).toBe("banana production")
-        expect(result.results.length).toBeGreaterThan(0)
-        expect(result.results.length).toBeLessThanOrEqual(5)
-        expect(result.nbHits).toBeGreaterThan(0)
-
-        // Check first result has required fields
-        const firstResult = result.results[0]
-        expect(firstResult).toHaveProperty("title")
-        expect(firstResult).toHaveProperty("slug")
-        expect(firstResult).toHaveProperty("type")
-        expect(firstResult).toHaveProperty("url")
-
-        // URL should be properly constructed
-        expect(firstResult.url).toMatch(/^https:\/\/ourworldindata\.org\//)
-
-        console.log("\nFirst page result for 'banana production':")
-        console.log(`Title: ${firstResult.title}`)
-        console.log(`Slug: ${firstResult.slug}`)
-        console.log(`Type: ${firstResult.type}`)
-        console.log(`URL: ${firstResult.url}`)
-    })
-
-    it("performs basic page search", async () => {
-        const result = await searchPages(algoliaConfig, "climate change", 0, 5)
-
-        expect(result.query).toBe("climate change")
-        expect(result.results.length).toBeGreaterThan(0)
-        expect(result.offset).toBe(0)
-        expect(result.length).toBe(5)
-
-        // Check required fields
-        expect(result.results[0]).toHaveProperty("title")
-        expect(result.results[0]).toHaveProperty("slug")
-        expect(result.results[0]).toHaveProperty("type")
-        expect(result.results[0]).toHaveProperty("url")
-    })
 
     it("handles pagination with offset", async () => {
         const page1 = await searchPages(algoliaConfig, "health", 0, 3)
@@ -340,71 +151,6 @@ describe("searchPages with real Algolia", () => {
         // All results should be about-pages
         result.results.forEach((page) => {
             expect(page.type).toBe("about-page")
-        })
-    })
-
-    it("builds type-specific URLs for non-article page types", async () => {
-        // data-insights bake to /data-insights/<slug> (see
-        // getPrefixedGdocPath), different from the bare /<slug> used by
-        // article/about-page.
-        const diResult = await searchPages(algoliaConfig, "co2", 0, 5, [
-            "data-insight",
-        ])
-        expect(diResult.results.length).toBeGreaterThan(0)
-        diResult.results.forEach((page) => {
-            expect(page.type).toBe("data-insight")
-            expect(page.url).toBe(
-                `https://ourworldindata.org/data-insights/${page.slug}`
-            )
-        })
-    })
-
-    it("removes internal Algolia fields from results", async () => {
-        const result = await searchPages(algoliaConfig, "population", 0, 1)
-
-        expect(result.results.length).toBeGreaterThan(0)
-
-        // Internal Algolia fields should be removed
-        expect(result.results[0]).not.toHaveProperty("objectID")
-        expect(result.results[0]).not.toHaveProperty("_highlightResult")
-        expect(result.results[0]).not.toHaveProperty("_snippetResult")
-
-        // Required fields should be present
-        expect(result.results[0]).toHaveProperty("title")
-        expect(result.results[0]).toHaveProperty("slug")
-        expect(result.results[0]).toHaveProperty("type")
-        expect(result.results[0]).toHaveProperty("url")
-    })
-
-    it("returns empty results for nonsense query", async () => {
-        const result = await searchPages(
-            algoliaConfig,
-            "xyzabc123nonsense456",
-            0,
-            10
-        )
-
-        expect(result.query).toBe("xyzabc123nonsense456")
-        expect(result.results.length).toBe(0)
-        expect(result.nbHits).toBe(0)
-    })
-
-    it("uses custom base URL for staging deployments", async () => {
-        const stagingUrl = "https://staging-pr-123.owid.io"
-        const result = await searchPages(
-            algoliaConfig,
-            "climate change",
-            0,
-            3,
-            ["article", "about-page"],
-            stagingUrl
-        )
-
-        expect(result.results.length).toBeGreaterThan(0)
-
-        // All URLs should use the staging base URL
-        result.results.forEach((hit) => {
-            expect(hit.url).toMatch(/^https:\/\/staging-pr-123\.owid\.io\//)
         })
     })
 })

--- a/functions/api/search/searchApi.test.ts
+++ b/functions/api/search/searchApi.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+    ChartRecordType,
+    FilterType,
+    OwidGdocType,
+} from "@ourworldindata/types"
+import {
+    searchCharts,
+    searchPages,
+    SearchValidationError,
+} from "./searchApi.js"
+
+const config = { appId: "fixture", apiKey: "fixture", indexPrefix: "test" }
+const state = { query: "population", filters: [], requireAllCountries: false }
+const internal = {
+    objectID: "internal-id",
+    _rankingInfo: { words: 2 },
+    _highlightResult: { title: "internal" },
+    _snippetResult: { content: "internal" },
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+// Stub fetch, not the search API or Algolia client: URL shaping, SDK request
+// serialization, closest-match routing and response cleanup all execute normally.
+function transport(results: object[]): ReturnType<typeof vi.fn> {
+    const fetch = vi.fn(async () => Response.json({ results }))
+    vi.stubGlobal("fetch", fetch)
+    return fetch
+}
+function response(hits: object[], pagination: object = {}): object {
+    return {
+        hits,
+        nbHits: hits.length,
+        page: 0,
+        nbPages: 1,
+        hitsPerPage: 20,
+        ...pagination,
+    }
+}
+function requestBody(
+    fetch: ReturnType<typeof vi.fn>,
+    call = 0
+): { requests: Record<string, unknown>[] } {
+    const args = fetch.mock.calls[call] as [unknown, RequestInit]
+    return JSON.parse(String(args[1].body))
+}
+
+describe("deterministic search response contracts", () => {
+    it("returns every chart result type with exact URLs and strips internal/unrequested fields", async () => {
+        transport([
+            response([
+                {
+                    ...internal,
+                    title: "Chart",
+                    slug: "population",
+                    type: ChartRecordType.Chart,
+                    queryParams: "?ignored=yes",
+                    internalScore: 999,
+                },
+                {
+                    ...internal,
+                    title: "Explorer",
+                    slug: "energy",
+                    type: ChartRecordType.ExplorerView,
+                    queryParams: "?country=FRA&Metric=Total",
+                },
+                {
+                    ...internal,
+                    title: "Multi-dimensional",
+                    slug: "health",
+                    type: ChartRecordType.MultiDimView,
+                    queryParams: "?metric=rate",
+                },
+            ]),
+        ])
+        expect(await searchCharts(config, state)).toEqual({
+            query: "population",
+            nbHits: 3,
+            page: 0,
+            nbPages: 1,
+            hitsPerPage: 20,
+            results: [
+                {
+                    title: "Chart",
+                    slug: "population",
+                    type: "chart",
+                    queryParams: "?ignored=yes",
+                    url: "https://ourworldindata.org/grapher/population",
+                },
+                {
+                    title: "Explorer",
+                    slug: "energy",
+                    type: "explorerView",
+                    queryParams: "?country=FRA&Metric=Total",
+                    url: "https://ourworldindata.org/explorers/energy?country=FRA&Metric=Total",
+                },
+                {
+                    title: "Multi-dimensional",
+                    slug: "health",
+                    type: "multiDimView",
+                    queryParams: "?metric=rate",
+                    url: "https://ourworldindata.org/grapher/health?metric=rate",
+                },
+            ],
+        })
+    })
+
+    it("forwards page and page size and returns exact pagination metadata", async () => {
+        const fetch = transport([
+            response(
+                [
+                    {
+                        ...internal,
+                        title: "Second page",
+                        slug: "second",
+                        type: ChartRecordType.Chart,
+                    },
+                ],
+                { nbHits: 4, page: 1, nbPages: 2, hitsPerPage: 2 }
+            ),
+        ])
+        expect(
+            await searchCharts(config, state, 1, 2, "https://preview.example")
+        ).toEqual({
+            query: "population",
+            nbHits: 4,
+            page: 1,
+            nbPages: 2,
+            hitsPerPage: 2,
+            results: [
+                {
+                    title: "Second page",
+                    slug: "second",
+                    type: "chart",
+                    url: "https://preview.example/grapher/second",
+                },
+            ],
+        })
+        expect(requestBody(fetch).requests[0]).toMatchObject({
+            page: 1,
+            hitsPerPage: 2,
+            query: "population",
+        })
+    })
+
+    it.each([
+        [OwidGdocType.Article, "/example"],
+        [OwidGdocType.AboutPage, "/example"],
+        [OwidGdocType.DataInsight, "/data-insights/example"],
+        [OwidGdocType.Profile, "/profile/example"],
+        [OwidGdocType.Author, "/team/example"],
+        [OwidGdocType.TopicPage, "/example"],
+        [OwidGdocType.LinearTopicPage, "/example"],
+        [OwidGdocType.Announcement, "/example"],
+    ])(
+        "returns an explicit %s page and its canonical path",
+        async (type, path) => {
+            const fetch = transport([
+                response(
+                    [
+                        {
+                            ...internal,
+                            title: "A page",
+                            slug: "example",
+                            type,
+                            content: "Public summary",
+                            authors: ["Fixture Author"],
+                        },
+                    ],
+                    { nbHits: 7 }
+                ),
+            ])
+            expect(
+                await searchPages(
+                    config,
+                    "health",
+                    3,
+                    2,
+                    [type],
+                    "https://preview.example"
+                )
+            ).toEqual({
+                query: "health",
+                nbHits: 7,
+                offset: 3,
+                length: 2,
+                results: [
+                    {
+                        title: "A page",
+                        slug: "example",
+                        type,
+                        content: "Public summary",
+                        authors: ["Fixture Author"],
+                        url: `https://preview.example${path}`,
+                    },
+                ],
+            })
+            expect(requestBody(fetch).requests[0]).toMatchObject({
+                offset: 3,
+                length: 2,
+                filters: `type:${type}`,
+            })
+        }
+    )
+
+    it.each(["charts", "pages"] as const)(
+        "keeps empty %s responses honest",
+        async (kind) => {
+            transport([response([], { nbPages: 0 })])
+            const result =
+                kind === "charts"
+                    ? await searchCharts(config, {
+                          ...state,
+                          query: "nonsense",
+                      })
+                    : await searchPages(config, "nonsense")
+            expect(result.query).toBe("nonsense")
+            expect(result.results).toEqual([])
+            expect(result.nbHits).toBe(0)
+            expect(result).not.toHaveProperty("closestMatches")
+        }
+    )
+
+    it("distinguishes invalid topics from valid topics with no results using the full facet inventory", async () => {
+        const fetch = vi.fn(async (_input: unknown, init?: RequestInit) => {
+            const { requests } = JSON.parse(String(init?.body)) as {
+                requests: { facets?: string[] }[]
+            }
+            return Response.json({
+                results: [
+                    requests[0].facets
+                        ? {
+                              hits: [],
+                              facets: { tags: { Health: 5, Polio: 1 } },
+                          }
+                        : response([], { nbPages: 0 }),
+                ],
+            })
+        })
+        vi.stubGlobal("fetch", fetch)
+        await expect(
+            searchCharts(config, {
+                ...state,
+                query: "",
+                filters: [{ type: FilterType.TOPIC, name: "Imaginary" }],
+            })
+        ).rejects.toThrow(
+            new SearchValidationError(
+                'No results found. The topic "Imaginary" does not exist. Available topics: Health, Polio'
+            )
+        )
+        expect(
+            await searchCharts(config, {
+                ...state,
+                query: "",
+                filters: [{ type: FilterType.TOPIC, name: "Polio" }],
+            })
+        ).toEqual({
+            query: "",
+            results: [],
+            nbHits: 0,
+            page: 0,
+            nbPages: 0,
+            hitsPerPage: 20,
+        })
+        const facetRequests = fetch.mock.calls
+            .flatMap(
+                ([, init]) =>
+                    (
+                        JSON.parse(String(init?.body)) as {
+                            requests: Record<string, unknown>[]
+                        }
+                    ).requests
+            )
+            .filter((request) => request.facets)
+        expect(facetRequests).toHaveLength(2)
+        for (const request of facetRequests)
+            expect(request).toMatchObject({
+                facets: ["tags"],
+                hitsPerPage: 0,
+                maxValuesPerFacet: 1000,
+            })
+    })
+})

--- a/functions/api/search/searchApi.ts
+++ b/functions/api/search/searchApi.ts
@@ -285,6 +285,7 @@ export async function searchPages(
         const {
             _highlightResult,
             _snippetResult,
+            _rankingInfo,
             objectID: _objectID,
             ...cleanHit
         } = hit as any


### PR DESCRIPTION
> _Written by OpenAI GPT-6 — @danyx23 at the wheel._

Move search response-shaping assertions into deterministic transport-level tests while retaining live evidence for index filtering, pagination, and Workers compatibility. The new tests expose and fix `_rankingInfo` leaking into page search responses.

Closes #7203. Based on #7190 (`test-strategy`). Existing test execution policy is unchanged; documentation now correctly identifies live tests included in default Vitest discovery and CI.

<details><summary>Details</summary>

- Run the real search implementation and Algolia client with controlled HTTP responses. Require all three chart result types and eight page types, exact URLs and public fields, pagination forwarding, empty responses, and invalid-versus-empty topic behavior.
- Keep seven existing live tests unchanged for country/all-country/topic filtering, rare valid topics, chart/page pagination, and page-type filtering. Workers search and deterministic local R2 suites remain unchanged.
- Map removed assertions to retained evidence and document commands/policy in `functions/api/search/TESTING.md`.
- Validation: all 19 original live tests passed before the rewrite. The final focused run passed 32 tests across four files (13 deterministic API tests, 7 retained live tests, and 12 Workers/search/R2 tests).
- Regression evidence: adding ranking metadata to fixtures failed all eight page-type cases before the response cleanup fix; all pass afterward.
- Repository typecheck, changed-file lint, formatting, and diff whitespace checks passed.

</details>
