### PR TITLE
Point the MDIM GitHub link at etl/steps/viz/chart

### DIFF
--- a/adminSiteClient/DatasetEditPage.tsx
+++ b/adminSiteClient/DatasetEditPage.tsx
@@ -299,7 +299,7 @@ class MultiDimList extends Component<MultiDimListProps> {
                                             )
                                         return githubPath ? (
                                             <a
-                                                href={`https://github.com/owid/etl/tree/master/etl/steps/export/multidim/${githubPath}`}
+                                                href={`https://github.com/owid/etl/tree/master/etl/steps/viz/chart/${githubPath}`}
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                             >


### PR DESCRIPTION
> _Written by Claude Fable 5.1 — @pabloarosado at the wheel._

[owid/etl#6836 "🔨 Rename export steps to viz://chart, viz://explorer, viz://static and viz://bespoke"](https://github.com/owid/etl/pull/6836) moves the MDIM step files from `etl/steps/export/multidim/` to `etl/steps/viz/chart/`. The dataset edit page links each MDIM to its step folder on GitHub; this updates that link so it doesn't 404 once the ETL PR is merged.

**Merge order:** merge this only after the ETL PR has landed on `master`. Until then the new link points at a directory that doesn't exist there yet; after the ETL merge the old link is the one that 404s.

Nothing else in grapher depends on the ETL step layout: MDIM identity is `catalogPath`, chart identity is the `chart_config_id` UUID, explorers are keyed by slug.