### PR TITLE
🐛🤖 roll back the publish toggle when saving a chart fails

### DIFF
--- a/adminSiteClient/AbstractChartEditor.ts
+++ b/adminSiteClient/AbstractChartEditor.ts
@@ -364,5 +364,5 @@ export abstract class AbstractChartEditor<
     abstract get isNewGrapher(): boolean
     abstract get availableTabs(): EditorTab[]
 
-    abstract saveGrapher(props?: { onError?: () => void }): Promise<void>
+    abstract saveGrapher(): Promise<void>
 }

--- a/adminSiteClient/ChartEditor.ts
+++ b/adminSiteClient/ChartEditor.ts
@@ -177,9 +177,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
         }
     }
 
-    async saveGrapher({
-        onError,
-    }: { onError?: () => void } = {}): Promise<void> {
+    async saveGrapher(): Promise<void> {
         const { grapherState, isNewGrapher, patchConfig } = this
 
         // Chart title and slug may be autocalculated from data, in which case they won't be in props
@@ -224,7 +222,7 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
                     this.isInheritanceEnabled = shouldEnableInheritance
                 })
             }
-        } else onError?.()
+        }
     }
 
     async saveAsNewGrapher(): Promise<void> {
@@ -298,27 +296,35 @@ export class ChartEditor extends AbstractChartEditor<ChartEditorManager> {
         }
     }
 
-    publishGrapher(): void {
-        const url = `${BAKED_GRAPHER_URL}/${this.grapherState.displaySlug}`
-
-        if (window.confirm(`Publish chart at ${url}?`)) {
-            this.grapherState.isPublished = true
-            void this.saveGrapher({
-                onError: () => (this.grapherState.isPublished = undefined),
-            })
+    private async savePublishedState(
+        isPublished: true | undefined
+    ): Promise<void> {
+        const previousIsPublished = this.grapherState.isPublished
+        this.grapherState.isPublished = isPublished
+        try {
+            await this.saveGrapher()
+        } catch {
+            runInAction(
+                () => (this.grapherState.isPublished = previousIsPublished)
+            )
         }
     }
 
-    unpublishGrapher(): void {
+    async publishGrapher(): Promise<void> {
+        const url = `${BAKED_GRAPHER_URL}/${this.grapherState.displaySlug}`
+
+        if (window.confirm(`Publish chart at ${url}?`)) {
+            await this.savePublishedState(true)
+        }
+    }
+
+    async unpublishGrapher(): Promise<void> {
         const message =
             this.references && getFullReferencesCount(this.references) > 0
                 ? "WARNING: This chart might be referenced from public posts, please double check before unpublishing. Try to remove the chart anyway?"
                 : "Are you sure you want to unpublish this chart?"
         if (window.confirm(message)) {
-            this.grapherState.isPublished = undefined
-            void this.saveGrapher({
-                onError: () => (this.grapherState.isPublished = true),
-            })
+            await this.savePublishedState(undefined)
         }
     }
 

--- a/adminSiteClient/NarrativeChartEditor.ts
+++ b/adminSiteClient/NarrativeChartEditor.ts
@@ -92,9 +92,7 @@ export class NarrativeChartEditor extends AbstractChartEditor<NarrativeChartEdit
         }
     }
 
-    async saveGrapher({
-        onError,
-    }: { onError?: () => void } = {}): Promise<void> {
+    async saveGrapher(): Promise<void> {
         const { patchConfig, narrativeChartId } = this
 
         const json = await this.manager.admin.requestJSON(
@@ -107,8 +105,6 @@ export class NarrativeChartEditor extends AbstractChartEditor<NarrativeChartEdit
             runInAction(() => {
                 this.savedPatchConfig = json.savedPatch
             })
-        } else {
-            onError?.()
         }
     }
 }

--- a/adminSiteClient/SaveButtons.tsx
+++ b/adminSiteClient/SaveButtons.tsx
@@ -63,8 +63,8 @@ class SaveButtonsForChart extends Component<SaveButtonsProps<ChartEditor>> {
 
     @action.bound onPublishToggle() {
         if (this.props.editor.grapherState.isPublished)
-            this.props.editor.unpublishGrapher()
-        else this.props.editor.publishGrapher()
+            void this.props.editor.unpublishGrapher()
+        else void this.props.editor.publishGrapher()
     }
 
     @action.bound onDeleteChart() {


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

A failed publish leaves the admin believing the chart is published. `publishGrapher` sets `isPublished` before the request, because the server reads it off the config being saved, and passes an `onError` callback to put it back. That callback never runs. `Admin.requestJSON` throws as soon as the response body carries an `error`, which is long before `saveGrapher` reaches the `json.success` branch that would have called it, and the rejection lands in a `void` and surfaces as an unhandled promise rejection. Now both handlers await the save and restore the previous value when it rejects.

To trigger it on master, open a draft chart, set its slug to one a published chart already owns, and hit Publish. The save is refused for the duplicate slug and the error dialog appears, but the editor still reads Update chart and Unpublish until you reload.

- The rollback swallows the rejection rather than rethrowing it. `Admin.requestJSON` has already shown the user the error dialog by the time we get there, and rethrowing would put back the unhandled rejection this removes.
- `saveGrapher` loses its `onError` parameter, and so does `NarrativeChartEditor`, whose own `else onError?.()` was unreachable for the same reason and had no caller at all.
- The route still answers a failed write with HTTP 200 and the real status buried in the body, which is why the dialog is titled `(200)`. That is the next change in this series, not this one.