### PR TITLE
Rich editor M7: drag blocks from the palette, in-place site preview

### DIFF
--- a/adminShared/RichEditorTypes.ts
+++ b/adminShared/RichEditorTypes.ts
@@ -11,6 +11,7 @@ import {
     PostGdocCommentThreadStatus,
     PostGdocRevisionKind,
 } from "@ourworldindata/types"
+import type { OwidGdocPageData, ProfileEntity } from "@ourworldindata/utils"
 
 // Request/response types for the rich editor API, shared between
 // adminSiteServer and adminSiteClient.
@@ -238,3 +239,30 @@ export type RichEditorSelectionRef =
           /** the selected text at capture time, for prompts and orphan UI */
           excerpt: string
       }
+
+// ── Preview (render the draft through the site components) ────────────────
+
+export interface RichEditorPreviewRequest {
+    /**
+     * The body as the editor currently has it (it may be ahead of the
+     * persisted draft head); the remaining content fields come from the
+     * draft. Omit to preview the draft head as stored.
+     */
+    body?: OwidEnrichedGdocBlock[]
+    /** Profiles: the entity to instantiate the template for (default: first in scope) */
+    entity?: string
+}
+
+export interface RichEditorPreviewResponse {
+    /**
+     * The same payload the site page embeds as `_OWID_GDOC_PROPS`: content
+     * plus every attachment the site components read from
+     * AttachmentsContext, with dates serialized as strings.
+     */
+    gdoc: OwidGdocPageData
+    /** Validation messages the gdoc pipeline produced for this content */
+    errors: OwidGdocErrorMessage[]
+    /** Profiles: the entities in scope, and the one this preview shows */
+    profileEntities?: ProfileEntity[]
+    profileEntity?: ProfileEntity
+}

--- a/adminSiteClient/richEditor/RichEditor.scss
+++ b/adminSiteClient/richEditor/RichEditor.scss
@@ -7,6 +7,13 @@
 
 @import "../../packages/@ourworldindata/components/src/styles/typography-constants.scss";
 
+// AdminLayout gives <main> a fixed viewport height (content overflows it);
+// the sticky topbar needs the page to be as tall as its content
+.AdminLayout > main.rich-editor-page {
+    height: auto;
+    min-height: calc(100vh - 45px);
+}
+
 .rich-editor-page {
     padding: 16px 24px;
     // full width up to a wide maximum, so the canvas can show the desktop
@@ -19,11 +26,21 @@
     max-width: 640px;
 }
 
+// the page's own toolbar stays reachable while scrolling (mode toggle,
+// history, publish); the sticky elements below it are offset by its height,
+// which RichEditorPage measures into --rich-editor-topbar-height
 .rich-editor-page__topbar {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-    margin-bottom: 12px;
+    gap: 16px;
+    margin: -16px -24px 12px;
+    padding: 12px 24px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: #f5f5f5;
+    border-bottom: 1px solid #e5e1d8;
 }
 
 .rich-editor-page__workspace {
@@ -31,12 +48,33 @@
     gap: 24px;
     align-items: flex-start;
     margin-top: 12px;
+
+    // the workspace stays mounted while the preview is shown
+    &[hidden] {
+        display: none;
+    }
+}
+
+// --- preview (the document rendered through the site components) ---
+
+.rich-editor-page__preview {
+    margin-top: 12px;
+
+    &[hidden] {
+        display: none;
+    }
+}
+
+.rich-editor-page__preview-loading {
+    padding: 48px;
+    text-align: center;
+    color: #8a8577;
 }
 
 .rich-editor-page__palette {
     flex: 0 0 200px;
     position: sticky;
-    top: 16px;
+    top: calc(var(--rich-editor-topbar-height, 0px) + 16px);
     background: #faf9f6;
     border: 1px solid #e5e1d8;
     border-radius: 8px;
@@ -61,12 +99,17 @@
     background: none;
     border: none;
     border-radius: 6px;
-    cursor: pointer;
+    // click inserts at the cursor, drag inserts at the drop point
+    cursor: grab;
     font-size: 13px;
     text-align: left;
 
     &:hover {
         background: #efece4;
+    }
+
+    &:active {
+        cursor: grabbing;
     }
 }
 
@@ -503,7 +546,7 @@ $canvas-wide-measure: 1280px;
 .rich-editor-page__rail {
     flex: 0 0 320px;
     position: sticky;
-    top: 16px;
+    top: calc(var(--rich-editor-topbar-height, 0px) + 16px);
     background: #faf9f6;
     border: 1px solid #e5e1d8;
     border-radius: 8px;
@@ -667,7 +710,7 @@ $canvas-wide-measure: 1280px;
 
 .rich-editor-toolbar {
     position: sticky;
-    top: 0;
+    top: var(--rich-editor-topbar-height, 0px);
     z-index: 5;
     background: #fff;
     border: 1px solid #e5e1d8;

--- a/adminSiteClient/richEditor/RichEditor.tsx
+++ b/adminSiteClient/richEditor/RichEditor.tsx
@@ -14,6 +14,7 @@ import { enrichedBlocksToPmDoc } from "../../adminShared/richEditor/serializatio
 import { Collaboration } from "@tiptap/extension-collaboration"
 import { CollaborationCaret } from "@tiptap/extension-collaboration-caret"
 import { SlashCommands } from "./SlashCommands.js"
+import { PaletteDrop } from "./paletteDrop.js"
 import { CommentMark } from "./comments.js"
 import { BlockIdAssignment, ensureBlockIds } from "./blockIdentity.js"
 import type { RichEditorCollaboration } from "./collaboration.js"
@@ -172,6 +173,11 @@ export function RichEditor(props: {
     collaboration?: RichEditorCollaboration | null
     onCreate?: (editor: Editor) => void
     onSelectionChange?: (editor: Editor) => void
+    /**
+     * A block item from the insert palette was dropped on the canvas: the
+     * item's key and the block boundary to insert it at.
+     */
+    onPaletteDrop?: (itemKey: string, pos: number) => void
 }): React.ReactElement {
     const {
         initialBody,
@@ -182,6 +188,7 @@ export function RichEditor(props: {
         collaboration,
         onCreate,
         onSelectionChange,
+        onPaletteDrop,
     } = props
 
     // Set when a slash-menu "Image" command is waiting for the user to pick
@@ -196,6 +203,8 @@ export function RichEditor(props: {
     onCreateRef.current = onCreate
     const onSelectionChangeRef = useRef(onSelectionChange)
     onSelectionChangeRef.current = onSelectionChange
+    const onPaletteDropRef = useRef(onPaletteDrop)
+    onPaletteDropRef.current = onPaletteDrop
     if (requestImageRef) {
         requestImageRef.current = (insert) =>
             setPendingImageInsert(() => insert)
@@ -240,6 +249,10 @@ export function RichEditor(props: {
             SlashCommands.configure({
                 onRequestImage: (insert) => setPendingImageInsert(() => insert),
                 docType,
+            }),
+            PaletteDrop.configure({
+                onDrop: (itemKey, pos) =>
+                    onPaletteDropRef.current?.(itemKey, pos),
             }),
         ]
         // the editor schema is fixed after mount

--- a/adminSiteClient/richEditor/RichEditorPage.tsx
+++ b/adminSiteClient/richEditor/RichEditorPage.tsx
@@ -18,6 +18,7 @@ import {
     List,
     Modal,
     Popconfirm,
+    Segmented,
     Select,
     Space,
     Tabs,
@@ -26,7 +27,11 @@ import {
 } from "antd"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { Editor } from "@tiptap/core"
-import { OwidGdocAuthoringMode, OwidGdocType } from "@ourworldindata/types"
+import {
+    OwidEnrichedGdocBlock,
+    OwidGdocAuthoringMode,
+    OwidGdocType,
+} from "@ourworldindata/types"
 import { dayjs } from "@ourworldindata/utils"
 import {
     RichEditorCommentThreadsResponse,
@@ -41,6 +46,7 @@ import { AdminLayout } from "../AdminLayout.js"
 import { RichEditor } from "./RichEditor.js"
 import {
     getBlockItemsForDocType,
+    RICH_EDITOR_PALETTE_DRAG_MIME,
     RichEditorBlockItem,
 } from "./blockRegistry.js"
 import { pmDocToEnrichedBlocks } from "../../adminShared/richEditor/serialization/serialization.js"
@@ -54,6 +60,7 @@ import {
     InspectedBlock,
     hasTextRangeSelection,
     inspectedBlockFromSelection,
+    placeCursorAtBlockBoundary,
     placeCursorBelowSelectedBlock,
     replaceSelectedBlockWithCursor,
     selectionBlockKey,
@@ -70,6 +77,11 @@ import {
 // the assistant pulls in the pi agent framework + its stylesheet; load it
 // only when the rich editor page actually renders the tab
 const AssistantPanel = lazy(() => import("./assistant/AssistantPanel.js"))
+// the preview renders the document through the site's components and pulls
+// in the (scoped) site stylesheet; load it on first use
+const GdocPreview = lazy(() => import("./preview/GdocPreview.js"))
+
+type ViewMode = "edit" | "preview"
 
 type SaveState =
     | { kind: "saved"; at: Date | null }
@@ -266,6 +278,85 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
     const [pendingInsert, setPendingInsert] =
         useState<RichEditorBlockItem | null>(null)
     const [publishing, setPublishing] = useState(false)
+
+    // Edit the document, or preview it as the site would render it. The
+    // editor stays mounted (hidden) while previewing, so selection, undo
+    // history and the live graphers survive switching back and forth; each
+    // mode remembers its own scroll position.
+    const [viewMode, setViewMode] = useState<ViewMode>("edit")
+    const scrollByMode = useRef<Record<ViewMode, number>>({
+        edit: 0,
+        preview: 0,
+    })
+    const [preview, setPreview] = useState<{
+        body: OwidEnrichedGdocBlock[]
+        version: number
+    } | null>(null)
+    const [previewEntity, setPreviewEntity] = useState<string | undefined>()
+
+    const snapshotPreview = useCallback(
+        (options?: { force: boolean }): void => {
+            const editor = editorRef.current
+            if (!editor) return
+            const body = pmDocToEnrichedBlocks(editor.getJSON())
+            setPreview((current) => {
+                // unchanged body: keep the rendered preview (and its cache key),
+                // unless an explicit refresh asks to re-resolve the attachments
+                if (
+                    current &&
+                    !options?.force &&
+                    JSON.stringify(current.body) === JSON.stringify(body)
+                )
+                    return current
+                return { body, version: (current?.version ?? 0) + 1 }
+            })
+        },
+        []
+    )
+
+    const switchViewMode = useCallback(
+        (mode: ViewMode): void => {
+            if (mode === viewMode) return
+            scrollByMode.current[viewMode] = window.scrollY
+            if (mode === "preview") snapshotPreview()
+            setViewMode(mode)
+        },
+        [snapshotPreview, viewMode]
+    )
+
+    // The topbar (with the Edit/Preview toggle) is sticky; the canvas
+    // toolbar and side panels stick below it, so publish its height to CSS.
+    // A callback ref, because the topbar only exists once the doc has loaded.
+    const topbarObserver = useRef<ResizeObserver | null>(null)
+    const topbarRef = useCallback((topbar: HTMLElement | null): void => {
+        topbarObserver.current?.disconnect()
+        topbarObserver.current = null
+        const main = topbar?.parentElement
+        if (!topbar || !main) return
+        const update = (): void => {
+            main.style.setProperty(
+                "--rich-editor-topbar-height",
+                `${topbar.offsetHeight}px`
+            )
+        }
+        update()
+        topbarObserver.current = new ResizeObserver(update)
+        topbarObserver.current.observe(topbar)
+    }, [])
+
+    // restore the scroll position the mode was left at (after the hidden
+    // workspace/preview has been shown again and laid out)
+    const viewModeMounted = useRef(false)
+    useEffect(() => {
+        if (!viewModeMounted.current) {
+            viewModeMounted.current = true
+            return undefined
+        }
+        const frame = requestAnimationFrame(() => {
+            window.scrollTo({ top: scrollByMode.current[viewMode] })
+        })
+        return () => cancelAnimationFrame(frame)
+    }, [viewMode])
 
     // Local overrides for fields the page mutates without refetching
     const [published, setPublished] = useState<boolean | null>(null)
@@ -580,6 +671,14 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
         })
     }
 
+    // a palette item was dragged onto the canvas: insert it at the drop point
+    const onPaletteDrop = (itemKey: string, pos: number): void => {
+        const editor = editorRef.current
+        const item = paletteItems.find((candidate) => candidate.key === itemKey)
+        if (!editor || !item) return
+        if (placeCursorAtBlockBoundary(editor, pos)) runInsertItem(item)
+    }
+
     const confirmPendingInsert = (mode: "replace" | "below"): void => {
         const editor = editorRef.current
         const item = pendingInsert
@@ -595,7 +694,7 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
     return (
         <AdminLayout title={`Editing: ${title}`} noSidebar fixedNav={false}>
             <main className="rich-editor-page">
-                <header className="rich-editor-page__topbar">
+                <header className="rich-editor-page__topbar" ref={topbarRef}>
                     <div>
                         <Typography.Title level={4} style={{ margin: 0 }}>
                             {title}
@@ -616,6 +715,21 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                         </Space>
                     </div>
                     <Space>
+                        <Segmented<ViewMode>
+                            value={viewMode}
+                            onChange={switchViewMode}
+                            options={[
+                                { label: "Edit", value: "edit" },
+                                { label: "Preview", value: "preview" },
+                            ]}
+                        />
+                        {viewMode === "preview" && (
+                            <Button
+                                onClick={() => snapshotPreview({ force: true })}
+                            >
+                                Refresh preview
+                            </Button>
+                        )}
                         <Button onClick={() => setRevisionsOpen(true)}>
                             History
                         </Button>
@@ -736,8 +850,34 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                     />
                 )}
 
+                {preview && (
+                    <div
+                        className="rich-editor-page__preview"
+                        hidden={viewMode !== "preview"}
+                    >
+                        <Suspense
+                            fallback={
+                                <div className="rich-editor-page__preview-loading">
+                                    Loading preview…
+                                </div>
+                            }
+                        >
+                            <GdocPreview
+                                gdocId={id}
+                                body={preview.body}
+                                version={preview.version}
+                                entity={previewEntity}
+                                onEntityChange={setPreviewEntity}
+                            />
+                        </Suspense>
+                    </div>
+                )}
+
                 <ChartEditingContext.Provider value={chartEditing.contextValue}>
-                    <div className="rich-editor-page__workspace">
+                    <div
+                        className="rich-editor-page__workspace"
+                        hidden={viewMode !== "edit"}
+                    >
                         <aside className="rich-editor-page__palette">
                             <h4>Insert</h4>
                             {paletteItems.map((item) => (
@@ -745,7 +885,16 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                                     key={item.key}
                                     type="button"
                                     className="rich-editor-page__palette-item"
-                                    title={item.description}
+                                    title={`${item.description} — click to insert at the cursor, or drag into the document`}
+                                    draggable
+                                    onDragStart={(event) => {
+                                        event.dataTransfer.setData(
+                                            RICH_EDITOR_PALETTE_DRAG_MIME,
+                                            item.key
+                                        )
+                                        event.dataTransfer.effectAllowed =
+                                            "copy"
+                                    }}
                                     onClick={() => {
                                         const editor = editorRef.current
                                         if (!editor) return
@@ -765,8 +914,9 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                                 </button>
                             ))}
                             <p className="rich-editor-page__palette-hint">
-                                Tip: type <code>/</code> in the text to insert
-                                blocks without leaving the keyboard.
+                                Drag a block into the document to insert it
+                                there, or type <code>/</code> in the text to
+                                insert blocks without leaving the keyboard.
                             </p>
                         </aside>
                         <div className="rich-editor-page__canvas-col">
@@ -804,6 +954,7 @@ function RichEditorPageForId(props: { id: string }): React.ReactElement {
                                             : null
                                     }
                                     onCreate={setEditorInstance}
+                                    onPaletteDrop={onPaletteDrop}
                                     onSelectionChange={(editor) => {
                                         setHasTextSelection(
                                             hasTextRangeSelection(editor)

--- a/adminSiteClient/richEditor/blockRegistry.ts
+++ b/adminSiteClient/richEditor/blockRegistry.ts
@@ -6,6 +6,13 @@ import { pmNodeNames } from "../../adminShared/richEditor/serialization/pmJson.j
 // (see devTools/richEditor and the project plan). Powers both the slash menu
 // and the insert palette.
 
+/**
+ * The dataTransfer type a palette item sets when dragged into the canvas;
+ * its data is the item's `key`. See paletteDrop.ts for the drop side.
+ */
+export const RICH_EDITOR_PALETTE_DRAG_MIME =
+    "application/x-owid-rich-editor-block"
+
 export interface RichEditorBlockItem {
     key: string
     title: string

--- a/adminSiteClient/richEditor/inspection.ts
+++ b/adminSiteClient/richEditor/inspection.ts
@@ -513,3 +513,22 @@ export function placeCursorBelowSelectedBlock(editor: Editor): boolean {
         .setTextSelection(pos + 1)
         .run()
 }
+
+/**
+ * Insert an empty paragraph at the given block boundary (e.g. the position a
+ * palette item was dropped at) and put the cursor inside it, so a subsequent
+ * insert command lands there. Same mechanics as the selection-relative
+ * helpers above.
+ */
+export function placeCursorAtBlockBoundary(
+    editor: Editor,
+    pos: number
+): boolean {
+    const clamped = Math.max(0, Math.min(pos, editor.state.doc.content.size))
+    return editor
+        .chain()
+        .focus()
+        .insertContentAt(clamped, { type: pmNodeNames.paragraph })
+        .setTextSelection(clamped + 1)
+        .run()
+}

--- a/adminSiteClient/richEditor/paletteDrop.ts
+++ b/adminSiteClient/richEditor/paletteDrop.ts
@@ -1,0 +1,128 @@
+import { Extension } from "@tiptap/core"
+import { Plugin, PluginKey } from "@tiptap/pm/state"
+import { Fragment, Slice } from "@tiptap/pm/model"
+import { dropPoint } from "@tiptap/pm/transform"
+import type { EditorView } from "@tiptap/pm/view"
+import { pmNodeNames } from "../../adminShared/richEditor/serialization/pmJson.js"
+import { RICH_EDITOR_PALETTE_DRAG_MIME } from "./blockRegistry.js"
+
+export interface PaletteDropOptions {
+    /**
+     * Called when a palette item is dropped on the canvas, with the item's
+     * key and the document position (a block boundary) to insert it at.
+     */
+    onDrop: (itemKey: string, pos: number) => void
+}
+
+const paletteDropKey = new PluginKey("paletteDrop")
+
+function isPaletteDrag(event: DragEvent): boolean {
+    const types = event.dataTransfer?.types
+    if (!types) return false
+    // DataTransfer.types is a DOMStringList in some browsers, an array in others
+    return Array.from(types).includes(RICH_EDITOR_PALETTE_DRAG_MIME)
+}
+
+/**
+ * Drop target for dragging block items from the insert palette into the
+ * canvas.
+ *
+ * While a palette item is dragged over the editor, the view's `dragging`
+ * state is set to a placeholder slice (an empty paragraph), so the regular
+ * drop cursor draws its block-level indicator at the exact boundary the item
+ * will land on — the same `dropPoint` computation the drop handler uses,
+ * and the same feedback as when reordering blocks within the canvas.
+ * `view.dragging` is cleared again when the drag leaves the editor without
+ * dropping, so a later external drop (plain text from another window) isn't
+ * mistaken for the placeholder.
+ */
+export const PaletteDrop = Extension.create<PaletteDropOptions>({
+    name: "paletteDrop",
+
+    addOptions() {
+        return {
+            onDrop: () => undefined,
+        }
+    },
+
+    addProseMirrorPlugins() {
+        const { onDrop } = this.options
+        const placeholderSlice = new Slice(
+            Fragment.from(
+                this.editor.schema.nodes[pmNodeNames.paragraph].create()
+            ),
+            0,
+            0
+        )
+        const isOurDragging = (view: EditorView): boolean =>
+            view.dragging?.slice === placeholderSlice
+
+        const resolveDropPos = (view: EditorView, event: DragEvent): number => {
+            const coords = view.posAtCoords({
+                left: event.clientX,
+                top: event.clientY,
+            })
+            const pos = coords?.pos ?? view.state.doc.content.size
+            const point = dropPoint(view.state.doc, pos, placeholderSlice)
+            if (point !== null) return point
+            // no valid block boundary found near the pointer: fall back to
+            // the end of the enclosing text block (or the position itself)
+            const $pos = view.state.doc.resolve(pos)
+            return $pos.parent.isTextblock ? $pos.after() : pos
+        }
+
+        return [
+            new Plugin({
+                key: paletteDropKey,
+                props: {
+                    handleDOMEvents: {
+                        dragenter: (view, event) => {
+                            if (!isPaletteDrag(event)) return false
+                            view.dragging = {
+                                slice: placeholderSlice,
+                                move: false,
+                            }
+                            event.preventDefault()
+                            return false
+                        },
+                        dragover: (view, event) => {
+                            if (!isPaletteDrag(event)) return false
+                            if (!isOurDragging(view)) {
+                                view.dragging = {
+                                    slice: placeholderSlice,
+                                    move: false,
+                                }
+                            }
+                            if (event.dataTransfer)
+                                event.dataTransfer.dropEffect = "copy"
+                            event.preventDefault()
+                            return false
+                        },
+                        dragleave: (view, event) => {
+                            if (!isOurDragging(view)) return false
+                            const related = event.relatedTarget
+                            if (
+                                related instanceof Node &&
+                                view.dom.contains(related)
+                            )
+                                return false
+                            view.dragging = null
+                            return false
+                        },
+                    },
+                    handleDrop: (view, event) => {
+                        if (!isPaletteDrag(event)) return false
+                        const itemKey = event.dataTransfer?.getData(
+                            RICH_EDITOR_PALETTE_DRAG_MIME
+                        )
+                        // ProseMirror has already cleared view.dragging
+                        event.preventDefault()
+                        if (!itemKey) return true
+                        onDrop(itemKey, resolveDropPos(view, event))
+                        return true
+                    },
+                },
+            }),
+        ]
+    },
+})

--- a/adminSiteClient/richEditor/preview/GdocPreview.scss
+++ b/adminSiteClient/richEditor/preview/GdocPreview.scss
@@ -1,0 +1,31 @@
+// Chrome around the preview. The site stylesheet itself is in
+// siteStyles.scss, scoped to .rich-editor-preview.
+
+.rich-editor-preview {
+    // the site page is the full viewport width; give the preview the same
+    // footing, clipping the full-bleed grid's horizontal overflow like
+    // html { overflow-x: hidden } does on the site
+    overflow-x: hidden;
+    // the containing block and stacking context the page's absolutely
+    // positioned, full-bleed elements (article header banner, admin bar)
+    // are laid out against on the site
+    position: relative;
+    z-index: 0;
+    border: 1px solid #e5e1d8;
+    border-radius: 8px;
+    min-height: 60vh;
+}
+
+.rich-editor-preview__toolbar {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+
+.rich-editor-preview__status {
+    padding: 48px;
+    text-align: center;
+    color: #8a8577;
+}

--- a/adminSiteClient/richEditor/preview/GdocPreview.tsx
+++ b/adminSiteClient/richEditor/preview/GdocPreview.tsx
@@ -1,0 +1,178 @@
+import { useContext } from "react"
+import { Alert, Button, Select, Space, Typography } from "antd"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import {
+    OwidEnrichedGdocBlock,
+    OwidGdocErrorMessageType,
+} from "@ourworldindata/types"
+import { deserializeOwidGdocPageData } from "@ourworldindata/utils"
+import {
+    RichEditorPreviewRequest,
+    RichEditorPreviewResponse,
+} from "../../../adminShared/RichEditorTypes.js"
+import { AdminAppContext } from "../../AdminAppContext.js"
+import { OwidGdoc } from "../../../site/gdocs/OwidGdoc.js"
+import { DebugProvider } from "../../../site/gdocs/DebugProvider.js"
+import { AriaAnnouncerProvider } from "../../../site/AriaAnnouncerContext.js"
+import { AriaAnnouncer } from "../../../site/AriaAnnouncer.js"
+
+import "./siteStyles.scss"
+import "./GdocPreview.scss"
+
+export interface GdocPreviewProps {
+    gdocId: string
+    /** The body as the editor has it right now */
+    body: OwidEnrichedGdocBlock[]
+    /** Bumped by the parent to re-snapshot the body and refetch attachments */
+    version: number
+    /** Profiles: the entity to show; undefined picks the first in scope */
+    entity?: string
+    onEntityChange: (entity: string) => void
+}
+
+/**
+ * The document as the site would publish it, rendered in place through the
+ * site's own page component. The server resolves the attachments (linked
+ * charts, images, authors, …) for the current body, exactly as it does when
+ * baking; the site stylesheet is scoped to this container. Lazy-loaded by
+ * the editor page, so the site CSS and components only load on first use.
+ */
+export default function GdocPreview(
+    props: GdocPreviewProps
+): React.ReactElement {
+    const { gdocId, body, version, entity, onEntityChange } = props
+    const { admin } = useContext(AdminAppContext)
+
+    const previewQuery = useQuery<RichEditorPreviewResponse>({
+        queryKey: ["richEditorPreview", gdocId, version, entity ?? null],
+        queryFn: () => {
+            const request: RichEditorPreviewRequest = { body, entity }
+            return admin.requestJSON<RichEditorPreviewResponse>(
+                `/api/gdocs/${gdocId}/editorPreview`,
+                request,
+                "POST"
+            )
+        },
+        staleTime: Infinity,
+        retry: false,
+        // keep showing the previous render while a refreshed snapshot loads,
+        // so the page keeps its height (and scroll position)
+        placeholderData: keepPreviousData,
+    })
+
+    if (previewQuery.isError) {
+        return (
+            <Alert
+                type="error"
+                showIcon
+                title="Could not render the preview"
+                description={String(previewQuery.error ?? "")}
+                action={
+                    <Button
+                        size="small"
+                        onClick={() => {
+                            void previewQuery.refetch()
+                        }}
+                    >
+                        Retry
+                    </Button>
+                }
+            />
+        )
+    }
+
+    const data = previewQuery.data
+    const errors = data?.errors ?? []
+    const blocking = errors.filter(
+        (error) => error.type === OwidGdocErrorMessageType.Error
+    )
+    const warnings = errors.filter(
+        (error) => error.type !== OwidGdocErrorMessageType.Error
+    )
+
+    return (
+        <div className="rich-editor-preview-wrapper">
+            <div className="rich-editor-preview__toolbar">
+                <Typography.Text type="secondary">
+                    {previewQuery.isFetching
+                        ? "Rendering preview…"
+                        : "Preview of the current draft, rendered as it would appear on the site."}
+                </Typography.Text>
+                {data?.profileEntities && data.profileEntities.length > 0 && (
+                    <Space size="small">
+                        <Typography.Text type="secondary">
+                            Entity
+                        </Typography.Text>
+                        <Select
+                            size="small"
+                            showSearch={{ optionFilterProp: "label" }}
+                            style={{ minWidth: 220 }}
+                            value={data.profileEntity?.code}
+                            onChange={onEntityChange}
+                            options={data.profileEntities.map((candidate) => ({
+                                value: candidate.code,
+                                label: candidate.name,
+                            }))}
+                        />
+                    </Space>
+                )}
+            </div>
+            {blocking.length > 0 && (
+                <Alert
+                    style={{ marginBottom: 12 }}
+                    type="error"
+                    showIcon
+                    title={`${blocking.length} validation ${
+                        blocking.length === 1 ? "error blocks" : "errors block"
+                    } publishing`}
+                    description={<ErrorList errors={blocking} />}
+                />
+            )}
+            {warnings.length > 0 && (
+                <Alert
+                    style={{ marginBottom: 12 }}
+                    type="warning"
+                    showIcon
+                    title={`${warnings.length} validation ${
+                        warnings.length === 1 ? "warning" : "warnings"
+                    }`}
+                    description={<ErrorList errors={warnings} />}
+                />
+            )}
+            <div className="rich-editor-preview">
+                {data ? (
+                    <AriaAnnouncerProvider>
+                        <DebugProvider debug>
+                            <OwidGdoc
+                                // remount when the snapshot changes so
+                                // site components reset their local state
+                                key={`${version}-${entity ?? ""}`}
+                                {...deserializeOwidGdocPageData(data.gdoc)}
+                                isPreviewing
+                            />
+                        </DebugProvider>
+                        <AriaAnnouncer />
+                    </AriaAnnouncerProvider>
+                ) : (
+                    <div className="rich-editor-preview__status">
+                        Rendering preview…
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}
+
+function ErrorList(props: {
+    errors: RichEditorPreviewResponse["errors"]
+}): React.ReactElement {
+    return (
+        <ul style={{ margin: 0, paddingLeft: 18 }}>
+            {props.errors.map((error, index) => (
+                <li key={index}>
+                    <strong>{error.property}</strong>: {error.message}
+                </li>
+            ))}
+        </ul>
+    )
+}

--- a/adminSiteClient/richEditor/preview/siteStyles.scss
+++ b/adminSiteClient/richEditor/preview/siteStyles.scss
@@ -1,0 +1,5 @@
+// The site's stylesheet, for rendering the site components inside the
+// admin. Scoped to `.rich-editor-preview` at build time by pluginScopedCss
+// (see vite.config-common.mts): every selector is prefixed with that class,
+// and the site's html/body rules apply to the container instead.
+@import "../../../site/owid.scss";

--- a/adminSiteServer/apiRouter.ts
+++ b/adminSiteServer/apiRouter.ts
@@ -54,6 +54,7 @@ import {
 import {
     createNativeGdoc,
     getGdocForEditor,
+    previewGdocForEditor,
     saveGdocBody,
     saveGdocEditorSettings,
     getGdocRevisions,
@@ -433,6 +434,11 @@ postRouteWithRWTransaction(apiRouter, "/gdocs/:gdocId/setTags", setGdocTags)
 // Rich editor routes (native gdoc editing)
 postRouteWithRWTransaction(apiRouter, "/gdocs/createNative", createNativeGdoc)
 getRouteWithROTransaction(apiRouter, "/gdocs/:id/editor", getGdocForEditor)
+postRouteWithRWTransaction(
+    apiRouter,
+    "/gdocs/:id/editorPreview",
+    previewGdocForEditor
+)
 putRouteWithRWTransaction(apiRouter, "/gdocs/:id/body", saveGdocBody)
 getRouteWithROTransaction(apiRouter, "/gdocs/:id/revisions", getGdocRevisions)
 getRouteWithROTransaction(

--- a/adminSiteServer/apiRoutes/richEditor.ts
+++ b/adminSiteServer/apiRoutes/richEditor.ts
@@ -17,13 +17,25 @@ import {
     DbRawPostGdocDraft,
     DbRawPostGdocRevision,
 } from "@ourworldindata/types"
-import { slugify } from "@ourworldindata/utils"
+import {
+    extractGdocPageData,
+    GdocsContentSource,
+    getEntitiesForProfile,
+    OwidGdocPageData,
+    slugify,
+} from "@ourworldindata/utils"
+import {
+    GdocProfile,
+    instantiateProfileForEntity,
+} from "../../db/model/Gdoc/GdocProfile.js"
 import { randomUUID } from "crypto"
 import * as db from "../../db/db.js"
 import {
     GdocLinkUpdateMode,
     gdocFromJSON,
     getAndLoadGdocById,
+    getGdocBaseObjectById,
+    loadGdocFromGdocBase,
     setImagesInContentGraph,
     setLinksForGdoc,
     updateDerivedGdocPostsComponents,
@@ -57,6 +69,8 @@ import {
     RichEditorSaveBodyResponse,
     RichEditorSaveConflictResponse,
     RichEditorCommentAnchorUpdate,
+    RichEditorPreviewRequest,
+    RichEditorPreviewResponse,
     RichEditorSaveSettingsRequest,
     RichEditorUpdateThreadRequest,
 } from "../../adminShared/RichEditorTypes.js"
@@ -293,6 +307,75 @@ export async function getGdocForEditor(
             : row.updatedAt
               ? new Date(row.updatedAt).toISOString()
               : null,
+    }
+}
+
+/**
+ * Everything the site needs to render the draft: the draft content (with the
+ * body the editor currently has, if given) run through the same attachment
+ * loading as a published page. The client renders the result through the
+ * site's own `OwidGdoc` component, so the preview is the page as it would
+ * be published — nothing is written.
+ */
+export async function previewGdocForEditor(
+    req: Request,
+    res: HandlerResponse,
+    trx: db.KnexReadonlyTransaction
+): Promise<RichEditorPreviewResponse> {
+    const { id } = req.params
+    const { body, entity } = (req.body ?? {}) as RichEditorPreviewRequest
+
+    const base = await getGdocBaseObjectById(trx, id, true)
+    if (!base) throw new JsonError(`No document with id ${id} found`, 404)
+
+    const draft = await trx
+        .table(PostsGdocsDraftsTableName)
+        .where({ gdocId: id })
+        .first<DbRawPostGdocDraft | undefined>()
+    const draftContent: OwidGdocContent = draft
+        ? JSON.parse(draft.content)
+        : base.content
+    const content = withoutBlockIds(
+        body !== undefined
+            ? { ...draftContent, body: validateBodyBlocks(body) }
+            : draftContent
+    )
+
+    const gdoc = await loadGdocFromGdocBase(
+        trx,
+        { ...base, content },
+        GdocsContentSource.Internal
+    )
+
+    let pageGdoc: Parameters<typeof extractGdocPageData>[0] = gdoc
+    let profileEntities: RichEditorPreviewResponse["profileEntities"]
+    let profileEntity: RichEditorPreviewResponse["profileEntity"]
+    if (gdoc.content.type === OwidGdocType.Profile) {
+        // a profile is a template; the site only ever shows it instantiated
+        // for one entity
+        profileEntities = getEntitiesForProfile(
+            gdoc.content.scope,
+            gdoc.content.exclude
+        )
+        profileEntity =
+            profileEntities.find((candidate) => candidate.code === entity) ??
+            profileEntities[0]
+        if (profileEntity) {
+            pageGdoc = await instantiateProfileForEntity(
+                gdoc as GdocProfile,
+                profileEntity,
+                { knex: trx }
+            )
+        }
+    }
+
+    res.set("Cache-Control", "no-store")
+    return {
+        // dates are serialized on the wire; the client deserializes them
+        gdoc: extractGdocPageData(pageGdoc) as unknown as OwidGdocPageData,
+        errors: gdoc.errors,
+        profileEntities,
+        profileEntity,
     }
 }
 

--- a/devTools/vite/pluginScopedCss.mts
+++ b/devTools/vite/pluginScopedCss.mts
@@ -1,0 +1,58 @@
+import postcss, { type AtRule, type Plugin as PostcssPlugin } from "postcss"
+import type { Plugin } from "vite"
+
+/**
+ * Scopes whole stylesheets to a container element.
+ *
+ * Every selector in a listed stylesheet is prefixed with its scope selector
+ * (`a` → `.scope a`), and selectors for the document itself (`html`, `body`,
+ * `:root`) become the scope element, so a page-level stylesheet applies to
+ * one subtree of another page instead — the rich editor renders the site's
+ * components inside the admin this way.
+ *
+ * Runs on the compiled CSS, after Vite has processed Sass and inlined plain
+ * CSS `@import`s, so vendor stylesheets get scoped too. Sass nesting can't
+ * do that: plain CSS imports can't be nested and would be hoisted out.
+ *
+ * `files` maps repo-relative stylesheet paths to their scope selector.
+ */
+export function pluginScopedCss(files: Record<string, string>): Plugin {
+    const entries = Object.entries(files)
+    return {
+        name: "owid:scoped-css",
+        async transform(code, id) {
+            const path = id.split("?")[0]
+            const match = entries.find(([file]) => path.endsWith(`/${file}`))
+            if (!match) return null
+            const result = await postcss([scopeSelectors(match[1])]).process(
+                code,
+                { from: path, map: false }
+            )
+            return { code: result.css, map: null }
+        },
+    }
+}
+
+const DOCUMENT_SELECTOR = /^(html|body|:root)(?![\w-])/
+
+function scopeSelectors(scope: string): PostcssPlugin {
+    return {
+        postcssPlugin: "owid-scope-selectors",
+        Once(root) {
+            root.walkRules((rule) => {
+                // keyframe selectors (from, to, 50%) are not element selectors
+                const parent = rule.parent as AtRule | undefined
+                if (parent?.type === "atrule" && /keyframes$/i.test(parent.name))
+                    return
+                rule.selectors = rule.selectors.map((selector) => {
+                    const trimmed = selector.trim()
+                    if (DOCUMENT_SELECTOR.test(trimmed)) {
+                        // `body`, `html.no-scroll`, `body > .x` → the scope element
+                        return trimmed.replace(DOCUMENT_SELECTOR, scope)
+                    }
+                    return `${scope} ${trimmed}`
+                })
+            })
+        },
+    }
+}

--- a/package.json
+++ b/package.json
@@ -247,6 +247,7 @@
         "oxlint": "^1.78.0",
         "oxlint-tsgolint": "^7.0.2001",
         "playwright-bdd": "^9.1.0",
+        "postcss": "^8.5.6",
         "sass": "^1.89.2",
         "schema-dts": "^2.0.0",
         "topojson-server": "^3.0.1",

--- a/vite.config-common.mts
+++ b/vite.config-common.mts
@@ -8,6 +8,7 @@ import {
     VITE_ENTRYPOINT_INFO,
     ViteEntryPoint,
 } from "./site/viteConstants.js"
+import { pluginScopedCss } from "./devTools/vite/pluginScopedCss.mts"
 
 // https://vitejs.dev/config/
 export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
@@ -117,6 +118,12 @@ export const defineViteConfigForEntrypoint = (entrypoint: ViteEntryPoint) => {
             pluginReact(),
             pluginOptimizeReactAriaLocales({
                 locales: ["en-US"],
+            }),
+            pluginScopedCss({
+                // the rich editor's preview renders the site's components
+                // (and stylesheet) inside the admin page
+                "adminSiteClient/richEditor/preview/siteStyles.scss":
+                    ".rich-editor-preview",
             }),
             // Put the Sentry vite plugin after all other plugins.
             clientSettings.LOAD_SENTRY &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -10479,6 +10479,7 @@ __metadata:
     papaparse: "npm:^5.5.3"
     playwright-bdd: "npm:^9.1.0"
     polylabel: "npm:^2.0.1"
+    postcss: "npm:^8.5.6"
     progress: "npm:^2.0.3"
     react: "npm:^19.2.4"
     react-aria-components: "npm:^1.20.0"
@@ -13594,7 +13595,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.25":
+"postcss@npm:^8.5.25, postcss@npm:^8.5.6":
   version: 8.5.26
   resolution: "postcss@npm:8.5.26"
   dependencies:


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @danyx23 at the wheel._

Stacked on #6710 (M6). Two additions to the rich editor:

## Context

**Drag from the palette.** The insert palette's items are now draggable into the canvas. Dropping one inserts it at the block boundary under the pointer, with the regular drop cursor showing where it will land (the same indicator as reordering blocks). Click-to-insert and the slash menu are unchanged.

**Preview.** An Edit/Preview toggle in the topbar renders the draft as it would appear on the site, on the editor page itself, through the site's own `OwidGdoc` component. A new endpoint `POST /api/gdocs/:id/editorPreview` takes the body as the editor has it, runs it through the same attachment loading a bake uses (`loadGdocFromGdocBase` → `loadState`), and returns the `_OWID_GDOC_PROPS` payload plus the pipeline's validation messages, which the preview shows as error/warning banners. Profiles get an entity picker. The editor stays mounted while previewing, so switching back and forth keeps selection, undo history, live graphers, and each mode's scroll position. The topbar is now sticky so the toggle is always reachable.

Things worth knowing:

- **Site CSS in the admin.** The site stylesheet (`site/owid.scss`) is loaded into the admin page scoped to the preview container, via a small Vite plugin (`devTools/vite/pluginScopedCss.mts`) that prefixes every selector with `.rich-editor-preview` and maps `html`/`body`/`:root` onto the container. It runs on the compiled CSS, after plain CSS imports (normalize, tippy, fonts) have been inlined, which is why Sass nesting alone wasn't enough. The preview module is lazy-loaded, so this ~600 kB stylesheet only loads on first use and doesn't affect the site bundle.
- **Snapshot, not live.** The preview is rendered from a snapshot of the body taken when you switch to it (and re-taken on every switch or "Refresh preview"); it doesn't re-render as you type. Attachments have to be re-resolved server-side when references change, so a live preview would need the incremental attachment resolution planned for later.
- `AdminLayout` gives `<main>` a fixed viewport height; the editor page now overrides that so the sticky topbar keeps working when the page is taller than the viewport.

## Screenshots / Videos / Diagrams

The sandbox this was built in can't upload images to GitHub. Verified visually there (see Details); the staging server is the place to look.

## Testing guidance

On `staging-site-rich-editing-m7`, open a native document in the rich editor (`/admin/gdocs/<id>/edit`):

1. Drag "Heading" from the left palette into the text between two paragraphs; a horizontal drop cursor should follow the pointer, and releasing inserts an empty heading there with the cursor in it. Drag "Call to action" or "Chart" onto the canvas; the block appears at the drop point. Drop into a sticky-right column or table cell works too.
2. Scroll down, click **Preview** in the (now sticky) topbar. The document renders with site styling; graphers hydrate as they scroll into view. Click **Edit**: the editor is where you left it (selection, scroll). Click **Preview** again: back at the preview's scroll position, without a refetch when nothing changed.
3. Edit some text, switch to Preview: the change is there. **Refresh preview** re-resolves attachments (e.g. after changing a chart URL in the inspector).
4. A profile shows an entity dropdown above the preview.
5. Break something (e.g. a chart URL to a nonexistent slug) and preview: the validation error banner appears above the render.

- [ ] Does the change work in the archive? (n/a, admin only)
- [ ] Does the staging experience have sign-off from product stakeholders?

## Checklist

### Before merging

- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints

<details><summary>Details</summary>

### Drag and drop

- `blockRegistry.ts`: `RICH_EDITOR_PALETTE_DRAG_MIME` (`application/x-owid-rich-editor-block`), the dataTransfer type whose data is the item key.
- `paletteDrop.ts`: a TipTap extension with a ProseMirror plugin. On `dragenter`/`dragover` with that MIME it sets `view.dragging` to a placeholder slice (an empty paragraph) so prosemirror-dropcursor draws its block-level cursor at the `dropPoint` (the same computation the drop handler uses); `dragleave` outside the editor clears it so a later external drop of plain text isn't mistaken for the placeholder. `handleDrop` resolves the position with `dropPoint(doc, posAtCoords, placeholder)`, falling back to the end of the enclosing textblock, and calls `onDrop(itemKey, pos)`.
- `inspection.ts`: `placeCursorAtBlockBoundary(editor, pos)`, the position-based sibling of `placeCursorBelowSelectedBlock`: inserts an empty paragraph at the boundary and puts the cursor in it, so the item's normal insert command (setNode for headings, toggle for lists, insertContent for atoms, which replaces the empty paragraph) lands there.
- `RichEditor.tsx`: `onPaletteDrop` prop wired through a ref into `PaletteDrop.configure`. `RichEditorPage.tsx`: palette buttons get `draggable` + `onDragStart`; `onPaletteDrop` looks the key up in the doc type's palette items and runs it. Palette items are cursor-`grab`.

### Preview

- `adminShared/RichEditorTypes.ts`: `RichEditorPreviewRequest { body?, entity? }`, `RichEditorPreviewResponse { gdoc: OwidGdocPageData, errors, profileEntities?, profileEntity? }`.
- `adminSiteServer/apiRoutes/richEditor.ts` `previewGdocForEditor`: loads the row with tags/breadcrumbs (`getGdocBaseObjectById`), takes the draft head's content (or the row's), overrides the body with the request's (validated, block ids stripped as on publish), then `loadGdocFromGdocBase(..., Internal)` → `loadState` (attachments + `validate`). Profiles: `getEntitiesForProfile` + `instantiateProfileForEntity` for the requested/first entity. Returns `extractGdocPageData(...)` (dates serialized, client uses `deserializeOwidGdocPageData`), `gdoc.errors`, entities. Nothing is written. Registered as `POST /gdocs/:id/editorPreview`; `Cache-Control: no-store`.
- `preview/GdocPreview.tsx` (lazy): react-query keyed by `[gdocId, version, entity]` with `keepPreviousData` so a refresh keeps the page height (and scroll). Renders `<OwidGdoc isPreviewing>` inside `AriaAnnouncerProvider`/`DebugProvider` like `hydrateOwidGdoc` does; `key` on version+entity remounts site components on a new snapshot. Error/warning alerts from `errors`; entity `Select` for profiles.
- `preview/siteStyles.scss`: `@import "../../../site/owid.scss"`, scoped by the plugin. `preview/GdocPreview.scss`: container chrome; `position: relative; z-index: 0` so the site's absolutely positioned full-bleed elements (`.centered-article-header__banner`, `.gdoc-admin-bar`) are laid out against the container like against the site's viewport.
- `devTools/vite/pluginScopedCss.mts`: `transform` on the listed stylesheet paths (matched by suffix, query stripped); runs a PostCSS plugin that prefixes selectors, rewrites `html|body|:root` prefixes to the scope (`body.no-scroll` → `.scope.no-scroll`), skips keyframe selectors. Registered in `vite.config-common.mts` for `adminSiteClient/richEditor/preview/siteStyles.scss` → `.rich-editor-preview`. `postcss` added to devDependencies (it was already installed transitively via Vite).
- `RichEditorPage.tsx`: `viewMode` state; `snapshotPreview({force})` serializes the editor doc and bumps a version only when the body changed (or forced); `switchViewMode` saves `window.scrollY` per mode; an effect restores it on the next frame (skipping the initial mount). Workspace and preview are both kept mounted and toggled with `hidden`. Sticky topbar: a callback ref + `ResizeObserver` writes `--rich-editor-topbar-height` on `<main>`; the palette, rail and format toolbar offset their sticky `top` by it. `.AdminLayout > main.rich-editor-page { height: auto }` overrides the layout's fixed main height, which otherwise ends the sticky containing block after one viewport.

### Verification

- `yarn typecheck`, oxlint on the changed files (no new warnings), oxfmt, 118 rich editor unit tests pass, `yarn buildViteAdmin` succeeds and the emitted preview CSS chunk contains no leftover `@import` and only scoped selectors.
- Browser-verified (Playwright against the local dev stack, on a scratch merge with master because the M6 branch predates the `chart_configs.full` removal the DB snapshot already has): heading dropped between paragraphs lands at the drop cursor and converts the placeholder paragraph; CTA dropped at the end appears as an atom block; both show up in the preview; preview renders with site fonts (`Playfair Display` headings), graphers hydrate; editor content, selection and scroll (600 → 655 with scroll anchoring) survive the round trip; preview scroll position (1400) is restored exactly when switching back; topbar sticky in both modes; no page errors.
- Not covered: the archive (admin only), mobile breakpoints.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JErCyPQ9hgzYTGfWDpVR11