### PR TITLE
Prototype: Ask-AI demand probe on data pages (V2/V3/V5)

### DIFF
--- a/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
+++ b/packages/@ourworldindata/types/src/analyticsTypes/analyticsTypes.ts
@@ -51,6 +51,7 @@ export enum EventCategory {
     SiteChartPreviewMouseover = "owid.site_chart_preview_mouseover",
     SiteStaticVizDownload = "owid.site_static_viz_download",
     SiteUserSurvey = "owid.site_user_survey",
+    SiteAskAi = "owid.site_ask_ai",
     TranslatePage = "owid.translate_page",
 }
 
@@ -79,6 +80,7 @@ export type EventParamsMap = {
     [EventCategory.SiteChartPreviewMouseover]: SiteChartPreviewMouseoverParams
     [EventCategory.SiteStaticVizDownload]: SiteStaticVizDownloadParams
     [EventCategory.SiteUserSurvey]: SiteUserSurveyParams
+    [EventCategory.SiteAskAi]: SiteAskAiParams
     [EventCategory.SiteClick]: SiteClickParams
     [EventCategory.SiteFormSubmit]: SiteFormSubmitParams
     [EventCategory.SiteInstantSearchClick]: SiteInstantSearchClickParams
@@ -227,6 +229,53 @@ export interface SiteStaticVizDownloadParams {
     /** Additional context (e.g., 'desktop' or 'mobile' for images, URL for data/source) */
     eventContext?: string
 }
+
+// Ask-AI probe (data page). See experiments/briefs/ask_ai_button_20260828 in
+// the analytics repo. Arms match the design canvas: v2 = framed buttons only,
+// v3 = free-text box, v5 = presets that fill an editable box.
+export type AskAiArm = "v2" | "v3" | "v5"
+
+export type AskAiEngine = "claude" | "chatgpt"
+
+/** Where the text sent to the assistant came from. */
+export type AskAiPromptSource = "default" | "preset" | "freeform"
+
+export type SiteAskAiParams =
+    | {
+          /** Always 'ask_ai_show' for this event */
+          eventAction: "ask_ai_show"
+          /** Which arm the visitor was shown */
+          askAiArm: AskAiArm
+          /** Grapher slug the block was rendered under */
+          askAiSlug: string
+      }
+    | {
+          /** Always 'ask_ai_preset_click' for this event */
+          eventAction: "ask_ai_preset_click"
+          askAiArm: AskAiArm
+          askAiSlug: string
+          /** Stable id of the preset chosen */
+          askAiPresetId: string
+      }
+    | {
+          /** Always 'ask_ai_submit' for this event — the outbound click */
+          eventAction: "ask_ai_submit"
+          askAiArm: AskAiArm
+          askAiSlug: string
+          /** Assistant the visitor was sent to */
+          askAiEngine: AskAiEngine
+          askAiPromptSource: AskAiPromptSource
+          /** Preset id, when askAiPromptSource is 'preset' */
+          askAiPresetId?: string
+          /**
+           * The visitor's own words. GA4 truncates every string parameter at
+           * 100 characters, so this is the first 100 only — pair it with
+           * askAiQuestionLength to see how much was lost.
+           */
+          askAiQuestion?: string
+          /** Full length of the visitor's question, before truncation */
+          askAiQuestionLength?: number
+      }
 
 export type UserSurveyExperimentArm = "long-list" | "short-list" | "free-form"
 

--- a/site/AskAI.scss
+++ b/site/AskAI.scss
@@ -1,0 +1,120 @@
+// Ask-AI demand probe. Rendered under the chart on data pages when the
+// ?askai=v2|v3|v5 query param is present. See the brief in the analytics repo:
+// experiments/briefs/ask_ai_button_20260828
+.ask-ai {
+    margin: 24px 0 32px;
+    padding: 24px;
+    background-color: $blue-5;
+    border-top: 1px solid $blue-20;
+
+    @include sm-only {
+        padding: 16px;
+        margin: 16px 0 24px;
+    }
+}
+
+.ask-ai__heading {
+    @include h3-bold;
+    margin: 0 0 4px;
+    color: $blue-90;
+}
+
+.ask-ai__intro {
+    @include body-3-medium;
+    margin: 0 0 16px;
+    max-width: 60ch;
+    color: $gray-70;
+}
+
+.ask-ai__presets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.ask-ai__preset {
+    @include body-3-medium;
+    padding: 6px 12px;
+    background-color: white;
+    border: 1px solid $blue-20;
+    color: $blue-90;
+    cursor: pointer;
+
+    &:hover {
+        background-color: $blue-10;
+    }
+
+    &[aria-pressed="true"] {
+        background-color: $blue-90;
+        border-color: $blue-90;
+        color: white;
+    }
+}
+
+.ask-ai__field {
+    display: block;
+    margin-bottom: 16px;
+}
+
+.ask-ai__label {
+    @include body-3-bold;
+    display: block;
+    margin-bottom: 4px;
+    color: $blue-90;
+}
+
+.ask-ai__input {
+    @include body-3-medium;
+    width: 100%;
+    max-width: 640px;
+    padding: 8px 12px;
+    border: 1px solid $blue-20;
+    background-color: white;
+    color: $blue-90;
+    resize: vertical;
+    font-family: inherit;
+
+    &::placeholder {
+        color: $gray-60;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $accent-electric-blue;
+        outline-offset: -1px;
+    }
+}
+
+.ask-ai__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.ask-ai__button {
+    @include body-3-bold;
+    display: inline-flex;
+    align-items: center;
+    height: 32px;
+    padding: 0 16px;
+    background-color: $blue-90;
+    border: none;
+    color: white;
+    cursor: pointer;
+
+    &:hover {
+        background-color: $blue-100;
+    }
+
+    &:focus-visible {
+        outline: 2px solid $accent-electric-blue;
+        outline-offset: 2px;
+    }
+}
+
+.ask-ai__privacy {
+    @include body-3-medium;
+    margin: 12px 0 0;
+    max-width: 60ch;
+    color: $gray-60;
+}

--- a/site/AskAI.scss
+++ b/site/AskAI.scss
@@ -13,9 +13,40 @@
     }
 }
 
+.ask-ai__header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 4px;
+}
+
+// Signals that the whole block is a trial, in every arm. Amber rather than
+// the block's blue so it reads as a caveat, not another control.
+.ask-ai__badge {
+    @include body-3-bold;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    // NB the amber scale is light-only ($amber-110 is lighter than $amber),
+    // so the text colour has to come from elsewhere to stay legible.
+    background-color: $amber-10;
+    color: $blue-90;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-size: 11px;
+    line-height: 18px;
+    white-space: nowrap;
+
+    svg {
+        font-size: 10px;
+    }
+}
+
 .ask-ai__heading {
     @include h3-bold;
-    margin: 0 0 4px;
+    margin: 0;
     color: $blue-90;
 }
 

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -45,6 +45,27 @@ describe("prompt construction", () => {
         expect(prompt).toContain(`${SLUG_URL}.csv?csvType=filtered`)
     })
 
+    it("nudges towards the OWID skills afterwards", () => {
+        expect(prompt).toContain("https://github.com/owid/skills")
+        expect(prompt).toContain("Afterwards")
+    })
+
+    it("keeps the skills nudge even when the prompt has to shrink", () => {
+        const slugUrl = `${OWID_PUBLIC_GRAPHER_URL}/share-of-population-living-in-cities-towns-and-villages`
+        const queryStr =
+            "?country=~NGA~IND~USA~CHN~BRA~ZAF~IDN&time=1960..latest&tab=chart"
+        const worst = buildPrompt({
+            title: "Share of population living in cities, towns and villages",
+            pageUrl: `${slugUrl}${queryStr}`,
+            slugUrl,
+            queryStr,
+            stateSummary: describeChartState(queryStr),
+            question:
+                "How has the urban share changed in each of these countries since 1960?",
+        })
+        expect(worst).toContain("https://github.com/owid/skills")
+    })
+
     it("asks for a short, data-led answer", () => {
         expect(prompt).toContain("keep it short")
         expect(prompt).toContain("compact table")
@@ -68,8 +89,44 @@ describe("prompt construction", () => {
         expect(prompt).toContain("rather than estimating")
     })
 
-    it("stays well inside a safe URL length once encoded", () => {
-        expect(encodeURIComponent(prompt).length).toBeLessThan(1800)
+    it("stays inside a safe URL length for a realistic worst case", () => {
+        // Long slug, several entities, a time range and a wordy question —
+        // roughly the largest prompt a visitor can generate. Some WAFs get
+        // unhappy well before browsers do, so keep the whole URL under ~2 KB.
+        const slugUrl = `${OWID_PUBLIC_GRAPHER_URL}/share-of-population-living-in-cities-towns-and-villages`
+        const queryStr =
+            "?country=~NGA~IND~USA~CHN~BRA~ZAF~IDN&time=1960..latest&tab=chart"
+        const worst = buildPrompt({
+            title: "Share of population living in cities, towns and villages",
+            pageUrl: `${slugUrl}${queryStr}`,
+            slugUrl,
+            queryStr,
+            stateSummary: describeChartState(queryStr),
+            question:
+                "How has the urban share changed in each of these countries since 1960, and which of them urbanised fastest over that period?",
+        })
+        // A realistic worst case fits without shedding anything.
+        expect(encodeURIComponent(worst).length).toBeLessThan(3000)
+        expect(worst).toContain("csvType=filtered")
+        expect(worst).toContain("csvType=full")
+        expect(worst).toContain(".metadata.json")
+        expect(worst).toContain("Lead with the data")
+        expect(worst).toContain(
+            "which of them urbanised fastest over that period?"
+        )
+    })
+
+    it("truncates the question rather than let the URL be clipped", () => {
+        const slugUrl = `${OWID_PUBLIC_GRAPHER_URL}/child-mortality`
+        const out = buildPrompt({
+            title: "Child mortality rate",
+            pageUrl: slugUrl,
+            slugUrl,
+            queryStr: "",
+            question: "why ".repeat(500),
+        })
+        expect(encodeURIComponent(out).length).toBeLessThanOrEqual(3000)
+        expect(out).toContain("\u2026")
     })
 
     it("omits the state line when the chart is untouched", () => {
@@ -151,7 +208,11 @@ describe("public origin", () => {
             queryStr: "?country=~NGA",
             question: "Explain this.",
         })
+        // The skills repo is the one deliberate exception; everything else
+        // must be on the public site, never a staging or localhost origin.
+        const OWID_SKILLS_REPO = "https://github.com/owid/skills"
         for (const url of prompt.match(/https?:\/\/[^\s)]+/g) ?? []) {
+            if (url === OWID_SKILLS_REPO) continue
             expect(url.startsWith("https://ourworldindata.org/")).toBe(true)
         }
     })

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -5,6 +5,7 @@ import {
     describeChartState,
     buildEngineUrl,
     buildCsvUrl,
+    buildFullCsvUrl,
     OWID_PUBLIC_GRAPHER_URL,
 } from "./askAiPrompt.js"
 
@@ -54,7 +55,7 @@ describe("prompt construction", () => {
     })
 
     it("welcomes relevant Our World in Data links but forbids inventing them", () => {
-        expect(prompt).toContain("related research and related charts")
+        expect(prompt).toContain("related research and charts")
         expect(prompt).toContain("Don't invent URLs")
     })
 
@@ -95,6 +96,23 @@ describe("engine deep links", () => {
 })
 
 describe("data and image URLs", () => {
+    it("offers the full export as a fallback, ignoring selection", () => {
+        expect(buildFullCsvUrl(SLUG_URL)).toBe(`${SLUG_URL}.csv?csvType=full`)
+    })
+
+    it("offers both exports and says which to prefer", () => {
+        const p = buildPrompt({
+            title: "Child mortality rate",
+            pageUrl: SLUG_URL,
+            slugUrl: SLUG_URL,
+            queryStr: "?country=~NGA",
+            question: "Explain this.",
+        })
+        expect(p).toContain("csvType=filtered")
+        expect(p).toContain("csvType=full")
+        expect(p).toContain("prefer the first")
+    })
+
     it("always requests the filtered CSV, even with no selection", () => {
         expect(buildCsvUrl(SLUG_URL, "")).toBe(
             `${SLUG_URL}.csv?csvType=filtered`

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -1,6 +1,10 @@
 import { expect, it, describe } from "vitest"
 
-import { buildPrompt, describeChartState, buildEngineUrl } from "./askAiPrompt.js"
+import {
+    buildPrompt,
+    describeChartState,
+    buildEngineUrl,
+} from "./askAiPrompt.js"
 
 const SLUG_URL = "https://ourworldindata.org/grapher/child-mortality"
 

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -6,6 +6,7 @@ import {
     buildEngineUrl,
     buildCsvUrl,
     buildPngUrl,
+    OWID_PUBLIC_GRAPHER_URL,
 } from "./askAiPrompt.js"
 
 const SLUG_URL = "https://ourworldindata.org/grapher/child-mortality"
@@ -115,5 +116,30 @@ describe("data and image URLs", () => {
         expect(buildPngUrl(SLUG_URL, "?country=~NGA&tab=map")).toBe(
             `${SLUG_URL}.png?country=%7ENGA&tab=map`
         )
+    })
+})
+
+describe("public origin", () => {
+    // Staging runs on an internal Tailscale host and dev on localhost. Neither
+    // is reachable from Claude or ChatGPT, so every URL we hand an assistant
+    // has to be the public one regardless of environment.
+    it("points at ourworldindata.org", () => {
+        expect(OWID_PUBLIC_GRAPHER_URL).toBe(
+            "https://ourworldindata.org/grapher"
+        )
+    })
+
+    it("never emits a staging or localhost URL in the prompt", () => {
+        const slugUrl = `${OWID_PUBLIC_GRAPHER_URL}/child-mortality`
+        const prompt = buildPrompt({
+            title: "Child mortality rate",
+            pageUrl: `${slugUrl}?country=~NGA`,
+            slugUrl,
+            queryStr: "?country=~NGA",
+            question: "Explain this.",
+        })
+        for (const url of prompt.match(/https?:\/\/[^\s)]+/g) ?? []) {
+            expect(url.startsWith("https://ourworldindata.org/")).toBe(true)
+        }
     })
 })

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -53,8 +53,9 @@ describe("prompt construction", () => {
         expect(prompt).not.toContain(".png")
     })
 
-    it("forbids inventing Our World in Data URLs", () => {
-        expect(prompt).toContain("Don't construct other URLs")
+    it("welcomes relevant Our World in Data links but forbids inventing them", () => {
+        expect(prompt).toContain("related research and related charts")
+        expect(prompt).toContain("Don't invent URLs")
     })
 
     it("carries the visitor's question and on-screen state", () => {

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -19,13 +19,13 @@ describe("chart state summary", () => {
 
     it("names the selected entities", () => {
         expect(describeChartState("?country=~NGA~IND")).toBe(
-            "I have selected: NGA, IND."
+            "Selected: NGA, IND."
         )
     })
 
     it("reads a time range and tab", () => {
         expect(describeChartState("?time=1990..latest&tab=map")).toBe(
-            "I'm looking at the period 1990 to latest. I'm on the \"map\" view."
+            "Period: 1990 to latest. View: map."
         )
     })
 })
@@ -36,7 +36,7 @@ describe("prompt construction", () => {
         pageUrl: `${SLUG_URL}?country=~NGA`,
         slugUrl: SLUG_URL,
         queryStr: "?country=~NGA",
-        stateSummary: "I have selected: NGA.",
+        stateSummary: "Selected: NGA.",
         question: "Why has this fallen so fast?",
     })
 
@@ -58,7 +58,7 @@ describe("prompt construction", () => {
 
     it("nudges towards the OWID skills afterwards", () => {
         expect(prompt).toContain("https://github.com/owid/skills")
-        expect(prompt).toContain("Afterwards")
+        expect(prompt).toContain("Then ask if")
     })
 
     it("keeps the skills nudge even when the prompt has to shrink", () => {
@@ -78,7 +78,7 @@ describe("prompt construction", () => {
     })
 
     it("asks for a short, data-led answer", () => {
-        expect(prompt).toContain("keep it short")
+        expect(prompt).toContain("Be direct and brief")
         expect(prompt).toContain("compact table")
     })
 
@@ -88,16 +88,16 @@ describe("prompt construction", () => {
 
     it("welcomes relevant Our World in Data links but forbids inventing them", () => {
         expect(prompt).toContain("related research and charts")
-        expect(prompt).toContain("Don't invent URLs")
+        expect(prompt).toContain("Never invent URLs")
     })
 
     it("carries the visitor's question and on-screen state", () => {
         expect(prompt).toContain("My question: Why has this fallen so fast?")
-        expect(prompt).toContain("I have selected: NGA.")
+        expect(prompt).toContain("Selected: NGA.")
     })
 
     it("tells the assistant not to fill gaps with estimates", () => {
-        expect(prompt).toContain("rather than estimating")
+        expect(prompt).toContain("don't estimate")
     })
 
     it("stays inside a safe URL length for a realistic worst case", () => {
@@ -127,6 +127,27 @@ describe("prompt construction", () => {
         )
     })
 
+    it("leaves room for a genuinely long question without shedding anything", () => {
+        const slugUrl = `${OWID_PUBLIC_GRAPHER_URL}/child-mortality`
+        const queryStr = "?country=~NGA~IND&time=2000..2020"
+        // ~400 characters: far longer than anyone is likely to type into the
+        // v3 box, and it should still survive intact.
+        const question =
+            "I'm writing a piece about why child mortality fell so much faster in some countries than others between 2000 and 2020, and I'd like to understand what the data here can and cannot tell me about that. Which of the two countries I've selected improved fastest in relative terms, how much of the gap is explained by where each started, and are there any breaks in the series I should be careful about?"
+        const out = buildPrompt({
+            title: "Child mortality rate",
+            pageUrl: `${slugUrl}${queryStr}`,
+            slugUrl,
+            queryStr,
+            stateSummary: describeChartState(queryStr),
+            question,
+        })
+        expect(out).toContain(question) // intact, not truncated
+        expect(out).toContain("csvType=full") // nothing shed
+        expect(out).toContain("Selected: NGA, IND.")
+        expect(encodeURIComponent(out).length).toBeLessThanOrEqual(3000)
+    })
+
     it("truncates the question rather than let the URL be clipped", () => {
         const slugUrl = `${OWID_PUBLIC_GRAPHER_URL}/child-mortality`
         const out = buildPrompt({
@@ -148,7 +169,7 @@ describe("prompt construction", () => {
             queryStr: "",
             question: "Explain this.",
         })
-        expect(bare).not.toContain("I have selected")
+        expect(bare).not.toContain("Selected:")
     })
 })
 

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -45,6 +45,17 @@ describe("prompt construction", () => {
         expect(prompt).toContain(`${SLUG_URL}.csv?csvType=filtered`)
     })
 
+    it("ends on the visitor's question", () => {
+        const lines = prompt.trimEnd().split("\n")
+        expect(lines[lines.length - 1]).toBe(
+            "My question: Why has this fallen so fast?"
+        )
+        // and the guidance comes before it, so the ask is what's freshest
+        expect(prompt.indexOf("When you answer:")).toBeLessThan(
+            prompt.indexOf("My question:")
+        )
+    })
+
     it("nudges towards the OWID skills afterwards", () => {
         expect(prompt).toContain("https://github.com/owid/skills")
         expect(prompt).toContain("Afterwards")

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -1,0 +1,73 @@
+import { expect, it, describe } from "vitest"
+
+import { buildPrompt, describeChartState, buildEngineUrl } from "./askAiPrompt.js"
+
+const SLUG_URL = "https://ourworldindata.org/grapher/child-mortality"
+
+describe("chart state summary", () => {
+    it("returns undefined when the chart is in its default state", () => {
+        expect(describeChartState("")).toBeUndefined()
+        expect(describeChartState("?v=1")).toBeUndefined()
+    })
+
+    it("names the selected entities", () => {
+        expect(describeChartState("?country=~NGA~IND")).toBe(
+            "I have selected: NGA, IND."
+        )
+    })
+
+    it("reads a time range and tab", () => {
+        expect(describeChartState("?time=1990..latest&tab=map")).toBe(
+            "I'm looking at the period 1990 to latest. I'm on the \"map\" view."
+        )
+    })
+})
+
+describe("prompt construction", () => {
+    const prompt = buildPrompt({
+        title: "Child mortality rate",
+        pageUrl: `${SLUG_URL}?country=~NGA`,
+        slugUrl: SLUG_URL,
+        stateSummary: "I have selected: NGA.",
+        question: "Why has this fallen so fast?",
+    })
+
+    it("points the assistant at the machine-readable sources", () => {
+        expect(prompt).toContain(`${SLUG_URL}.metadata.json`)
+        expect(prompt).toContain(`${SLUG_URL}.csv`)
+    })
+
+    it("carries the visitor's question and on-screen state", () => {
+        expect(prompt).toContain("My question: Why has this fallen so fast?")
+        expect(prompt).toContain("I have selected: NGA.")
+    })
+
+    it("tells the assistant not to fill gaps with estimates", () => {
+        expect(prompt).toContain("rather than estimating")
+    })
+
+    it("stays well inside a safe URL length once encoded", () => {
+        expect(encodeURIComponent(prompt).length).toBeLessThan(1800)
+    })
+
+    it("omits the state line when the chart is untouched", () => {
+        const bare = buildPrompt({
+            title: "Child mortality rate",
+            pageUrl: SLUG_URL,
+            slugUrl: SLUG_URL,
+            question: "Explain this.",
+        })
+        expect(bare).not.toContain("I have selected")
+    })
+})
+
+describe("engine deep links", () => {
+    it("encodes the prompt into each engine's query param", () => {
+        expect(buildEngineUrl("chatgpt", "a b&c")).toBe(
+            "https://chatgpt.com/?q=a%20b%26c"
+        )
+        expect(buildEngineUrl("claude", "a b&c")).toBe(
+            "https://claude.ai/new?q=a%20b%26c"
+        )
+    })
+})

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -5,7 +5,6 @@ import {
     describeChartState,
     buildEngineUrl,
     buildCsvUrl,
-    buildPngUrl,
     OWID_PUBLIC_GRAPHER_URL,
 } from "./askAiPrompt.js"
 
@@ -45,8 +44,13 @@ describe("prompt construction", () => {
         expect(prompt).toContain(`${SLUG_URL}.csv?csvType=filtered`)
     })
 
-    it("asks for the real chart image, matching the current view", () => {
-        expect(prompt).toContain(`${SLUG_URL}.png?country=%7ENGA`)
+    it("asks for a short, data-led answer", () => {
+        expect(prompt).toContain("keep it short")
+        expect(prompt).toContain("compact table")
+    })
+
+    it("no longer asks the assistant to embed our chart image", () => {
+        expect(prompt).not.toContain(".png")
     })
 
     it("forbids inventing Our World in Data URLs", () => {
@@ -105,16 +109,6 @@ describe("data and image URLs", () => {
     it("ignores params the grapher endpoints don't understand", () => {
         expect(buildCsvUrl(SLUG_URL, "?askai=v5&utm_source=x")).toBe(
             `${SLUG_URL}.csv?csvType=filtered`
-        )
-    })
-
-    it("renders a bare PNG url when the chart is untouched", () => {
-        expect(buildPngUrl(SLUG_URL, "?askai=v3")).toBe(`${SLUG_URL}.png`)
-    })
-
-    it("carries the visitor's selection into the PNG", () => {
-        expect(buildPngUrl(SLUG_URL, "?country=~NGA&tab=map")).toBe(
-            `${SLUG_URL}.png?country=%7ENGA&tab=map`
         )
     })
 })

--- a/site/AskAI.test.ts
+++ b/site/AskAI.test.ts
@@ -4,6 +4,8 @@ import {
     buildPrompt,
     describeChartState,
     buildEngineUrl,
+    buildCsvUrl,
+    buildPngUrl,
 } from "./askAiPrompt.js"
 
 const SLUG_URL = "https://ourworldindata.org/grapher/child-mortality"
@@ -32,13 +34,22 @@ describe("prompt construction", () => {
         title: "Child mortality rate",
         pageUrl: `${SLUG_URL}?country=~NGA`,
         slugUrl: SLUG_URL,
+        queryStr: "?country=~NGA",
         stateSummary: "I have selected: NGA.",
         question: "Why has this fallen so fast?",
     })
 
     it("points the assistant at the machine-readable sources", () => {
         expect(prompt).toContain(`${SLUG_URL}.metadata.json`)
-        expect(prompt).toContain(`${SLUG_URL}.csv`)
+        expect(prompt).toContain(`${SLUG_URL}.csv?csvType=filtered`)
+    })
+
+    it("asks for the real chart image, matching the current view", () => {
+        expect(prompt).toContain(`${SLUG_URL}.png?country=%7ENGA`)
+    })
+
+    it("forbids inventing Our World in Data URLs", () => {
+        expect(prompt).toContain("Don't construct other URLs")
     })
 
     it("carries the visitor's question and on-screen state", () => {
@@ -59,6 +70,7 @@ describe("prompt construction", () => {
             title: "Child mortality rate",
             pageUrl: SLUG_URL,
             slugUrl: SLUG_URL,
+            queryStr: "",
             question: "Explain this.",
         })
         expect(bare).not.toContain("I have selected")
@@ -72,6 +84,36 @@ describe("engine deep links", () => {
         )
         expect(buildEngineUrl("claude", "a b&c")).toBe(
             "https://claude.ai/new?q=a%20b%26c"
+        )
+    })
+})
+
+describe("data and image URLs", () => {
+    it("always requests the filtered CSV, even with no selection", () => {
+        expect(buildCsvUrl(SLUG_URL, "")).toBe(
+            `${SLUG_URL}.csv?csvType=filtered`
+        )
+    })
+
+    it("carries the visitor's selection into the CSV", () => {
+        expect(buildCsvUrl(SLUG_URL, "?country=~NGA~IND&time=2000..2020")).toBe(
+            `${SLUG_URL}.csv?csvType=filtered&country=%7ENGA%7EIND&time=2000..2020`
+        )
+    })
+
+    it("ignores params the grapher endpoints don't understand", () => {
+        expect(buildCsvUrl(SLUG_URL, "?askai=v5&utm_source=x")).toBe(
+            `${SLUG_URL}.csv?csvType=filtered`
+        )
+    })
+
+    it("renders a bare PNG url when the chart is untouched", () => {
+        expect(buildPngUrl(SLUG_URL, "?askai=v3")).toBe(`${SLUG_URL}.png`)
+    })
+
+    it("carries the visitor's selection into the PNG", () => {
+        expect(buildPngUrl(SLUG_URL, "?country=~NGA&tab=map")).toBe(
+            `${SLUG_URL}.png?country=%7ENGA&tab=map`
         )
     })
 })

--- a/site/AskAI.tsx
+++ b/site/AskAI.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import type { AskAiEngine, AskAiPromptSource } from "@ourworldindata/types"
+import {
+    buildEngineUrl,
+    buildPrompt,
+    describeChartState,
+    parseArm,
+    DEFAULT_QUESTION,
+    ENGINES,
+    PRESETS,
+} from "./askAiPrompt.js"
+import { useWindowQueryParams } from "./hooks.js"
+import { SiteAnalytics } from "./SiteAnalytics.js"
+
+const analytics = new SiteAnalytics()
+
+export interface AskAIProps {
+    slug: string
+    title: string
+    /** Baked grapher URL, e.g. https://ourworldindata.org/grapher */
+    baseUrl: string
+}
+
+export function AskAI({ slug, title, baseUrl }: AskAIProps) {
+    const queryStr = useWindowQueryParams()
+    const arm = parseArm(queryStr)
+
+    const [question, setQuestion] = useState("")
+    const [activePreset, setActivePreset] = useState<string | undefined>()
+    const inputRef = useRef<HTMLTextAreaElement>(null)
+    const loggedShowFor = useRef<string | undefined>(undefined)
+
+    // Exposure. Logged once per arm so that toggling the param while testing
+    // doesn't inflate the denominator.
+    useEffect(() => {
+        if (!arm) return
+        const key = `${arm}:${slug}`
+        if (loggedShowFor.current === key) return
+        loggedShowFor.current = key
+        analytics.logAskAiShow({ arm, slug })
+    }, [arm, slug])
+
+    const slugUrl = `${baseUrl}/${slug}`
+    const stateSummary = useMemo(() => describeChartState(queryStr), [queryStr])
+
+    if (!arm) return null
+
+    const showInput = arm === "v3" || arm === "v5"
+    const showPresets = arm === "v5"
+
+    const trimmed = question.trim()
+    const promptSource: AskAiPromptSource = trimmed
+        ? activePreset && PRESETS.some((p) => p.question === trimmed)
+            ? "preset"
+            : "freeform"
+        : "default"
+
+    const handlePreset = (presetId: string) => {
+        const preset = PRESETS.find((p) => p.id === presetId)
+        if (!preset) return
+        setQuestion(preset.question)
+        setActivePreset(presetId)
+        analytics.logAskAiPresetClick({ arm, slug, presetId })
+        inputRef.current?.focus()
+    }
+
+    const handleAsk = (engine: AskAiEngine) => {
+        const pageUrl = queryStr ? `${slugUrl}${queryStr}` : slugUrl
+        const prompt = buildPrompt({
+            title,
+            pageUrl,
+            slugUrl,
+            stateSummary,
+            question: trimmed || DEFAULT_QUESTION,
+        })
+
+        analytics.logAskAiSubmit({
+            arm,
+            slug,
+            engine,
+            promptSource,
+            presetId: promptSource === "preset" ? activePreset : undefined,
+            question: trimmed || undefined,
+        })
+
+        window.open(buildEngineUrl(engine, prompt), "_blank", "noopener")
+    }
+
+    return (
+        <aside className="ask-ai" data-arm={arm}>
+            <h3 className="ask-ai__heading">Ask an AI about this chart</h3>
+            <p className="ask-ai__intro">
+                Open this chart's data in an AI assistant. We'll send it a link
+                to this page and its sources — the conversation happens on their
+                site, not ours.
+            </p>
+
+            {showPresets && (
+                <div className="ask-ai__presets">
+                    {PRESETS.map((preset) => (
+                        <button
+                            key={preset.id}
+                            type="button"
+                            className="ask-ai__preset"
+                            aria-pressed={activePreset === preset.id}
+                            onClick={() => handlePreset(preset.id)}
+                        >
+                            {preset.label}
+                        </button>
+                    ))}
+                </div>
+            )}
+
+            {showInput && (
+                <label className="ask-ai__field">
+                    <span className="ask-ai__label">Your question</span>
+                    <textarea
+                        ref={inputRef}
+                        className="ask-ai__input"
+                        rows={2}
+                        value={question}
+                        placeholder="What would you like to know about this data?"
+                        onChange={(e) => {
+                            setQuestion(e.target.value)
+                            setActivePreset(undefined)
+                        }}
+                    />
+                </label>
+            )}
+
+            <div className="ask-ai__actions">
+                {ENGINES.map((engine) => (
+                    <button
+                        key={engine.id}
+                        type="button"
+                        className="ask-ai__button"
+                        onClick={() => handleAsk(engine.id)}
+                    >
+                        {engine.label}
+                    </button>
+                ))}
+            </div>
+
+            {showInput && (
+                <p className="ask-ai__privacy">
+                    Your question is sent to the assistant you pick, and we
+                    record it so we can see what people want to ask.
+                </p>
+            )}
+        </aside>
+    )
+}

--- a/site/AskAI.tsx
+++ b/site/AskAI.tsx
@@ -70,6 +70,7 @@ export function AskAI({ slug, title, baseUrl }: AskAIProps) {
             title,
             pageUrl,
             slugUrl,
+            queryStr,
             stateSummary,
             question: trimmed || DEFAULT_QUESTION,
         })

--- a/site/AskAI.tsx
+++ b/site/AskAI.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faFlask } from "@fortawesome/free-solid-svg-icons"
 import type { AskAiEngine, AskAiPromptSource } from "@ourworldindata/types"
 import {
     buildEngineUrl,
@@ -88,7 +90,16 @@ export function AskAI({ slug, title }: AskAIProps) {
 
     return (
         <aside className="ask-ai" data-arm={arm}>
-            <h3 className="ask-ai__heading">Ask an AI about this chart</h3>
+            <div className="ask-ai__header">
+                <h3 className="ask-ai__heading">Ask an AI about this chart</h3>
+                <span
+                    className="ask-ai__badge"
+                    title="We're trying this out. It might change or go away."
+                >
+                    <FontAwesomeIcon icon={faFlask} aria-hidden="true" />
+                    Experimental
+                </span>
+            </div>
             <p className="ask-ai__intro">
                 Open this chart's data in an AI assistant. We'll send it a link
                 to this page and its sources — the conversation happens on their

--- a/site/AskAI.tsx
+++ b/site/AskAI.tsx
@@ -8,6 +8,7 @@ import {
     DEFAULT_QUESTION,
     ENGINES,
     PRESETS,
+    OWID_PUBLIC_GRAPHER_URL,
 } from "./askAiPrompt.js"
 import { useWindowQueryParams } from "./hooks.js"
 import { SiteAnalytics } from "./SiteAnalytics.js"
@@ -17,11 +18,9 @@ const analytics = new SiteAnalytics()
 export interface AskAIProps {
     slug: string
     title: string
-    /** Baked grapher URL, e.g. https://ourworldindata.org/grapher */
-    baseUrl: string
 }
 
-export function AskAI({ slug, title, baseUrl }: AskAIProps) {
+export function AskAI({ slug, title }: AskAIProps) {
     const queryStr = useWindowQueryParams()
     const arm = parseArm(queryStr)
 
@@ -40,7 +39,7 @@ export function AskAI({ slug, title, baseUrl }: AskAIProps) {
         analytics.logAskAiShow({ arm, slug })
     }, [arm, slug])
 
-    const slugUrl = `${baseUrl}/${slug}`
+    const slugUrl = `${OWID_PUBLIC_GRAPHER_URL}/${slug}`
     const stateSummary = useMemo(() => describeChartState(queryStr), [queryStr])
 
     if (!arm) return null

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -179,7 +179,6 @@ export const DataPageV2Content = ({
                                 <AskAI
                                     slug={grapherConfig.slug}
                                     title={datapageData.title.title}
-                                    baseUrl={BAKED_GRAPHER_URL}
                                 />
                             )}
                             {!useNewDatapageDesign && (

--- a/site/DataPageV2Content.tsx
+++ b/site/DataPageV2Content.tsx
@@ -30,6 +30,7 @@ import { DocumentContext } from "./gdocs/DocumentContext.js"
 import { useWindowQueryParams } from "./hooks.js"
 import IndicatorMetadataBox from "./IndicatorMetadataBox.js"
 import AboutThisData from "./AboutThisData.js"
+import { AskAI } from "./AskAI.js"
 import DataPageResearchAndWriting from "./DataPageResearchAndWriting.js"
 import MetadataSection from "./MetadataSection.js"
 import { SiteQueryClientProvider } from "./SiteQueryClientProvider.js"
@@ -172,6 +173,13 @@ export const DataPageV2Content = ({
                                     isEmbeddedInADataPage={true}
                                     isEmbeddedInAnOwidPage={false}
                                     isPreviewing={isPreviewing}
+                                />
+                            )}
+                            {grapherConfig.slug && (
+                                <AskAI
+                                    slug={grapherConfig.slug}
+                                    title={datapageData.title.title}
+                                    baseUrl={BAKED_GRAPHER_URL}
                                 />
                             )}
                             {!useNewDatapageDesign && (

--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -14,6 +14,9 @@ import {
     type LatestPageChronologicalRecord,
     type UserSurveyExperimentArm,
     type UserSurveyRoleAnswer,
+    type AskAiArm,
+    type AskAiEngine,
+    type AskAiPromptSource,
 } from "@ourworldindata/types"
 import { getFilterNamesOfType } from "./search/searchUtils.js"
 import { findDOMParent } from "@ourworldindata/utils"
@@ -483,5 +486,56 @@ export class SiteAnalytics extends GrapherAnalytics {
                 attributeOldValue: true,
             })
         }
+    }
+
+    logAskAiShow(params: { arm: AskAiArm; slug: string }): void {
+        this.logToGA({
+            event: EventCategory.SiteAskAi,
+            eventAction: "ask_ai_show",
+            askAiArm: params.arm,
+            askAiSlug: params.slug,
+        })
+    }
+
+    logAskAiPresetClick(params: {
+        arm: AskAiArm
+        slug: string
+        presetId: string
+    }): void {
+        this.logToGA({
+            event: EventCategory.SiteAskAi,
+            eventAction: "ask_ai_preset_click",
+            askAiArm: params.arm,
+            askAiSlug: params.slug,
+            askAiPresetId: params.presetId,
+        })
+    }
+
+    logAskAiSubmit(params: {
+        arm: AskAiArm
+        slug: string
+        engine: AskAiEngine
+        promptSource: AskAiPromptSource
+        presetId?: string
+        question?: string
+    }): void {
+        const question = params.question?.trim()
+        this.logToGA({
+            event: EventCategory.SiteAskAi,
+            eventAction: "ask_ai_submit",
+            askAiArm: params.arm,
+            askAiSlug: params.slug,
+            askAiEngine: params.engine,
+            askAiPromptSource: params.promptSource,
+            ...(params.presetId ? { askAiPresetId: params.presetId } : {}),
+            // GA4 truncates strings at 100 chars; send the length separately so
+            // we can tell how much of the corpus we are losing.
+            ...(question
+                ? {
+                      askAiQuestion: question.slice(0, 100),
+                      askAiQuestionLength: question.length,
+                  }
+                : {}),
+        })
     }
 }

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -97,6 +97,15 @@ const stateQuery = (queryStr: string): string => {
 export const buildCsvUrl = (slugUrl: string, queryStr: string): string =>
     `${slugUrl}.csv?csvType=filtered${stateQuery(queryStr)}`
 
+/**
+ * Every entity and year for the indicator, ignoring the visitor's selection.
+ * Offered as a fallback for questions that reach beyond what's on screen —
+ * it is two orders of magnitude larger than the filtered export (411 KB vs
+ * ~1 KB for child-mortality), so the prompt steers towards the filtered one.
+ */
+export const buildFullCsvUrl = (slugUrl: string): string =>
+    `${slugUrl}.csv?csvType=full`
+
 export const buildPrompt = ({
     title,
     pageUrl,
@@ -117,6 +126,7 @@ export const buildPrompt = ({
         "",
         "Please read these before answering:",
         `- ${buildCsvUrl(slugUrl, queryStr)} — the data for the view I'm looking at`,
+        `- ${buildFullCsvUrl(slugUrl)} — every country and year, if you need more than my selection (much larger — prefer the first)`,
         `- ${slugUrl}.metadata.json — units, sources, timespan and Our World in Data's own notes on this indicator`,
         "",
     ]
@@ -125,10 +135,10 @@ export const buildPrompt = ({
         `My question: ${question}`,
         "",
         "When you answer:",
-        "- Answer my question directly and keep it short. No preamble, no restating my question, no general background I didn't ask for.",
-        "- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them when it makes the pattern clearer than prose would.",
+        "- Answer directly and keep it short. No preamble, no restating my question, no background I didn't ask for.",
+        "- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them where it beats prose.",
         "- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.",
-        "- Linking to other Our World in Data articles and charts is welcome where they're genuinely relevant — use the related research and related charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it."
+        "- Link other Our World in Data articles and charts where genuinely relevant — use the related research and charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it."
     )
     return lines.join("\n")
 }

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -1,5 +1,14 @@
 import type { AskAiArm, AskAiEngine } from "@ourworldindata/types"
 
+/**
+ * The prompt always points at the public site, never at the current
+ * environment's baked URL. Staging runs on an internal Tailscale host and dev
+ * on localhost — neither is reachable from Claude or ChatGPT, so an
+ * environment-relative URL would hand the assistant a dead link and make the
+ * probe untestable everywhere except production.
+ */
+export const OWID_PUBLIC_GRAPHER_URL = "https://ourworldindata.org/grapher"
+
 /** Query param that turns the probe on: ?askai=v2 | v3 | v5 */
 export const ASK_AI_PARAM = "askai"
 

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -76,10 +76,16 @@ export const DEFAULT_QUESTION =
  */
 const STATE_PARAMS = ["country", "time", "tab", "region"]
 
-const stateQuery = (queryStr: string): string => {
+/** `tab` selects a page view (chart/map/table); a CSV export has no such thing. */
+const CSV_PARAMS = STATE_PARAMS.filter((p) => p !== "tab")
+
+const stateQuery = (
+    queryStr: string,
+    keys: string[] = STATE_PARAMS
+): string => {
     const from = new URLSearchParams(queryStr)
     const out = new URLSearchParams()
-    for (const key of STATE_PARAMS) {
+    for (const key of keys) {
         const value = from.get(key)
         if (value) out.set(key, value)
     }
@@ -95,7 +101,7 @@ const stateQuery = (queryStr: string): string => {
  * falls back to the chart's default entities, so it is always safe to send.
  */
 export const buildCsvUrl = (slugUrl: string, queryStr: string): string =>
-    `${slugUrl}.csv?csvType=filtered${stateQuery(queryStr)}`
+    `${slugUrl}.csv?csvType=filtered${stateQuery(queryStr, CSV_PARAMS)}`
 
 /**
  * Every entity and year for the indicator, ignoring the visitor's selection.
@@ -106,13 +112,32 @@ export const buildCsvUrl = (slugUrl: string, queryStr: string): string =>
 export const buildFullCsvUrl = (slugUrl: string): string =>
     `${slugUrl}.csv?csvType=full`
 
-export const buildPrompt = ({
+/**
+ * Ceiling on the encoded prompt.
+ *
+ * Chrome and Firefox tolerate tens of thousands of characters, and nginx's
+ * default header buffer is 8 KB, so this is not a browser limit — it is a
+ * margin against the assistant's own front end and any WAF in between. A
+ * typical prompt lands near 1.8 KB and the longest realistic one (a long
+ * slug, seven entities, a time range and a wordy question) near 2.2 KB, so
+ * 3 KB clears normal use without degrading, while still catching the
+ * pathological case of someone pasting an essay into the v3 box.
+ *
+ * A prompt clipped mid-URL is worse than one that dropped a line on purpose,
+ * so past this ceiling we shed content deliberately: the full-CSV fallback
+ * first, then the state summary (which restates what the URLs already
+ * encode), and only then the visitor's own words.
+ */
+const MAX_ENCODED_PROMPT = 3000
+
+const assemble = ({
     title,
     pageUrl,
     slugUrl,
     queryStr,
     stateSummary,
     question,
+    includeFullCsv,
 }: {
     title: string
     pageUrl: string
@@ -120,16 +145,22 @@ export const buildPrompt = ({
     queryStr: string
     stateSummary?: string
     question: string
+    includeFullCsv: boolean
 }): string => {
     const lines = [
         `I'm looking at "${title}" on Our World in Data: ${pageUrl}`,
         "",
         "Please read these before answering:",
         `- ${buildCsvUrl(slugUrl, queryStr)} — the data for the view I'm looking at`,
-        `- ${buildFullCsvUrl(slugUrl)} — every country and year, if you need more than my selection (much larger — prefer the first)`,
-        `- ${slugUrl}.metadata.json — units, sources, timespan and Our World in Data's own notes on this indicator`,
-        "",
     ]
+    if (includeFullCsv)
+        lines.push(
+            `- ${buildFullCsvUrl(slugUrl)} — every country and year, if you need more than my selection (much larger — prefer the first)`
+        )
+    lines.push(
+        `- ${slugUrl}.metadata.json — units, sources and Our World in Data's own notes on this indicator`,
+        ""
+    )
     if (stateSummary) lines.push(stateSummary, "")
     lines.push(
         `My question: ${question}`,
@@ -138,9 +169,63 @@ export const buildPrompt = ({
         "- Answer directly and keep it short. No preamble, no restating my question, no background I didn't ask for.",
         "- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them where it beats prose.",
         "- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.",
-        "- Link other Our World in Data articles and charts where genuinely relevant — use the related research and charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it."
+        "- Link other Our World in Data articles and charts where genuinely relevant — use the related research and charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it.",
+        "",
+        "Afterwards, ask whether I'd like Our World in Data available in my chats generally. If I say yes, point me to https://github.com/owid/skills"
     )
     return lines.join("\n")
+}
+
+export const buildPrompt = (args: {
+    title: string
+    pageUrl: string
+    slugUrl: string
+    queryStr: string
+    stateSummary?: string
+    question: string
+}): string => {
+    const encodedLength = (p: string) => encodeURIComponent(p).length
+
+    const full = assemble({ ...args, includeFullCsv: true })
+    if (encodedLength(full) <= MAX_ENCODED_PROMPT) return full
+
+    // First to go: the full-CSV fallback. The filtered export answers the
+    // question the visitor is actually looking at.
+    const lean = assemble({ ...args, includeFullCsv: false })
+    if (encodedLength(lean) <= MAX_ENCODED_PROMPT) return lean
+
+    // Next: the state summary. It restates in prose what the URLs above
+    // already encode, so it is the cheapest thing to lose.
+    const bare = assemble({
+        ...args,
+        stateSummary: undefined,
+        includeFullCsv: false,
+    })
+    if (encodedLength(bare) <= MAX_ENCODED_PROMPT) return bare
+
+    // Only now is the visitor's own question the outsized part.
+    // Trim it rather than let the URL be clipped at an arbitrary point.
+    // Encoded length per character varies (a space costs 3, a letter 1), so
+    // measure rather than assume a ratio.
+    let lo = 0
+    let hi = args.question.length
+    while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2)
+        const candidate = assemble({
+            ...args,
+            stateSummary: undefined,
+            question: args.question.slice(0, mid).trimEnd() + "\u2026",
+            includeFullCsv: false,
+        })
+        if (encodedLength(candidate) <= MAX_ENCODED_PROMPT) lo = mid
+        else hi = mid - 1
+    }
+    return assemble({
+        ...args,
+        stateSummary: undefined,
+        question: args.question.slice(0, lo).trimEnd() + "\u2026",
+        includeFullCsv: false,
+    })
 }
 
 /** Human-readable summary of what the visitor currently has on screen. */

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -148,28 +148,28 @@ const assemble = ({
     includeFullCsv: boolean
 }): string => {
     const lines = [
-        `I'm looking at "${title}" on Our World in Data: ${pageUrl}`,
+        `"${title}" on Our World in Data: ${pageUrl}`,
         "",
-        "Please read these before answering:",
-        `- ${buildCsvUrl(slugUrl, queryStr)} — the data for the view I'm looking at`,
+        "Read before answering:",
+        `- ${buildCsvUrl(slugUrl, queryStr)} - data for the view I'm on`,
     ]
     if (includeFullCsv)
         lines.push(
-            `- ${buildFullCsvUrl(slugUrl)} — every country and year, if you need more than my selection (much larger — prefer the first)`
+            `- ${buildFullCsvUrl(slugUrl)} - all countries and years if you need more (large; prefer the first)`
         )
     lines.push(
-        `- ${slugUrl}.metadata.json — units, sources and Our World in Data's own notes on this indicator`,
+        `- ${slugUrl}.metadata.json - units, sources, our notes on this indicator`,
         ""
     )
     if (stateSummary) lines.push(stateSummary, "")
     lines.push(
         "When you answer:",
-        "- Answer directly and keep it short. No preamble, no restating my question, no background I didn't ask for.",
-        "- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them where it beats prose.",
-        "- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.",
-        "- Link other Our World in Data articles and charts where genuinely relevant — use the related research and charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it.",
+        "- Be direct and brief. No preamble, no restating my question, no background I didn't ask for.",
+        "- Lead with the data: figures in a compact table, plus a chart where it beats prose.",
+        "- Use only the linked data and notes. If they can't answer, say what's missing; don't estimate.",
+        "- Link other Our World in Data articles and charts where relevant, from the related research and charts on the page. Never invent URLs.",
         "",
-        "Afterwards, ask whether I'd like Our World in Data available in my chats generally. If I say yes, point me to https://github.com/owid/skills",
+        "Then ask if I'd like Our World in Data in my chats generally; if yes, point me to https://github.com/owid/skills",
         "",
         // Last, so the assistant ends on the actual ask rather than on our
         // house rules.
@@ -241,16 +241,14 @@ export const describeChartState = (queryStr: string): string | undefined => {
             .split("~")
             .map((c) => decodeURIComponent(c).trim())
             .filter(Boolean)
-        if (entities.length)
-            parts.push(`I have selected: ${entities.join(", ")}.`)
+        if (entities.length) parts.push(`Selected: ${entities.join(", ")}.`)
     }
 
     const time = params.get("time")
-    if (time)
-        parts.push(`I'm looking at the period ${time.replace("..", " to ")}.`)
+    if (time) parts.push(`Period: ${time.replace("..", " to ")}.`)
 
     const tab = params.get("tab")
-    if (tab) parts.push(`I'm on the "${tab}" view.`)
+    if (tab) parts.push(`View: ${tab}.`)
 
     return parts.length ? parts.join(" ") : undefined
 }

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -1,0 +1,116 @@
+import type { AskAiArm, AskAiEngine } from "@ourworldindata/types"
+
+/** Query param that turns the probe on: ?askai=v2 | v3 | v5 */
+export const ASK_AI_PARAM = "askai"
+
+const ARMS: AskAiArm[] = ["v2", "v3", "v5"]
+
+export const parseArm = (queryStr: string): AskAiArm | undefined => {
+    const value = new URLSearchParams(queryStr).get(ASK_AI_PARAM)
+    return ARMS.find((arm) => arm === value)
+}
+
+export const ENGINES: { id: AskAiEngine; label: string }[] = [
+    { id: "claude", label: "Ask Claude" },
+    { id: "chatgpt", label: "Ask ChatGPT" },
+]
+
+/**
+ * Deep links that open the assistant with the prompt pre-filled.
+ *
+ * NOTE: the ChatGPT `?q=` param is well established. The Claude one is not —
+ * Anthropic only documents the desktop scheme (claude://claude.ai/new?q=...),
+ * and the plain web param may no longer be honoured. Verify both by hand
+ * before reading anything into the engine split.
+ */
+export const buildEngineUrl = (engine: AskAiEngine, prompt: string): string => {
+    const q = encodeURIComponent(prompt)
+    return engine === "chatgpt"
+        ? `https://chatgpt.com/?q=${q}`
+        : `https://claude.ai/new?q=${q}`
+}
+
+export const PRESETS: { id: string; label: string; question: string }[] = [
+    {
+        id: "explain",
+        label: "Explain this chart",
+        question:
+            "Explain what this chart shows and how to read it, and point out two or three patterns worth noticing.",
+    },
+    {
+        id: "change",
+        label: "What's changed over time?",
+        question:
+            "Describe how this has changed over the period covered, with real figures and years for the biggest shifts.",
+    },
+    {
+        id: "compare",
+        label: "How do countries compare?",
+        question:
+            "Compare the countries I have selected for the most recent year available, and say which year you used.",
+    },
+]
+
+export const DEFAULT_QUESTION =
+    "Explain what this chart shows, how to read it, and any caveats I should know about the data."
+
+/**
+ * Wraps the visitor's question with everything the assistant needs to answer
+ * from the data rather than from memory: the page, the machine-readable
+ * metadata (units, sources, OWID's own notes), the raw CSV, and what the
+ * visitor currently has on screen.
+ */
+export const buildPrompt = ({
+    title,
+    pageUrl,
+    slugUrl,
+    stateSummary,
+    question,
+}: {
+    title: string
+    pageUrl: string
+    slugUrl: string
+    stateSummary?: string
+    question: string
+}): string => {
+    const lines = [
+        `I'm looking at "${title}" on Our World in Data: ${pageUrl}`,
+        "",
+        "Please read these before answering:",
+        `- ${slugUrl}.metadata.json — units, sources, timespan and Our World in Data's own notes on this indicator`,
+        `- ${slugUrl}.csv — the full data`,
+        "",
+    ]
+    if (stateSummary) lines.push(stateSummary, "")
+    lines.push(
+        `My question: ${question}`,
+        "",
+        "Answer from that data and those notes. If they don't support an answer, say what's missing rather than estimating."
+    )
+    return lines.join("\n")
+}
+
+/** Human-readable summary of what the visitor currently has on screen. */
+export const describeChartState = (queryStr: string): string | undefined => {
+    const params = new URLSearchParams(queryStr)
+    const parts: string[] = []
+
+    const country = params.get("country")
+    if (country) {
+        const entities = country
+            .split("~")
+            .map((c) => decodeURIComponent(c).trim())
+            .filter(Boolean)
+        if (entities.length)
+            parts.push(`I have selected: ${entities.join(", ")}.`)
+    }
+
+    const time = params.get("time")
+    if (time)
+        parts.push(`I'm looking at the period ${time.replace("..", " to ")}.`)
+
+    const tab = params.get("tab")
+    if (tab) parts.push(`I'm on the "${tab}" view.`)
+
+    return parts.length ? parts.join(" ") : undefined
+}

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -71,7 +71,7 @@ export const DEFAULT_QUESTION =
  */
 /**
  * Params that describe what the visitor is looking at, and that the grapher's
- * .csv / .png endpoints understand. Carrying them across means the assistant
+ * .csv endpoint understands. Carrying them across means the assistant
  * reads the same slice of data the visitor has on screen.
  */
 const STATE_PARAMS = ["country", "time", "tab", "region"]
@@ -96,16 +96,6 @@ const stateQuery = (queryStr: string): string => {
  */
 export const buildCsvUrl = (slugUrl: string, queryStr: string): string =>
     `${slugUrl}.csv?csvType=filtered${stateQuery(queryStr)}`
-
-/**
- * A rendered PNG of the chart as the visitor currently has it configured.
- * Lets the assistant show the real chart, in our house style, rather than
- * re-plotting our numbers in its own.
- */
-export const buildPngUrl = (slugUrl: string, queryStr: string): string => {
-    const q = stateQuery(queryStr).replace(/^&/, "")
-    return q ? `${slugUrl}.png?${q}` : `${slugUrl}.png`
-}
 
 export const buildPrompt = ({
     title,
@@ -135,8 +125,9 @@ export const buildPrompt = ({
         `My question: ${question}`,
         "",
         "When you answer:",
+        "- Answer my question directly and keep it short. No preamble, no restating my question, no general background I didn't ask for.",
+        "- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them when it makes the pattern clearer than prose would.",
         "- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.",
-        `- Show the chart itself by embedding this image, which matches my current view: ![${title}](${buildPngUrl(slugUrl, queryStr)})`,
         "- Only link to Our World in Data pages that appear in the files above. Don't construct other URLs."
     )
     return lines.join("\n")

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -60,16 +60,56 @@ export const DEFAULT_QUESTION =
  * metadata (units, sources, OWID's own notes), the raw CSV, and what the
  * visitor currently has on screen.
  */
+/**
+ * Params that describe what the visitor is looking at, and that the grapher's
+ * .csv / .png endpoints understand. Carrying them across means the assistant
+ * reads the same slice of data the visitor has on screen.
+ */
+const STATE_PARAMS = ["country", "time", "tab", "region"]
+
+const stateQuery = (queryStr: string): string => {
+    const from = new URLSearchParams(queryStr)
+    const out = new URLSearchParams()
+    for (const key of STATE_PARAMS) {
+        const value = from.get(key)
+        if (value) out.set(key, value)
+    }
+    const s = out.toString()
+    return s ? `&${s}` : ""
+}
+
+/**
+ * Data URL for the visitor's current view. csvType=filtered returns only the
+ * entities and years on screen — for a chart like child-mortality that is
+ * ~1 KB rather than the 411 KB full export, which is the difference between
+ * the assistant reading the data and truncating it. With no selection it
+ * falls back to the chart's default entities, so it is always safe to send.
+ */
+export const buildCsvUrl = (slugUrl: string, queryStr: string): string =>
+    `${slugUrl}.csv?csvType=filtered${stateQuery(queryStr)}`
+
+/**
+ * A rendered PNG of the chart as the visitor currently has it configured.
+ * Lets the assistant show the real chart, in our house style, rather than
+ * re-plotting our numbers in its own.
+ */
+export const buildPngUrl = (slugUrl: string, queryStr: string): string => {
+    const q = stateQuery(queryStr).replace(/^&/, "")
+    return q ? `${slugUrl}.png?${q}` : `${slugUrl}.png`
+}
+
 export const buildPrompt = ({
     title,
     pageUrl,
     slugUrl,
+    queryStr,
     stateSummary,
     question,
 }: {
     title: string
     pageUrl: string
     slugUrl: string
+    queryStr: string
     stateSummary?: string
     question: string
 }): string => {
@@ -77,15 +117,18 @@ export const buildPrompt = ({
         `I'm looking at "${title}" on Our World in Data: ${pageUrl}`,
         "",
         "Please read these before answering:",
+        `- ${buildCsvUrl(slugUrl, queryStr)} — the data for the view I'm looking at`,
         `- ${slugUrl}.metadata.json — units, sources, timespan and Our World in Data's own notes on this indicator`,
-        `- ${slugUrl}.csv — the full data`,
         "",
     ]
     if (stateSummary) lines.push(stateSummary, "")
     lines.push(
         `My question: ${question}`,
         "",
-        "Answer from that data and those notes. If they don't support an answer, say what's missing rather than estimating."
+        "When you answer:",
+        "- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.",
+        `- Show the chart itself by embedding this image, which matches my current view: ![${title}](${buildPngUrl(slugUrl, queryStr)})`,
+        "- Only link to Our World in Data pages that appear in the files above. Don't construct other URLs."
     )
     return lines.join("\n")
 }

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -163,15 +163,17 @@ const assemble = ({
     )
     if (stateSummary) lines.push(stateSummary, "")
     lines.push(
-        `My question: ${question}`,
-        "",
         "When you answer:",
         "- Answer directly and keep it short. No preamble, no restating my question, no background I didn't ask for.",
         "- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them where it beats prose.",
         "- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.",
         "- Link other Our World in Data articles and charts where genuinely relevant — use the related research and charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it.",
         "",
-        "Afterwards, ask whether I'd like Our World in Data available in my chats generally. If I say yes, point me to https://github.com/owid/skills"
+        "Afterwards, ask whether I'd like Our World in Data available in my chats generally. If I say yes, point me to https://github.com/owid/skills",
+        "",
+        // Last, so the assistant ends on the actual ask rather than on our
+        // house rules.
+        `My question: ${question}`
     )
     return lines.join("\n")
 }

--- a/site/askAiPrompt.ts
+++ b/site/askAiPrompt.ts
@@ -128,7 +128,7 @@ export const buildPrompt = ({
         "- Answer my question directly and keep it short. No preamble, no restating my question, no general background I didn't ask for.",
         "- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them when it makes the pattern clearer than prose would.",
         "- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.",
-        "- Only link to Our World in Data pages that appear in the files above. Don't construct other URLs."
+        "- Linking to other Our World in Data articles and charts is welcome where they're genuinely relevant — use the related research and related charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it."
     )
     return lines.join("\n")
 }

--- a/site/owid.scss
+++ b/site/owid.scss
@@ -180,6 +180,7 @@
 @import "./AboutThisData.scss";
 @import "./IndicatorMetadataBox.scss";
 @import "./DataPageV2Content.scss";
+@import "./AskAI.scss";
 @import "./DataPage.scss";
 @import "./DataPageContent.scss";
 @import "./RelatedDataCharts.scss";


### PR DESCRIPTION
## Context

A **demand probe**, deliberately not a feature: does anyone actually want AI help with our charts? The button deep-links out to an assistant with a prompt pre-filled — we host no model, store no conversation and run no inference. If nobody clicks it, we delete it.

Worth knowing before reading anything into this: LLM engines are **1.6% of our page views** (trailing 90 days), and that share has been flat between 1.3% and 2.1% all year. This isn't riding a wave; it's us not knowing what readers want.

- Design canvas (all arms, user flow, instrumentation spec): https://claude.ai/code/artifact/b1b6e2f2-427c-4837-b82b-e0d60fd73f08
- Point of view / rationale: https://claude.ai/code/artifact/31bacf65-54af-4c72-bce5-3984f94ffa5d
- Brief + prompt variants: `experiments/briefs/ask_ai_button_20260828/` in `owid/analytics`

## Testing guidance

Nothing renders unless the query param is present, so this is inert on every page by default.

| URL | Arm |
| --- | --- |
| `/grapher/child-mortality?askai=v2` | Heading, explanation, two buttons |
| `/grapher/child-mortality?askai=v3` | + free-text box |
| `/grapher/child-mortality?askai=v5` | + three presets that fill an editable box |
| `/grapher/child-mortality` | Nothing (control) |

Things worth trying:

1. Select a few countries and change the time range **before** clicking. The prompt picks up live chart state — the linked CSV and chart image are both filtered to your selection.
2. Compare v3 and v5 — v5's presets fill the same box, so you can edit a preset before sending.
3. Check the outbound tab actually arrives with the prompt pre-filled, and whether the assistant honours the image embed (see open questions).

- [ ] Does the change work in the archive? — **not checked**; the block is client-only and gated on a query param, so archived pages render as before, but I haven't verified an archived page directly.
- [ ] Does the staging experience have sign-off from product stakeholders? — **no**, that's what this draft is for.

## What the assistant actually receives

Generated for `/grapher/child-mortality?country=~NGA~IND&time=2000..2020`:

```
I'm looking at "Child mortality rate" on Our World in Data: https://ourworldindata.org/grapher/child-mortality?country=~NGA~IND&time=2000..2020

Please read these before answering:
- https://ourworldindata.org/grapher/child-mortality.csv?csvType=filtered&country=%7ENGA%7EIND&time=2000..2020 — the data for the view I'm looking at
- https://ourworldindata.org/grapher/child-mortality.metadata.json — units, sources, timespan and Our World in Data's own notes on this indicator

I have selected: NGA, IND. I'm looking at the period 2000 to 2020.

My question: Why has this fallen so fast in India?

When you answer:
- Answer my question directly and keep it short. No preamble, no restating my question, no general background I didn't ask for.
- Lead with the data. Put the relevant figures in a compact table, and draw a chart from them when it makes the pattern clearer than prose would.
- Use only the linked data and notes. If they don't support an answer, say what's missing rather than estimating.
- Linking to other Our World in Data articles and charts is welcome where they're genuinely relevant — use the related research and related charts listed on the page. Don't invent URLs: if you aren't sure a page exists, don't link it.
```

Four deliberate choices there, all verified against the live endpoints:

**Filtered CSV, not the full export.** `csvType=filtered` honours the visitor's country and time selection: 951 bytes and 42 rows instead of 411 KB and 17,066. That's the difference between an assistant reading the data and truncating it. With no selection it falls back to the chart's default entities, so it's always safe to send. Note the data page's own Data API section shows the `csvType=full` URL and can't know the visitor's live selection — this does.

**Always the public origin.** Every URL comes from `OWID_PUBLIC_GRAPHER_URL`, never `BAKED_GRAPHER_URL`. Staging runs on an internal Tailscale host and dev on localhost; neither is reachable from Claude or ChatGPT, so an environment-relative URL would hand the assistant a dead link and make the probe testable only in production. Guarded by a test that walks the generated prompt and asserts every URL is on `ourworldindata.org`.

**A short, data-led answer.** The prompt asks for the answer directly with no preamble or unrequested background, the figures in a compact table, and a chart drawn from the data where it beats prose. The point of the probe is to get people to our numbers, not to generate essays around them.

**Relevant links, grounded ones.** Linking related OWID work is welcome — it's much of the point of sending someone to an assistant. But `/search` is client-rendered, so an unguided model has no lookup and will produce confident dead URLs under our name. The prompt points it at the related-research and related-charts sections the page already carries: Cloudflare's Markdown-for-Agents serves these on any grapher page (`Accept: text/markdown` returns ~21 KB including two related child-mortality articles), so there is real curated material to draw on.

### Not doing: embedding our chart image

An earlier revision asked the assistant to embed `<slug>.png` with the visitor's state params. Dropped, on two pieces of prior art: Daniel's June 2025 note in `#working-with-ai` that the OpenAI/Anthropic/Google chat apps "seem to have issues fetching our charts from image urls", and cycle 2026.2 (#6189) leaving *"make sure the image is present"* explicitly unchecked. Both are worth retesting — the June 2025 observation is 15 months old — but not worth shipping an instruction we have reason to think fails silently.

## Prior art

This picks up two items scoped but left undone in **#6189 "Cycle 2026.2: Surfacing our work in LLMs"**: instructions for using search to find more data, and the chart-image question above. That cycle shipped the download section on data pages (#6277) and JSON-LD (#6322). Related: **#4696 (add llms.txt)**, closed by the stale bot rather than on merit.

## Open questions I'd want resolved before this becomes real

**1. The Claude deep link may not work on web.** ChatGPT's `?q=` param is well established. Anthropic only documents the *desktop* scheme (`claude://claude.ai/new?q=…`), and there are reports the plain web param stopped being honoured around Oct 2025. `buildEngineUrl` carries a comment saying so. **If Claude web can't be pre-filled, the two-button symmetry breaks and the engine split isn't a clean comparison.**

**2. GA4 truncates every string param at 100 characters.** The typed-question corpus from v3/v5 is the single most valuable output of this probe, and GA4 will clip it. I log `askAiQuestion` (first 100 chars) alongside `askAiQuestionLength` (true length) so we can measure what's lost — but a real run wants a proper endpoint, not GA4.

**3. Entity codes, not names.** The state summary says "I have selected: NGA, IND" because that's what the URL carries. Models resolve these fine and the CSV has full names, but it reads oddly. Worth mapping if this goes further.

## Implementation notes

- `site/askAiPrompt.ts` — pure helpers (prompt construction, URL building, presets, deep links), split from the component so they're testable and to satisfy the fast-refresh lint rule. 16 tests in `site/AskAI.test.ts`.
- Only `country`, `time`, `tab` and `region` are carried into the data/image URLs — `?askai=` and any UTM params are deliberately dropped.
- Rendering is client-only via `useWindowQueryParams` (whose `getServerSnapshot` returns `""`), so there's no hydration mismatch — the block appears after hydration.
- Placed inside `.chart-key-info`, so it shows on both the old and new data-page layouts.

## Checklist

### Before merging

- [x] Google Analytics events were adapted to fit the changes in this PR — new `owid.site_ask_ai` category with `ask_ai_show` / `ask_ai_preset_click` / `ask_ai_submit`. **Custom params must be registered in GTM before they'll be collected.**
- [ ] Changes to CSS/HTML were checked on Desktop and Mobile Safari at all three breakpoints — **not done**; only the `sm-only` breakpoint is handled in SCSS and I haven't opened it in Safari.
- [ ] Changes to HTML were checked for accessibility concerns — presets use `aria-pressed` and inputs are labelled, but this hasn't had a real a11y pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


