### PR TITLE
Serve grapher pages as markdown at /grapher/<slug>.md

### DIFF
--- a/docs/chart-api.openapi.yaml
+++ b/docs/chart-api.openapi.yaml
@@ -282,6 +282,55 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /grapher/{slug}.md:
+    get:
+      summary: Get the chart page as markdown
+      description: >-
+        Returns an authored markdown rendering of the chart page: the title and
+        subtitle of the current view, the values the chart shows for its selected
+        entities, links to the underlying data, and the sources. Intended for
+        clients that read the page as text rather than running its JavaScript.
+        Dimension and entity query parameters select the view, as they do for
+        the .csv endpoint.
+      operationId: getChartMarkdown
+      tags:
+        - Metadata
+      parameters:
+        - $ref: "#/components/parameters/slug"
+        - $ref: "#/components/parameters/tab"
+        - $ref: "#/components/parameters/country"
+        - $ref: "#/components/parameters/time"
+      responses:
+        "200":
+          description: The chart page as markdown
+          content:
+            text/markdown:
+              schema:
+                type: string
+              examples:
+                life-expectancy:
+                  summary: Life expectancy as markdown
+                  x-request-params:
+                    slug: "life-expectancy"
+                  value: |
+                    # Life expectancy
+
+                    Period life expectancy at birth, in years.
+
+                    ## Values shown in this view
+
+                    **Life expectancy**, in years.
+
+                    | Entity | 1770 | 2023 |
+                    | --- | ---: | ---: |
+                    | World | 28.5 | 73.2 |
+
+                    ## Get this data
+
+                    - Data as CSV: https://ourworldindata.org/grapher/life-expectancy.csv
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /grapher/{slug}.readme.md:
     get:
       summary: Get chart README

--- a/docs/chart-api.openapi.yaml
+++ b/docs/chart-api.openapi.yaml
@@ -291,7 +291,8 @@ paths:
         entities, links to the underlying data, and the sources. Intended for
         clients that read the page as text rather than running its JavaScript.
         Dimension and entity query parameters select the view, as they do for
-        the .csv endpoint.
+        the .csv endpoint. The same document is returned by /grapher/{slug} itself
+        when the request's Accept header prefers text/markdown over text/html.
       operationId: getChartMarkdown
       tags:
         - Metadata

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -6,11 +6,14 @@ import {
     getEntityNamesParam,
     generateSelectedEntityNamesParam,
     constructGrapherValuesJson,
+    constructGrapherValuesJsonFromTable,
+    prepareCalloutTable,
 } from "@ourworldindata/grapher"
 import {
     GRAPHER_TAB_QUERY_PARAMS,
     EntityName,
     GrapherSearchResultJson,
+    GrapherValuesJson,
 } from "@ourworldindata/types"
 import { error, StatusError } from "itty-router"
 import { createZip, UncompressedFile } from "littlezipper"
@@ -282,13 +285,36 @@ export async function fetchMarkdownForGrapher(
         grapherState.availableEntityNames.includes(entityName)
     )
 
-    // No time argument: initGrapher applied the query string, so grapherState's
-    // bounds are already resolved against the data. Passing the raw `time` value
-    // through would replace those snapped bounds with an exact lookup and blank
-    // out every cell on a series that has no observation in precisely that year.
-    const valuesByEntity = entityNames.map((entityName) =>
-        assembleDataValues(grapherState, entityName)
-    )
+    // `constructGrapherValuesJson` reassigns the chart's selection to the one
+    // entity it reports on, which invalidates Grapher's computed chain and
+    // re-runs the transform pipeline over the whole table — 44% of the time
+    // spent assembling this document on a chart with seven selected entities.
+    // The batch form prepares the table once and then does a lookup per entity.
+    // It reads the input table rather than the chart-transformed one, so a chart
+    // whose values are transformed for display keeps the slower path: in
+    // relative mode the table would otherwise print absolutes where the chart
+    // shows percentages.
+    //
+    // Neither form is given the `time` param: initGrapher applied the query
+    // string, so grapherState's bounds are already resolved against the data,
+    // and passing the raw value through would replace those snapped bounds with
+    // an exact lookup and blank out every cell on a series that has no
+    // observation in precisely that year.
+    let valuesByEntity: GrapherValuesJson[]
+    if (grapherState.isRelativeMode) {
+        valuesByEntity = entityNames.map((entityName) =>
+            assembleDataValues(grapherState, entityName)
+        )
+    } else {
+        const prepared = prepareCalloutTable(grapherState.inputTable, {
+            ...grapherState.object,
+            minTime: grapherState.startTime,
+            maxTime: grapherState.endTime,
+        })
+        valuesByEntity = entityNames.map((entityName) =>
+            constructGrapherValuesJsonFromTable(prepared, entityName)
+        )
+    }
 
     const markdown = constructPageMarkdown(
         grapherState,

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -15,7 +15,7 @@ import {
 import { error, StatusError } from "itty-router"
 import { createZip, UncompressedFile } from "littlezipper"
 import { assembleMetadata, getColumnsForMetadata } from "./metadataTools.js"
-import { Env } from "./env.js"
+import { Env, extensions } from "./env.js"
 import {
     getDataApiUrl,
     GrapherIdentifier,
@@ -226,9 +226,28 @@ export function assembleReadme(
 export async function fetchMarkdownForGrapher(
     identifier: GrapherIdentifier,
     env: Env,
-    searchParams?: URLSearchParams
+    searchParams?: URLSearchParams,
+    ctx?: EventContext<unknown, any, Record<string, unknown>>
 ) {
     const params = searchParams ?? new URLSearchParams("")
+
+    // Assembling the markdown means fetching the indicator's full data and
+    // building the table, about a second; cache it for an hour like
+    // `.values.json`. The key is the `.md` URL for this view, so the page URL
+    // negotiated to markdown and the explicit `.md` URL share one entry, and the
+    // HTML page's own cache entry is never confused with it (the edge cache
+    // ignores `Vary`).
+    const shouldCache = ctx !== undefined && params.get("nocache") === null
+    const cacheKey = new Request(
+        `${env.url.origin}/grapher/${identifier.id}${extensions.markdown}${
+            params.size > 0 ? `?${params.toString()}` : ""
+        }`
+    )
+    if (shouldCache) {
+        const cached = await checkCache(cacheKey, true)
+        if (cached) return cached
+    }
+
     console.log("Initializing grapher")
     const { grapher } = await initGrapher(
         identifier,
@@ -277,11 +296,15 @@ export async function fetchMarkdownForGrapher(
         valuesByEntity,
         params.size > 0 ? `?${params.toString()}` : ""
     )
-    return new Response(markdown, {
+    const response = new Response(markdown, {
         headers: {
             "Content-Type": "text/markdown; charset=utf-8",
+            "Cache-Control": shouldCache ? "max-age=3600" : "no-cache",
         },
     })
+    if (shouldCache)
+        ctx.waitUntil(caches.default.put(cacheKey, response.clone()))
+    return response
 }
 
 export async function fetchDataValuesForGrapher(

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -304,7 +304,11 @@ export async function fetchMarkdownForGrapher(
     // an exact lookup and blank out every cell on a series that has no
     // observation in precisely that year.
     let valuesByEntity: GrapherValuesJson[]
-    if (grapherState.isRelativeMode) {
+    if (entityNames.length === 0) {
+        // A chart with no entity selected — a scatter plot, typically — has no
+        // values block to build, and preparing a table for it is pure cost.
+        valuesByEntity = []
+    } else if (grapherState.isRelativeMode) {
         valuesByEntity = entityNames.map((entityName) =>
             assembleDataValues(grapherState, entityName)
         )

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -241,10 +241,13 @@ export async function fetchMarkdownForGrapher(
     // HTML page's own cache entry is never confused with it (the edge cache
     // ignores `Vary`).
     const shouldCache = ctx !== undefined && params.get("nocache") === null
+    // `nocache` asks this handler to skip its cache; it selects no view, so it
+    // belongs in neither the cache key nor the data URLs the document prints.
+    const viewParams = new URLSearchParams(params)
+    viewParams.delete("nocache")
+    const viewSearch = viewParams.size > 0 ? `?${viewParams.toString()}` : ""
     const cacheKey = new Request(
-        `${env.url.origin}/grapher/${identifier.id}${extensions.markdown}${
-            params.size > 0 ? `?${params.toString()}` : ""
-        }`
+        `${env.url.origin}/grapher/${identifier.id}${extensions.markdown}${viewSearch}`
     )
     if (shouldCache) {
         const cached = await checkCache(cacheKey, true)
@@ -320,7 +323,7 @@ export async function fetchMarkdownForGrapher(
         grapherState,
         getColumnsForMetadata(grapherState),
         valuesByEntity,
-        params.size > 0 ? `?${params.toString()}` : ""
+        viewSearch
     )
     const response = new Response(markdown, {
         headers: {

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -23,6 +23,7 @@ import {
 } from "./grapherTools.js"
 import { TWITTER_OPTIONS } from "./imageOptions.js"
 import { constructReadme } from "./readmeTools.js"
+import { constructPageMarkdown } from "./pageMarkdownTools.js"
 import { constructSearchResultDataTableContent } from "./search/constructSearchResultDataTableContent.js"
 import { match } from "ts-pattern"
 import {
@@ -222,6 +223,61 @@ export function assembleReadme(
     )
 }
 
+export async function fetchMarkdownForGrapher(
+    identifier: GrapherIdentifier,
+    env: Env,
+    searchParams?: URLSearchParams
+) {
+    const params = searchParams ?? new URLSearchParams("")
+    console.log("Initializing grapher")
+    const { grapher } = await initGrapher(
+        identifier,
+        TWITTER_OPTIONS,
+        params,
+        env
+    )
+    const { grapherState } = grapher
+
+    const inputTable = await fetchInputTableForConfig({
+        dimensions: grapherState.dimensions,
+        selectedEntityColors: grapherState.selectedEntityColors,
+        dataApiUrl: getDataApiUrl(env),
+    })
+    if (inputTable) grapherState.inputTable = inputTable
+
+    // Grapher ignores the country param when entity selection is disabled, so read
+    // it back explicitly; with no country param the chart's own default selection is
+    // what a reader arriving at this URL sees.
+    const requestedEntities = getEntityNamesParam(
+        params.get("country") ?? undefined
+    )
+    const entityNames = (
+        requestedEntities?.length
+            ? requestedEntities
+            : // Snapshot: assembleDataValues reassigns the selection per entity.
+              [...grapherState.selection.selectedEntityNames]
+    ).filter((entityName) =>
+        grapherState.availableEntityNames.includes(entityName)
+    )
+
+    const timeParam = params.get("time") ?? undefined
+    const valuesByEntity = entityNames.map((entityName) =>
+        assembleDataValues(grapherState, entityName, timeParam)
+    )
+
+    const markdown = constructPageMarkdown(
+        grapherState,
+        getColumnsForMetadata(grapherState),
+        valuesByEntity,
+        params.size > 0 ? `?${params.toString()}` : ""
+    )
+    return new Response(markdown, {
+        headers: {
+            "Content-Type": "text/markdown; charset=utf-8",
+        },
+    })
+}
+
 export async function fetchDataValuesForGrapher(
     identifier: GrapherIdentifier,
     env: Env,
@@ -279,14 +335,15 @@ export async function fetchDataValuesForGrapher(
 
 export function assembleDataValues(
     grapherState: GrapherState,
-    entityName: EntityName
+    entityName: EntityName,
+    timeQueryParam?: string
 ) {
     // If the entity is invalid or not included in the chart, we can't return
     // any data, so we return the source only
     if (!grapherState.availableEntityNames.includes(entityName))
         return { source: grapherState.sourcesLine }
 
-    return constructGrapherValuesJson(grapherState, entityName)
+    return constructGrapherValuesJson(grapherState, entityName, timeQueryParam)
 }
 
 export async function fetchSearchResultDataForGrapher(

--- a/functions/_common/downloadFunctions.ts
+++ b/functions/_common/downloadFunctions.ts
@@ -244,6 +244,9 @@ export async function fetchMarkdownForGrapher(
         dataApiUrl: getDataApiUrl(env),
     })
     if (inputTable) grapherState.inputTable = inputTable
+    // The per-entity table below is a full data extract, so it falls under the same
+    // licensing restriction as the CSV and zip downloads.
+    ensureDownloadOfDataAllowed(grapherState)
 
     // Grapher ignores the country param when entity selection is disabled, so read
     // it back explicitly; with no country param the chart's own default selection is
@@ -260,9 +263,12 @@ export async function fetchMarkdownForGrapher(
         grapherState.availableEntityNames.includes(entityName)
     )
 
-    const timeParam = params.get("time") ?? undefined
+    // No time argument: initGrapher applied the query string, so grapherState's
+    // bounds are already resolved against the data. Passing the raw `time` value
+    // through would replace those snapped bounds with an exact lookup and blank
+    // out every cell on a series that has no observation in precisely that year.
     const valuesByEntity = entityNames.map((entityName) =>
-        assembleDataValues(grapherState, entityName, timeParam)
+        assembleDataValues(grapherState, entityName)
     )
 
     const markdown = constructPageMarkdown(
@@ -335,15 +341,14 @@ export async function fetchDataValuesForGrapher(
 
 export function assembleDataValues(
     grapherState: GrapherState,
-    entityName: EntityName,
-    timeQueryParam?: string
+    entityName: EntityName
 ) {
     // If the entity is invalid or not included in the chart, we can't return
     // any data, so we return the source only
     if (!grapherState.availableEntityNames.includes(entityName))
         return { source: grapherState.sourcesLine }
 
-    return constructGrapherValuesJson(grapherState, entityName, timeQueryParam)
+    return constructGrapherValuesJson(grapherState, entityName)
 }
 
 export async function fetchSearchResultDataForGrapher(

--- a/functions/_common/env.ts
+++ b/functions/_common/env.ts
@@ -45,5 +45,8 @@ export const extensions = {
     zip: ".zip",
     values: ".values.json",
     searchResult: ".search-result.json",
+    // Keep after `readme` so the redirect regex, which scans these in order,
+    // matches `.readme.md` rather than splitting it into `.readme` + `.md`.
+    markdown: ".md",
 }
 export type Etag = string

--- a/functions/_common/grapherTools.ts
+++ b/functions/_common/grapherTools.ts
@@ -439,6 +439,16 @@ export function rewriteMetaTags(
                 }
             },
         })
+        .on('link[rel="alternate"][type="text/markdown"]', {
+            // The page is baked once, for the default view, so the baked href has no
+            // query. Carry the requested view across, or an agent that follows this
+            // link from a customized URL silently gets the default entities and time.
+            element: (element) => {
+                const href = element.getAttribute("href")
+                if (href && url.search)
+                    element.setAttribute("href", href + url.search)
+            },
+        })
         .on('meta[property="og:url"]', {
             // Replace canonical URL, otherwise the preview image will not include the search parameters.
             element: (element) => {

--- a/functions/_common/pageMarkdownTools.test.ts
+++ b/functions/_common/pageMarkdownTools.test.ts
@@ -34,12 +34,13 @@ function makeGrapherState(overrides: Record<string, unknown> = {}) {
 function makeValues(
     entityName: string,
     startValue: string,
-    endValue: string
+    endValue: string,
+    times: { startTime?: number; endTime?: number } = {}
 ): GrapherValuesJson {
     return {
         entityName,
-        startTime: 1950,
-        endTime: 2023,
+        startTime: times.startTime ?? 1950,
+        endTime: times.endTime ?? 2023,
         columns: {
             population: { name: "Population", unit: "people" },
         },
@@ -69,6 +70,33 @@ describe(constructPageMarkdown, () => {
         expect(markdown).toContain("| Entity | 1950 | 2023 |")
         expect(markdown).toContain("| World | 2.5 billion | 8 billion |")
         expect(markdown).toContain("**Population**, in people.")
+    })
+
+    it("brackets the year when an entity's series starts or ends off the chart's years", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [
+                makeValues("World", "2.5 billion", "8 billion"),
+                makeValues("Oceania", "12 million", "45 million", {
+                    startTime: 1970,
+                    endTime: 2021,
+                }),
+            ],
+            ""
+        )
+
+        // Headings come from the first entity; the other entity says which years
+        // its values are really from, so a reader never attributes 1950 to it.
+        expect(markdown).toContain("| Entity | 1950 | 2023 |")
+        expect(markdown).toContain("| World | 2.5 billion | 8 billion |")
+        expect(markdown).toContain(
+            "| Oceania | 12 million (1970) | 45 million (2021) |"
+        )
+        expect(markdown).toContain("A year in brackets")
     })
 
     it("puts the extension before the query, exactly once", () => {

--- a/functions/_common/pageMarkdownTools.test.ts
+++ b/functions/_common/pageMarkdownTools.test.ts
@@ -1,0 +1,149 @@
+import { expect, it, describe } from "vitest"
+
+import { SynthesizeNonCountryTable } from "@ourworldindata/core-table"
+import { GrapherState } from "@ourworldindata/grapher"
+import { ColumnTypeNames, type GrapherValuesJson } from "@ourworldindata/types"
+import { getRandomNumberGenerator } from "@ourworldindata/utils"
+import { extensions } from "./env.js"
+import { constructPageMarkdown } from "./pageMarkdownTools.js"
+
+function makeGrapherState() {
+    const table = SynthesizeNonCountryTable({
+        columnDefs: [
+            {
+                slug: "population",
+                type: ColumnTypeNames.Population,
+                name: "Population",
+                sourceName: "Test source",
+                descriptionShort:
+                    "Measured in [terawatt-hours](#dod:watt-hours).",
+                generator: getRandomNumberGenerator(1e7, 1e9),
+                growthRateGenerator: getRandomNumberGenerator(-5, 5),
+            },
+        ],
+    })
+    return new GrapherState({
+        table,
+        ySlugs: "population",
+        title: "Population",
+        subtitle: "Measured in [terawatt-hours](#dod:watt-hours).",
+    })
+}
+
+function makeValues(
+    entityName: string,
+    startValue: string,
+    endValue: string
+): GrapherValuesJson {
+    return {
+        entityName,
+        startTime: 1950,
+        endTime: 2023,
+        columns: {
+            population: { name: "Population", unit: "people" },
+        },
+        startValues: {
+            y: [{ columnSlug: "population", formattedValue: startValue }],
+        },
+        endValues: {
+            y: [{ columnSlug: "population", formattedValue: endValue }],
+        },
+        source: "Test source",
+    }
+}
+
+describe(constructPageMarkdown, () => {
+    it("renders one table row per entity, with the values under their years", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [makeValues("World", "2.5 billion", "8 billion")],
+            ""
+        )
+
+        expect(markdown).toContain("## Values shown in this view")
+        expect(markdown).toContain("| Entity | 1950 | 2023 |")
+        expect(markdown).toContain("| World | 2.5 billion | 8 billion |")
+        expect(markdown).toContain("**Population**, in people.")
+    })
+
+    it("keeps the query string on the data URLs so they resolve to the same view", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [makeValues("World", "2.5 billion", "8 billion")],
+            "?country=~USA&time=2000..2023"
+        )
+
+        expect(markdown).toContain(".csv?country=~USA&time=2000..2023")
+        expect(markdown).toContain(
+            ".metadata.json?country=~USA&time=2000..2023"
+        )
+    })
+
+    it("strips detail-on-demand links but keeps their visible label", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [makeValues("World", "2.5 billion", "8 billion")],
+            ""
+        )
+
+        expect(markdown).not.toContain("#dod:")
+        expect(markdown).toContain("Measured in terawatt-hours.")
+    })
+
+    it("omits the values section rather than emitting an empty table", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [{ source: "Test source" }],
+            ""
+        )
+
+        expect(markdown).not.toContain("## Values shown in this view")
+        expect(markdown).toContain("## Get this data")
+    })
+})
+
+describe("the .md extension alongside .readme.md", () => {
+    // redirectTools builds this regex from `Object.values(extensions)`, so the
+    // order of that object decides whether `.readme.md` keeps its own suffix.
+    it("still splits .readme.md as the readme extension", () => {
+        const allExtensions = Object.values(extensions)
+            .map((ext) => ext.replace(".", "\\."))
+            .join("|")
+        const regex = new RegExp(
+            `^(?<slug>.*?)(?<extension>${allExtensions})?$`
+        )
+
+        const match = "life-expectancy.readme.md".match(regex)
+        expect(match?.groups?.slug).toBe("life-expectancy")
+        expect(match?.groups?.extension).toBe(extensions.readme)
+    })
+
+    it("splits a plain .md URL as the markdown extension", () => {
+        const allExtensions = Object.values(extensions)
+            .map((ext) => ext.replace(".", "\\."))
+            .join("|")
+        const regex = new RegExp(
+            `^(?<slug>.*?)(?<extension>${allExtensions})?$`
+        )
+
+        const match = "life-expectancy.md".match(regex)
+        expect(match?.groups?.slug).toBe("life-expectancy")
+        expect(match?.groups?.extension).toBe(extensions.markdown)
+    })
+})

--- a/functions/_common/pageMarkdownTools.test.ts
+++ b/functions/_common/pageMarkdownTools.test.ts
@@ -5,7 +5,7 @@ import { GrapherState } from "@ourworldindata/grapher"
 import { ColumnTypeNames, type GrapherValuesJson } from "@ourworldindata/types"
 import { getRandomNumberGenerator } from "@ourworldindata/utils"
 import { extensions } from "./env.js"
-import { constructPageMarkdown } from "./pageMarkdownTools.js"
+import { constructPageMarkdown, prefersMarkdown } from "./pageMarkdownTools.js"
 
 function makeGrapherState(overrides: Record<string, unknown> = {}) {
     const table = SynthesizeNonCountryTable({
@@ -291,5 +291,39 @@ describe("the .md extension alongside .readme.md", () => {
         const match = "life-expectancy.md".match(regex)
         expect(match?.groups?.slug).toBe("life-expectancy")
         expect(match?.groups?.extension).toBe(extensions.markdown)
+    })
+})
+
+describe(prefersMarkdown, () => {
+    it("is false for a browser, which asks for HTML and never markdown", () => {
+        expect(
+            prefersMarkdown(
+                "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+            )
+        ).toBe(false)
+    })
+
+    it("is true for an agent fetcher that lists markdown first", () => {
+        expect(prefersMarkdown("text/markdown, text/html, */*")).toBe(true)
+    })
+
+    it("is true when markdown is the only type asked for", () => {
+        expect(prefersMarkdown("text/markdown")).toBe(true)
+    })
+
+    it("respects q-values over list order", () => {
+        expect(prefersMarkdown("text/html;q=0.8, text/markdown")).toBe(true)
+        expect(prefersMarkdown("text/markdown;q=0.5, text/html")).toBe(false)
+    })
+
+    it("lets HTML win when it is listed before markdown at equal weight", () => {
+        expect(prefersMarkdown("text/html, text/markdown")).toBe(false)
+    })
+
+    it("is false for wildcards, an empty header or no header", () => {
+        expect(prefersMarkdown("*/*")).toBe(false)
+        expect(prefersMarkdown("")).toBe(false)
+        expect(prefersMarkdown(null)).toBe(false)
+        expect(prefersMarkdown(undefined)).toBe(false)
     })
 })

--- a/functions/_common/pageMarkdownTools.test.ts
+++ b/functions/_common/pageMarkdownTools.test.ts
@@ -122,9 +122,50 @@ describe(constructPageMarkdown, () => {
         // the HTML page with a mangled country value. Assert on whole lines, since
         // a substring check passes on that corrupted form too.
         expect(markdown).toContain(
-            "- Data as CSV: https://ourworldindata.org/grapher/population.csv?country=~USA&time=2000..2023"
+            "- Data URL (CSV format), displayed data: https://ourworldindata.org/grapher/population.csv?country=~USA&time=2000..2023&v=1&csvType=filtered&useColumnShortNames=false"
+        )
+        expect(markdown).toContain(
+            "- Data URL (CSV format), full data: https://ourworldindata.org/grapher/population.csv?v=1&csvType=full&useColumnShortNames=false"
         )
         expect(markdown).not.toMatch(/\?country=~USA[^\s]*\.csv/)
+    })
+
+    it("keeps the page's download section, FAQ and update dates, and documents the query grammar", () => {
+        const grapherState = makeGrapherState({
+            manager: {
+                baseUrl: "https://ourworldindata.org/grapher/population",
+            },
+        })
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [makeValues("World", "2.5 billion", "8 billion")],
+            ""
+        )
+
+        expect(markdown).toContain("## Download")
+        expect(markdown).toContain("#### Data API")
+        expect(markdown).toContain("#### Query parameters")
+        expect(markdown).toContain("ISO 3166-1 alpha-3")
+        expect(markdown).toContain("#### Code examples")
+        expect(markdown).toContain("##### Python with Pandas")
+        expect(markdown).toContain(
+            'pd.read_csv("https://ourworldindata.org/grapher/population.csv?v=1&csvType=full&useColumnShortNames=false"'
+        )
+        expect(markdown).toContain("## Frequently asked questions")
+        expect(markdown).toContain(
+            "#### How did Our World in Data process this data?"
+        )
+        // The Download section sits between the value tables and the About section,
+        // where the page puts it relative to the metadata.
+        expect(markdown.indexOf("## Download")).toBeGreaterThan(
+            markdown.indexOf("## Latest value for every entity")
+        )
+        expect(markdown.indexOf("## Download")).toBeLessThan(
+            markdown.indexOf("## About this data")
+        )
     })
 
     it("strips detail-on-demand links but keeps their visible label", () => {
@@ -288,7 +329,7 @@ describe(constructPageMarkdown, () => {
         )
 
         expect(markdown).not.toContain("## Values shown in this view")
-        expect(markdown).toContain("## Get this data")
+        expect(markdown).toContain("## Download")
     })
 })
 

--- a/functions/_common/pageMarkdownTools.test.ts
+++ b/functions/_common/pageMarkdownTools.test.ts
@@ -7,7 +7,7 @@ import { getRandomNumberGenerator } from "@ourworldindata/utils"
 import { extensions } from "./env.js"
 import { constructPageMarkdown } from "./pageMarkdownTools.js"
 
-function makeGrapherState() {
+function makeGrapherState(overrides: Record<string, unknown> = {}) {
     const table = SynthesizeNonCountryTable({
         columnDefs: [
             {
@@ -27,6 +27,7 @@ function makeGrapherState() {
         ySlugs: "population",
         title: "Population",
         subtitle: "Measured in [terawatt-hours](#dod:watt-hours).",
+        ...overrides,
     })
 }
 
@@ -70,8 +71,15 @@ describe(constructPageMarkdown, () => {
         expect(markdown).toContain("**Population**, in people.")
     })
 
-    it("keeps the query string on the data URLs so they resolve to the same view", () => {
-        const grapherState = makeGrapherState()
+    it("puts the extension before the query, exactly once", () => {
+        // initGrapher sets manager.baseUrl and queryStr, which is what makes
+        // canonicalUrl carry the query in production.
+        const grapherState = makeGrapherState({
+            manager: {
+                baseUrl: "https://ourworldindata.org/grapher/population",
+            },
+            queryStr: "?country=~USA&time=2000..2023",
+        })
         const columns = grapherState.tableForDownload.getColumns(["population"])
 
         const markdown = constructPageMarkdown(
@@ -81,10 +89,14 @@ describe(constructPageMarkdown, () => {
             "?country=~USA&time=2000..2023"
         )
 
-        expect(markdown).toContain(".csv?country=~USA&time=2000..2023")
+        // `canonicalUrl` is baseUrl + queryStr, so naively appending the extension
+        // to it produced `/slug?country=~USA.csv?country=~USA`: a URL pointing at
+        // the HTML page with a mangled country value. Assert on whole lines, since
+        // a substring check passes on that corrupted form too.
         expect(markdown).toContain(
-            ".metadata.json?country=~USA&time=2000..2023"
+            "- Data as CSV: https://ourworldindata.org/grapher/population.csv?country=~USA&time=2000..2023"
         )
+        expect(markdown).not.toMatch(/\?country=~USA[^\s]*\.csv/)
     })
 
     it("strips detail-on-demand links but keeps their visible label", () => {
@@ -154,6 +166,86 @@ describe(constructPageMarkdown, () => {
         // interpolating it directly renders "[object Object]".
         expect(markdown).not.toContain("[object Object]")
         expect(markdown).toContain("### Population")
+    })
+
+    it("reads a scatter plot's x indicator from the x datapoint", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        // constructGrapherValuesJson puts the y series in `points.y` and the x-axis
+        // indicator in `points.x`; searching only `y` left every x cell blank.
+        const values: GrapherValuesJson = {
+            entityName: "World",
+            startTime: 1950,
+            endTime: 2023,
+            columns: {
+                population: { name: "Population", unit: "people" },
+                gdp: { name: "GDP", unit: "int-$" },
+            },
+            startValues: {
+                y: [
+                    { columnSlug: "population", formattedValue: "2.5 billion" },
+                ],
+                x: { columnSlug: "gdp", formattedValue: "$10 trillion" },
+            },
+            endValues: {
+                y: [{ columnSlug: "population", formattedValue: "8 billion" }],
+                x: { columnSlug: "gdp", formattedValue: "$100 trillion" },
+            },
+            source: "Test source",
+        }
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [values],
+            ""
+        )
+
+        expect(markdown).toContain("| World | $10 trillion | $100 trillion |")
+    })
+
+    it("uses the datapoint's formatted time for subannual charts", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        // On a daily chart Time is a day offset from the epoch, so joining the raw
+        // numbers produced headings like "18262" instead of a date.
+        const values: GrapherValuesJson = {
+            entityName: "World",
+            startTime: 18262,
+            endTime: 19000,
+            columns: { population: { name: "Population", unit: "people" } },
+            startValues: {
+                y: [
+                    {
+                        columnSlug: "population",
+                        formattedValue: "1",
+                        formattedTime: "Jan 1, 2020",
+                    },
+                ],
+            },
+            endValues: {
+                y: [
+                    {
+                        columnSlug: "population",
+                        formattedValue: "2",
+                        formattedTime: "Jan 8, 2022",
+                    },
+                ],
+            },
+            source: "Test source",
+        }
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [values],
+            ""
+        )
+
+        expect(markdown).toContain("| Entity | Jan 1, 2020 | Jan 8, 2022 |")
+        expect(markdown).not.toContain("18262")
     })
 
     it("omits the values section rather than emitting an empty table", () => {

--- a/functions/_common/pageMarkdownTools.test.ts
+++ b/functions/_common/pageMarkdownTools.test.ts
@@ -102,6 +102,60 @@ describe(constructPageMarkdown, () => {
         expect(markdown).toContain("Measured in terawatt-hours.")
     })
 
+    it("lists every entity, not just the ones the chart selects", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [makeValues("World", "2.5 billion", "8 billion")],
+            ""
+        )
+
+        expect(markdown).toContain("## Latest value for every entity")
+        // SynthesizeNonCountryTable generates entities the chart never selects;
+        // the point of this section is that they show up anyway.
+        for (const entityName of grapherState.tableForDownload.get("population")
+            .uniqEntityNames) {
+            expect(markdown).toContain(`| ${entityName} |`)
+        }
+    })
+
+    it("names the shared year in prose when every entity reports the same one", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [makeValues("World", "2.5 billion", "8 billion")],
+            ""
+        )
+
+        // The synthesized table is complete, so every entity shares the end year
+        // and a per-row Year column would repeat it for nothing.
+        expect(markdown).toMatch(/All entities in \d{4}\./)
+        expect(markdown).not.toContain("| Entity | Population | Year |")
+    })
+
+    it("headings the About section with the indicator title as text", () => {
+        const grapherState = makeGrapherState()
+        const columns = grapherState.tableForDownload.getColumns(["population"])
+
+        const markdown = constructPageMarkdown(
+            grapherState,
+            columns,
+            [makeValues("World", "2.5 billion", "8 billion")],
+            ""
+        )
+
+        // `titlePublicOrDisplayName` is IndicatorTitleWithFragments, so
+        // interpolating it directly renders "[object Object]".
+        expect(markdown).not.toContain("[object Object]")
+        expect(markdown).toContain("### Population")
+    })
+
     it("omits the values section rather than emitting an empty table", () => {
         const grapherState = makeGrapherState()
         const columns = grapherState.tableForDownload.getColumns(["population"])

--- a/functions/_common/pageMarkdownTools.ts
+++ b/functions/_common/pageMarkdownTools.ts
@@ -1,11 +1,13 @@
+import * as _ from "lodash-es"
 import { OwidColumnDef, stripDetailOnDemandLinks } from "@ourworldindata/utils"
 import type { CoreColumn } from "@ourworldindata/core-table"
-import type { GrapherValuesJson } from "@ourworldindata/types"
+import type { EntityName, GrapherValuesJson, Time } from "@ourworldindata/types"
 import { GrapherState } from "@ourworldindata/grapher"
 import {
     getCitationLines,
     getDescriptionLines,
     getSourcesSection,
+    getTitle,
 } from "./readmeTools.js"
 
 /**
@@ -66,6 +68,91 @@ function* getValuesSection(
     }
 }
 
+/**
+ * The values block above covers the entities the chart selects, which is an editorial
+ * choice about what to draw — on `life-expectancy` it is six world regions. It cannot
+ * answer the two commonest things asked of a chart: the value for one particular
+ * country, and which country is highest. This table can, for around 1,500 tokens on a
+ * country-grained chart.
+ *
+ * Each entity is reported at its own latest time at or before the chart's end time,
+ * and the year is printed whenever entities disagree, so a country whose data stops
+ * early is never silently relabelled to the chart's end year.
+ */
+function* getAllEntityValuesSection(
+    grapherState: GrapherState
+): Generator<string, void, undefined> {
+    const table = grapherState.tableForDownload
+    const columns = grapherState.yColumnSlugs
+        .filter((slug) => table.has(slug))
+        .map((slug) => table.get(slug))
+    if (columns.length === 0) return
+
+    const endTime = grapherState.endTime
+    const entityNames = _.uniq(columns.flatMap((col) => col.uniqEntityNames))
+    if (entityNames.length === 0) return
+
+    interface Row {
+        entityName: EntityName
+        time: Time
+        cells: string[]
+    }
+    const rows: Row[] = []
+    for (const entityName of entityNames) {
+        const cells: string[] = []
+        let latestTime: Time | undefined
+        for (const column of columns) {
+            const entityRows = column.owidRowsByEntityName.get(entityName) ?? []
+            const eligible =
+                endTime === undefined
+                    ? entityRows
+                    : entityRows.filter((row) => row.time <= endTime)
+            // owidRows is time-sorted, so the last eligible row is the latest.
+            const row = eligible.at(-1)
+            cells.push(
+                row?.value === undefined
+                    ? ""
+                    : column.formatValueShort(row.value)
+            )
+            if (row && (latestTime === undefined || row.time > latestTime))
+                latestTime = row.time
+        }
+        if (cells.every((cell) => cell === "")) continue
+        rows.push({ entityName, time: latestTime ?? 0, cells })
+    }
+    if (rows.length === 0) return
+
+    const times = _.uniq(rows.map((row) => row.time))
+    const showTimeColumn = times.length > 1
+    const sharedTime = times[0]
+
+    yield ""
+    yield "## Latest value for every entity"
+    yield ""
+    yield showTimeColumn
+        ? "Each entity at its own latest year, at or before the year the chart ends on."
+        : `All entities in ${sharedTime}.`
+
+    const valueHeadings = columns.map((column) => column.displayName)
+    const headings = showTimeColumn
+        ? ["Entity", ...valueHeadings, "Year"]
+        : ["Entity", ...valueHeadings]
+
+    yield ""
+    yield `| ${headings.join(" | ")} |`
+    yield `| --- | ${headings
+        .slice(1)
+        .map(() => "---:")
+        .join(" | ")} |`
+
+    for (const row of _.sortBy(rows, (row) => row.entityName)) {
+        const cells = showTimeColumn
+            ? [...row.cells, String(row.time)]
+            : row.cells
+        yield `| ${row.entityName} | ${cells.join(" | ")} |`
+    }
+}
+
 function* getDataAccessSection(
     canonicalUrl: string,
     search: string
@@ -91,7 +178,7 @@ function* getAboutSection(
         if (description.length === 0 && citation.length === 0) continue
 
         yield ""
-        yield `### ${column.titlePublicOrDisplayName}`
+        yield `### ${getTitle(column)}`
         yield* description
         yield* citation
     }
@@ -124,6 +211,7 @@ export function constructPageMarkdown(
     }
 
     lines.push(...getValuesSection(valuesByEntity))
+    lines.push(...getAllEntityValuesSection(grapherState))
     lines.push(...getDataAccessSection(canonicalUrl, search))
 
     const about = [...getAboutSection(columnsWithSources)]

--- a/functions/_common/pageMarkdownTools.ts
+++ b/functions/_common/pageMarkdownTools.ts
@@ -53,6 +53,8 @@ function* getValuesSection(
 
     yield ""
     yield "## Values shown in this view"
+    yield ""
+    yield "Values at the years the chart starts and ends on. A year in brackets means that entity's data begins or ends there instead, and the value is from that year."
 
     for (const slug of columnSlugs) {
         const column = columns[slug]
@@ -85,10 +87,20 @@ function* getValuesSection(
         yield `| --- | ${headings.map(() => "---:").join(" | ")} |`
 
         for (const values of withData) {
-            const cells = headings.map(({ bound }) => {
+            const cells = headings.map(({ bound, time }) => {
                 const points =
                     bound === "start" ? values.startValues : values.endValues
-                return findPoint(points, slug)?.formattedValue ?? ""
+                const point = findPoint(points, slug)
+                if (!point) return ""
+                // An entity whose series starts later or ends earlier than the
+                // chart reports its own first or last value. Without the year it
+                // came from, the heading's year gets attributed to it (Oceania's
+                // 1870 value under "1770").
+                const ownTime =
+                    bound === "start" ? values.startTime : values.endTime
+                return ownTime !== undefined && ownTime !== time
+                    ? `${point.formattedValue} (${point.formattedTime ?? ownTime})`
+                    : point.formattedValue
             })
             yield `| ${values.entityName ?? ""} | ${cells.join(" | ")} |`
         }

--- a/functions/_common/pageMarkdownTools.ts
+++ b/functions/_common/pageMarkdownTools.ts
@@ -323,9 +323,7 @@ export function constructPageMarkdown(
     // fresh a quoted value is.
     const primary = columnsWithSources[0]
     if (primary) {
-        const keyData = [
-            ...getKeyDataLines(primary.def, primary),
-        ]
+        const keyData = [...getKeyDataLines(primary.def, primary)]
         if (keyData.length > 0) lines.push("", ...keyData)
     }
 

--- a/functions/_common/pageMarkdownTools.ts
+++ b/functions/_common/pageMarkdownTools.ts
@@ -244,3 +244,38 @@ export function constructPageMarkdown(
     // doesn't exist in the document.
     return stripDetailOnDemandLinks(lines.join("\n").trim()) + "\n"
 }
+
+interface MediaRange {
+    type: string
+    q: number
+    index: number
+}
+
+/**
+ * Whether a request would rather have markdown than HTML for a page URL, so
+ * `/grapher/<slug>` can serve the same document as `/grapher/<slug>.md` to
+ * clients that ask for it. Browsers send `text/html` first and never mention
+ * markdown; Claude Code's fetcher sends `text/markdown, text/html, *&#47;*`.
+ * Markdown wins when it is present with a q-value at least as high as HTML's,
+ * with list order breaking ties.
+ */
+export function prefersMarkdown(accept: string | null | undefined): boolean {
+    if (!accept) return false
+    const ranges: MediaRange[] = accept.split(",").map((part, index) => {
+        const [type, ...params] = part.trim().split(";")
+        const q = params.map((p) => p.trim()).find((p) => p.startsWith("q="))
+        return {
+            type: type.trim().toLowerCase(),
+            q: q ? Number(q.slice(2)) : 1,
+            index,
+        }
+    })
+    const markdown = ranges.find((r) => r.type === "text/markdown")
+    if (!markdown || !(markdown.q > 0)) return false
+    const html = ranges.find((r) => r.type === "text/html")
+    if (!html || !(html.q > 0)) return true
+    return (
+        markdown.q > html.q ||
+        (markdown.q === html.q && markdown.index < html.index)
+    )
+}

--- a/functions/_common/pageMarkdownTools.ts
+++ b/functions/_common/pageMarkdownTools.ts
@@ -1,0 +1,140 @@
+import { OwidColumnDef, stripDetailOnDemandLinks } from "@ourworldindata/utils"
+import type { CoreColumn } from "@ourworldindata/core-table"
+import type { GrapherValuesJson } from "@ourworldindata/types"
+import { GrapherState } from "@ourworldindata/grapher"
+import {
+    getCitationLines,
+    getDescriptionLines,
+    getSourcesSection,
+} from "./readmeTools.js"
+
+/**
+ * The values block is the reason this endpoint exists. A chart page describes its
+ * indicator well but never states a number, so a client that doesn't run JavaScript
+ * — a crawler, or an LLM agent reading the page once — has nothing of ours to quote
+ * and answers from its own priors instead. These are the same values the chart shows
+ * for the entities it has selected.
+ */
+function* getValuesSection(
+    valuesByEntity: GrapherValuesJson[]
+): Generator<string, void, undefined> {
+    const withData = valuesByEntity.filter(
+        (values) => values.startValues || values.endValues
+    )
+    if (withData.length === 0) return
+
+    // Every entity is read from the same chart view, so the columns and the time
+    // bounds are shared; take them from the first that has them.
+    const first = withData[0]
+    const columns = first.columns ?? {}
+    const columnSlugs = Object.keys(columns)
+    if (columnSlugs.length === 0) return
+
+    yield ""
+    yield "## Values shown in this view"
+
+    for (const slug of columnSlugs) {
+        const column = columns[slug]
+        const unit = column.unit ? `, in ${column.unit}` : ""
+        yield ""
+        yield `**${column.name}**${unit}.`
+
+        const startTime = first.startValues ? first.startTime : undefined
+        const endTime = first.endValues ? first.endTime : undefined
+        const timeHeadings = [startTime, endTime].filter(
+            (time) => time !== undefined
+        )
+        // A chart whose start and end resolve to the same year would otherwise print
+        // the same column twice under two identical headings.
+        const headings = [...new Set(timeHeadings)]
+
+        yield ""
+        yield `| Entity | ${headings.join(" | ")} |`
+        yield `| --- | ${headings.map(() => "---:").join(" | ")} |`
+
+        for (const values of withData) {
+            const cells = headings.map((time) => {
+                const points =
+                    time === values.startTime
+                        ? values.startValues
+                        : values.endValues
+                const point = points?.y.find((p) => p.columnSlug === slug)
+                return point?.formattedValue ?? ""
+            })
+            yield `| ${values.entityName ?? ""} | ${cells.join(" | ")} |`
+        }
+    }
+}
+
+function* getDataAccessSection(
+    canonicalUrl: string,
+    search: string
+): Generator<string, void, undefined> {
+    yield ""
+    yield "## Get this data"
+    yield ""
+    yield `- Data as CSV: ${canonicalUrl}.csv${search}`
+    yield `- Metadata as JSON: ${canonicalUrl}.metadata.json${search}`
+    yield `- Chart image: ${canonicalUrl}.png${search}`
+    yield `- Interactive chart: ${canonicalUrl}${search}`
+    yield ""
+    yield "Append `country=` to select entities (tilde-separated codes, e.g. `country=~USA~FRA`) and `time=` to select a range (e.g. `time=2000..2023`)."
+}
+
+function* getAboutSection(
+    columns: CoreColumn[]
+): Generator<string, void, undefined> {
+    for (const column of columns) {
+        const def = column.def as OwidColumnDef
+        const description = [...getDescriptionLines(def)]
+        const citation = [...getCitationLines(def, column)]
+        if (description.length === 0 && citation.length === 0) continue
+
+        yield ""
+        yield `### ${column.titlePublicOrDisplayName}`
+        yield* description
+        yield* citation
+    }
+}
+
+/**
+ * An agent-facing rendering of a chart page: what the view shows, the numbers in it,
+ * how to fetch the underlying data, and who to credit. Distinct from `constructReadme`,
+ * which documents a downloaded data package (CSV layout, zip contents) rather than the
+ * page a reader arrived at.
+ */
+export function constructPageMarkdown(
+    grapherState: GrapherState,
+    columns: CoreColumn[],
+    valuesByEntity: GrapherValuesJson[],
+    search: string
+): string {
+    const canonicalUrl = grapherState.canonicalUrl ?? ""
+    // Computed columns can have neither a source nor origins; they have nothing to
+    // say in the About and Sources sections.
+    const columnsWithSources = columns.filter(
+        (column) =>
+            !!column.source.name ||
+            ((column.def as OwidColumnDef).origins ?? []).length > 0
+    )
+
+    const lines: string[] = [`# ${grapherState.effectiveTitle}`]
+    if (grapherState.effectiveSubtitle) {
+        lines.push("", grapherState.effectiveSubtitle)
+    }
+
+    lines.push(...getValuesSection(valuesByEntity))
+    lines.push(...getDataAccessSection(canonicalUrl, search))
+
+    const about = [...getAboutSection(columnsWithSources)]
+    if (about.length > 0) {
+        lines.push("", "## About this data", ...about)
+    }
+
+    lines.push(...getSourcesSection(columnsWithSources))
+
+    // Detail-on-demand links (e.g. [terawatt-hours](#dod:watt-hours)) are hover
+    // tooltips on the website; here they would be dead links to a fragment that
+    // doesn't exist in the document.
+    return stripDetailOnDemandLinks(lines.join("\n").trim()) + "\n"
+}

--- a/functions/_common/pageMarkdownTools.ts
+++ b/functions/_common/pageMarkdownTools.ts
@@ -1,5 +1,10 @@
 import * as _ from "lodash-es"
-import { OwidColumnDef, stripDetailOnDemandLinks } from "@ourworldindata/utils"
+import {
+    OwidColumnDef,
+    SERVER_SIDE_DOWNLOAD_HELP_TEXT,
+    makeDownloadCodeExamples,
+    stripDetailOnDemandLinks,
+} from "@ourworldindata/utils"
 import type { CoreColumn } from "@ourworldindata/core-table"
 import type {
     GrapherValuesJson,
@@ -10,7 +15,9 @@ import type {
 import { GrapherState } from "@ourworldindata/grapher"
 import {
     getCitationLines,
+    getDataProcessingLines,
     getDescriptionLines,
+    getKeyDataLines,
     getSourcesSection,
     getTitle,
 } from "./readmeTools.js"
@@ -180,19 +187,90 @@ function* getAllEntityValuesSection(
     }
 }
 
-function* getDataAccessSection(
+/**
+ * The page's Download section, kept rather than compressed: the Data API URLs and
+ * the code examples exist so that machines find the data, and an agent reading
+ * the page benefits from them as much as a person does. What the page lacks is
+ * the query grammar. An agent that guessed `country=Zimbabwe` got an empty file
+ * and fell back to downloading everything; the codes and the meaning of
+ * `csvType` are the part worth spelling out.
+ */
+function* getDownloadSection(
+    grapherState: GrapherState,
     baseUrl: string,
     search: string
 ): Generator<string, void, undefined> {
+    const withDefaults = (params: string): string =>
+        `${search ? `${search}&` : "?"}${params}`
+    const fullCsvUrl = `${baseUrl}.csv?v=1&csvType=full&useColumnShortNames=false`
+    const displayedCsvUrl = `${baseUrl}.csv${withDefaults("v=1&csvType=filtered&useColumnShortNames=false")}`
+    const metadataUrl = `${baseUrl}.metadata.json?v=1&csvType=full&useColumnShortNames=false`
+
     yield ""
-    yield "## Get this data"
+    yield "## Download"
     yield ""
-    yield `- Data as CSV: ${baseUrl}.csv${search}`
-    yield `- Metadata as JSON: ${baseUrl}.metadata.json${search}`
+    yield SERVER_SIDE_DOWNLOAD_HELP_TEXT
+    yield ""
+    yield `- Full data, every entity and year: ${baseUrl}.zip?v=1&csvType=full&useColumnShortNames=false`
+    yield `- Displayed data, the entities and years shown in this view: ${baseUrl}.zip${withDefaults("v=1&csvType=filtered&useColumnShortNames=false")}`
+    yield ""
+    yield "#### Data API"
+    yield ""
+    yield `- Data URL (CSV format), full data: ${fullCsvUrl}`
+    yield `- Data URL (CSV format), displayed data: ${displayedCsvUrl}`
+    yield `- Metadata URL (JSON format): ${metadataUrl}`
+    yield `- Latest value for one entity (JSON): ${baseUrl}.values.json?country=~USA`
     yield `- Chart image: ${baseUrl}.png${search}`
     yield `- Interactive chart: ${baseUrl}${search}`
+
     yield ""
-    yield "Append `country=` to select entities (tilde-separated codes, e.g. `country=~USA~FRA`) and `time=` to select a range (e.g. `time=2000..2023`)."
+    yield "#### Query parameters"
+    yield ""
+    yield "- `country=` selects entities by code, tilde-separated: `country=~USA~FRA`. Codes are ISO 3166-1 alpha-3 (USA, FRA, ZWE); aggregates use OWID codes (OWID_WRL for World, OWID_EUR for Europe, OWID_AFR for Africa, OWID_ASI for Asia). Entity names are not accepted."
+    yield "- `time=` selects years: `time=2023` for one year or `time=1990..2023` for a range."
+    yield "- `csvType=filtered` returns the entities and years shown on the chart, or those `country=` and `time=` select. `csvType=full` returns every entity and year and ignores both parameters."
+    yield "- `useColumnShortNames=true` names columns by their stable machine-readable identifiers."
+
+    const table = grapherState.tableForDownload
+    const { minTime, maxTime } = table
+    if (minTime !== undefined && maxTime !== undefined) {
+        const timeColumn = table.timeColumn
+        yield ""
+        yield `This chart has ${table.availableEntityNames.length} entities and data from ${timeColumn.formatValue(minTime)} to ${timeColumn.formatValue(maxTime)}.`
+    }
+
+    yield ""
+    yield "#### Code examples"
+    for (const [name, snippet] of Object.entries(
+        makeDownloadCodeExamples(fullCsvUrl, metadataUrl)
+    )) {
+        yield ""
+        yield `##### ${name}`
+        yield ""
+        yield "```"
+        yield snippet
+        yield "```"
+    }
+}
+
+/**
+ * The page answers "how did Our World in Data process this data?" with a general
+ * paragraph and the indicator's own processing notes. The notes are where an
+ * agent learns that a series splices several sources, which changes how it
+ * should quote a value.
+ */
+function* getFaqSection(
+    columns: CoreColumn[]
+): Generator<string, void, undefined> {
+    yield ""
+    yield "## Frequently asked questions"
+    yield ""
+    yield "#### How did Our World in Data process this data?"
+    yield ""
+    yield "All data and visualizations on Our World in Data rely on data sourced from one or several original data providers. Preparing this original data involves several processing steps, such as harmonising country names, converting units and combining sources. The structure of our data pipeline and the code used to prepare every dataset are documented at https://docs.owid.io/projects/etl/."
+    for (const column of columns) {
+        yield* getDataProcessingLines(column.def)
+    }
 }
 
 function* getAboutSection(
@@ -240,15 +318,27 @@ export function constructPageMarkdown(
         lines.push("", grapherState.effectiveSubtitle)
     }
 
+    // Last updated, next expected update, date range and unit, as the page's
+    // metadata box shows them. The update date is what lets a reader judge how
+    // fresh a quoted value is.
+    const primary = columnsWithSources[0]
+    if (primary) {
+        const keyData = [
+            ...getKeyDataLines(primary.def, primary),
+        ]
+        if (keyData.length > 0) lines.push("", ...keyData)
+    }
+
     lines.push(...getValuesSection(valuesByEntity))
     lines.push(...getAllEntityValuesSection(grapherState))
-    lines.push(...getDataAccessSection(baseUrl, search))
+    lines.push(...getDownloadSection(grapherState, baseUrl, search))
 
     const about = [...getAboutSection(columnsWithSources)]
     if (about.length > 0) {
         lines.push("", "## About this data", ...about)
     }
 
+    lines.push(...getFaqSection(columnsWithSources))
     lines.push(...getSourcesSection(columnsWithSources))
 
     // Detail-on-demand links (e.g. [terawatt-hours](#dod:watt-hours)) are hover

--- a/functions/_common/pageMarkdownTools.ts
+++ b/functions/_common/pageMarkdownTools.ts
@@ -1,7 +1,12 @@
 import * as _ from "lodash-es"
 import { OwidColumnDef, stripDetailOnDemandLinks } from "@ourworldindata/utils"
 import type { CoreColumn } from "@ourworldindata/core-table"
-import type { EntityName, GrapherValuesJson, Time } from "@ourworldindata/types"
+import type {
+    GrapherValuesJson,
+    GrapherValuesJsonDataPoint,
+    GrapherValuesJsonDataPoints,
+    Time,
+} from "@ourworldindata/types"
 import { GrapherState } from "@ourworldindata/grapher"
 import {
     getCitationLines,
@@ -9,6 +14,20 @@ import {
     getSourcesSection,
     getTitle,
 } from "./readmeTools.js"
+
+/**
+ * A scatter plot's x indicator is reported in `points.x`, not among `points.y`, so
+ * looking only at the y series renders half of every plotted coordinate blank.
+ */
+function findPoint(
+    points: GrapherValuesJsonDataPoints | undefined,
+    columnSlug: string
+): GrapherValuesJsonDataPoint | undefined {
+    if (!points) return undefined
+    const yPoint = points.y.find((point) => point.columnSlug === columnSlug)
+    if (yPoint) return yPoint
+    return points.x?.columnSlug === columnSlug ? points.x : undefined
+}
 
 /**
  * The values block is the reason this endpoint exists. A chart page describes its
@@ -41,27 +60,35 @@ function* getValuesSection(
         yield ""
         yield `**${column.name}**${unit}.`
 
-        const startTime = first.startValues ? first.startTime : undefined
-        const endTime = first.endValues ? first.endTime : undefined
-        const timeHeadings = [startTime, endTime].filter(
-            (time) => time !== undefined
+        // Times are formatted by the point that carries them: on a daily or
+        // quarterly chart the raw Time is a day offset from the epoch, which would
+        // print as "18262" rather than a date.
+        const bounds = (
+            [
+                ["start", first.startTime, first.startValues],
+                ["end", first.endTime, first.endValues],
+            ] as const
         )
-        // A chart whose start and end resolve to the same year would otherwise print
-        // the same column twice under two identical headings.
-        const headings = [...new Set(timeHeadings)]
+            .filter(([, time, points]) => time !== undefined && points)
+            .map(([bound, time, points]) => ({
+                bound,
+                time: time as Time,
+                heading: findPoint(points, slug)?.formattedTime ?? String(time),
+            }))
+        // A chart whose start and end resolve to the same time would otherwise
+        // print the same column twice under two identical headings.
+        const headings = _.uniqBy(bounds, (bound) => bound.time)
+        if (headings.length === 0) continue
 
         yield ""
-        yield `| Entity | ${headings.join(" | ")} |`
+        yield `| Entity | ${headings.map((h) => h.heading).join(" | ")} |`
         yield `| --- | ${headings.map(() => "---:").join(" | ")} |`
 
         for (const values of withData) {
-            const cells = headings.map((time) => {
+            const cells = headings.map(({ bound }) => {
                 const points =
-                    time === values.startTime
-                        ? values.startValues
-                        : values.endValues
-                const point = points?.y.find((p) => p.columnSlug === slug)
-                return point?.formattedValue ?? ""
+                    bound === "start" ? values.startValues : values.endValues
+                return findPoint(points, slug)?.formattedValue ?? ""
             })
             yield `| ${values.entityName ?? ""} | ${cells.join(" | ")} |`
         }
@@ -75,68 +102,56 @@ function* getValuesSection(
  * country, and which country is highest. This table can, for around 1,500 tokens on a
  * country-grained chart.
  *
- * Each entity is reported at its own latest time at or before the chart's end time,
- * and the year is printed whenever entities disagree, so a country whose data stops
- * early is never silently relabelled to the chart's end year.
+ * Only the chart's first indicator is tabulated. Both questions this section exists to
+ * answer presuppose a single quantity, and reporting several indicators per row means
+ * either a row that mixes times under one time cell or a time cell per value; naming
+ * one indicator and pointing at the CSV for the rest is the honest version.
  */
 function* getAllEntityValuesSection(
     grapherState: GrapherState
 ): Generator<string, void, undefined> {
     const table = grapherState.tableForDownload
-    const columns = grapherState.yColumnSlugs
-        .filter((slug) => table.has(slug))
-        .map((slug) => table.get(slug))
-    if (columns.length === 0) return
+    const slugs = grapherState.yColumnSlugs.filter((slug) => table.has(slug))
+    if (slugs.length === 0) return
+    const column = table.get(slugs[0])
 
     const endTime = grapherState.endTime
-    const entityNames = _.uniq(columns.flatMap((col) => col.uniqEntityNames))
-    if (entityNames.length === 0) return
-
-    interface Row {
-        entityName: EntityName
-        time: Time
-        cells: string[]
-    }
-    const rows: Row[] = []
-    for (const entityName of entityNames) {
-        const cells: string[] = []
-        let latestTime: Time | undefined
-        for (const column of columns) {
-            const entityRows = column.owidRowsByEntityName.get(entityName) ?? []
-            const eligible =
-                endTime === undefined
-                    ? entityRows
-                    : entityRows.filter((row) => row.time <= endTime)
-            // owidRows is time-sorted, so the last eligible row is the latest.
-            const row = eligible.at(-1)
-            cells.push(
-                row?.value === undefined
-                    ? ""
-                    : column.formatValueShort(row.value)
-            )
-            if (row && (latestTime === undefined || row.time > latestTime))
-                latestTime = row.time
-        }
-        if (cells.every((cell) => cell === "")) continue
-        rows.push({ entityName, time: latestTime ?? 0, cells })
-    }
+    const rows = column.uniqEntityNames.flatMap((entityName) => {
+        const entityRows = column.owidRowsByEntityName.get(entityName) ?? []
+        const eligible =
+            endTime === undefined
+                ? entityRows
+                : entityRows.filter((row) => row.time <= endTime)
+        // owidRows is time-sorted, so the last eligible row is the latest.
+        const row = eligible.at(-1)
+        if (!row || row.value === undefined) return []
+        return [
+            {
+                entityName,
+                time: row.time,
+                value: column.formatValueShort(row.value),
+            },
+        ]
+    })
     if (rows.length === 0) return
 
     const times = _.uniq(rows.map((row) => row.time))
     const showTimeColumn = times.length > 1
-    const sharedTime = times[0]
 
     yield ""
     yield "## Latest value for every entity"
     yield ""
     yield showTimeColumn
-        ? "Each entity at its own latest year, at or before the year the chart ends on."
-        : `All entities in ${sharedTime}.`
+        ? "Each entity at its own latest time, at or before the time the chart ends on."
+        : `All entities in ${column.formatTime(times[0])}.`
+    if (slugs.length > 1) {
+        yield ""
+        yield `This chart plots ${slugs.length} indicators; only **${column.displayName}** is tabulated here. The others are in the CSV linked below.`
+    }
 
-    const valueHeadings = columns.map((column) => column.displayName)
     const headings = showTimeColumn
-        ? ["Entity", ...valueHeadings, "Year"]
-        : ["Entity", ...valueHeadings]
+        ? ["Entity", column.displayName, "Time"]
+        : ["Entity", column.displayName]
 
     yield ""
     yield `| ${headings.join(" | ")} |`
@@ -147,23 +162,23 @@ function* getAllEntityValuesSection(
 
     for (const row of _.sortBy(rows, (row) => row.entityName)) {
         const cells = showTimeColumn
-            ? [...row.cells, String(row.time)]
-            : row.cells
+            ? [row.value, column.formatTime(row.time)]
+            : [row.value]
         yield `| ${row.entityName} | ${cells.join(" | ")} |`
     }
 }
 
 function* getDataAccessSection(
-    canonicalUrl: string,
+    baseUrl: string,
     search: string
 ): Generator<string, void, undefined> {
     yield ""
     yield "## Get this data"
     yield ""
-    yield `- Data as CSV: ${canonicalUrl}.csv${search}`
-    yield `- Metadata as JSON: ${canonicalUrl}.metadata.json${search}`
-    yield `- Chart image: ${canonicalUrl}.png${search}`
-    yield `- Interactive chart: ${canonicalUrl}${search}`
+    yield `- Data as CSV: ${baseUrl}.csv${search}`
+    yield `- Metadata as JSON: ${baseUrl}.metadata.json${search}`
+    yield `- Chart image: ${baseUrl}.png${search}`
+    yield `- Interactive chart: ${baseUrl}${search}`
     yield ""
     yield "Append `country=` to select entities (tilde-separated codes, e.g. `country=~USA~FRA`) and `time=` to select a range (e.g. `time=2000..2023`)."
 }
@@ -196,7 +211,10 @@ export function constructPageMarkdown(
     valuesByEntity: GrapherValuesJson[],
     search: string
 ): string {
-    const canonicalUrl = grapherState.canonicalUrl ?? ""
+    // `canonicalUrl` is `baseUrl + queryStr`, so building extensions from it yields
+    // `/slug?country=~USA.csv?country=~USA` — a URL that resolves to the HTML page
+    // with a mangled country value. The extension belongs on the query-free base.
+    const baseUrl = grapherState.baseUrl ?? ""
     // Computed columns can have neither a source nor origins; they have nothing to
     // say in the About and Sources sections.
     const columnsWithSources = columns.filter(
@@ -212,7 +230,7 @@ export function constructPageMarkdown(
 
     lines.push(...getValuesSection(valuesByEntity))
     lines.push(...getAllEntityValuesSection(grapherState))
-    lines.push(...getDataAccessSection(canonicalUrl, search))
+    lines.push(...getDataAccessSection(baseUrl, search))
 
     const about = [...getAboutSection(columnsWithSources)]
     if (about.length > 0) {

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -121,14 +121,26 @@ router
     // variants vary on Accept so caches keep them apart.
     .get("/grapher/:slug", async (request, { searchParams }, env) => {
         const { slug } = request.params
-        const response = prefersMarkdown(request.headers.get("accept"))
-            ? await fetchMarkdownForGrapher(
-                  { type: "slug", id: slug },
-                  env,
-                  searchParams
-              )
-            : await handleHtmlPageRequest(slug, searchParams, env)
-        return withVaryAccept(response)
+        if (prefersMarkdown(request.headers.get("accept"))) {
+            try {
+                return withVaryAccept(
+                    await fetchMarkdownForGrapher(
+                        { type: "slug", id: slug },
+                        env,
+                        searchParams
+                    )
+                )
+            } catch (e) {
+                // The markdown carries data values, so charts with
+                // non-redistributable data refuse it (403). The page itself is
+                // still fine to serve; only a missing chart (404) should fall
+                // through to the redirect handling.
+                if (!(e instanceof StatusError) || e.status === 404) throw e
+            }
+        }
+        return withVaryAccept(
+            await handleHtmlPageRequest(slug, searchParams, env)
+        )
     })
     .all("*", () => error(404, "Route not defined"))
 

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -88,11 +88,12 @@ router
     // Declared after `.readme.md` so that route claims its own suffix first.
     .get(
         `/grapher/:slug${extensions.markdown}`,
-        async ({ params: { slug } }, { searchParams }, env) =>
+        async ({ params: { slug } }, { searchParams }, env, _etag, ctx) =>
             fetchMarkdownForGrapher(
                 { type: "slug", id: slug },
                 env,
-                searchParams
+                searchParams,
+                ctx
             )
     )
     .get(
@@ -119,29 +120,33 @@ router
     // it (Claude Code's fetcher sends `Accept: text/markdown, text/html, */*`),
     // so agents get the numbers without knowing about the .md suffix. Both
     // variants vary on Accept so caches keep them apart.
-    .get("/grapher/:slug", async (request, { searchParams }, env) => {
-        const { slug } = request.params
-        if (prefersMarkdown(request.headers.get("accept"))) {
-            try {
-                return withVaryAccept(
-                    await fetchMarkdownForGrapher(
-                        { type: "slug", id: slug },
-                        env,
-                        searchParams
+    .get(
+        "/grapher/:slug",
+        async (request, { searchParams }, env, _etag, ctx) => {
+            const { slug } = request.params
+            if (prefersMarkdown(request.headers.get("accept"))) {
+                try {
+                    return withVaryAccept(
+                        await fetchMarkdownForGrapher(
+                            { type: "slug", id: slug },
+                            env,
+                            searchParams,
+                            ctx
+                        )
                     )
-                )
-            } catch (e) {
-                // The markdown carries data values, so charts with
-                // non-redistributable data refuse it (403). The page itself is
-                // still fine to serve; only a missing chart (404) should fall
-                // through to the redirect handling.
-                if (!(e instanceof StatusError) || e.status === 404) throw e
+                } catch (e) {
+                    // The markdown carries data values, so charts with
+                    // non-redistributable data refuse it (403). The page itself is
+                    // still fine to serve; only a missing chart (404) should fall
+                    // through to the redirect handling.
+                    if (!(e instanceof StatusError) || e.status === 404) throw e
+                }
             }
+            return withVaryAccept(
+                await handleHtmlPageRequest(slug, searchParams, env)
+            )
         }
-        return withVaryAccept(
-            await handleHtmlPageRequest(slug, searchParams, env)
-        )
-    })
+    )
     .all("*", () => error(404, "Route not defined"))
 
 export const onRequest: PagesFunction<Env> = async (context) => {

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -2,6 +2,7 @@ import { Env, extensions, Etag } from "../_common/env.js"
 import {
     fetchCsvForGrapher,
     fetchDataValuesForGrapher,
+    fetchMarkdownForGrapher,
     fetchMetadataForGrapher,
     fetchReadmeForGrapher,
     fetchSearchResultDataForGrapher,
@@ -82,6 +83,16 @@ router
         `/grapher/:slug${extensions.zip}`,
         async ({ params: { slug } }, { searchParams }, env) =>
             fetchZipForGrapher({ type: "slug", id: slug }, env, searchParams)
+    )
+    // Declared after `.readme.md` so that route claims its own suffix first.
+    .get(
+        `/grapher/:slug${extensions.markdown}`,
+        async ({ params: { slug } }, { searchParams }, env) =>
+            fetchMarkdownForGrapher(
+                { type: "slug", id: slug },
+                env,
+                searchParams
+            )
     )
     .get(
         `/grapher/:slug${extensions.values}`,

--- a/functions/grapher/[slug].ts
+++ b/functions/grapher/[slug].ts
@@ -9,6 +9,7 @@ import {
     fetchZipForGrapher,
 } from "../_common/downloadFunctions.js"
 import { handleThumbnailRequest } from "../_common/reusableHandlers.js"
+import { prefersMarkdown } from "../_common/pageMarkdownTools.js"
 import {
     handlePageNotFound,
     getRedirectForUrl,
@@ -114,11 +115,21 @@ router
                 ctx
             )
     )
-    .get(
-        "/grapher/:slug",
-        async ({ params: { slug } }, { searchParams }, env) =>
-            handleHtmlPageRequest(slug, searchParams, env)
-    )
+    // The page URL itself serves the markdown document to clients that ask for
+    // it (Claude Code's fetcher sends `Accept: text/markdown, text/html, */*`),
+    // so agents get the numbers without knowing about the .md suffix. Both
+    // variants vary on Accept so caches keep them apart.
+    .get("/grapher/:slug", async (request, { searchParams }, env) => {
+        const { slug } = request.params
+        const response = prefersMarkdown(request.headers.get("accept"))
+            ? await fetchMarkdownForGrapher(
+                  { type: "slug", id: slug },
+                  env,
+                  searchParams
+              )
+            : await handleHtmlPageRequest(slug, searchParams, env)
+        return withVaryAccept(response)
+    })
     .all("*", () => error(404, "Route not defined"))
 
 export const onRequest: PagesFunction<Env> = async (context) => {
@@ -148,6 +159,16 @@ export const onRequest: PagesFunction<Env> = async (context) => {
                 return error(e.status, e.message)
             } else return error(500, e)
         })
+}
+
+/** Response headers are immutable on fetched responses, so copy before adding Vary. */
+function withVaryAccept(response: Response): Response {
+    const copy = new Response(response.body, response)
+    const vary = copy.headers.get("vary")
+    if (!vary) copy.headers.set("vary", "Accept")
+    else if (!/\bAccept\b/i.test(vary))
+        copy.headers.set("vary", `${vary}, Accept`)
+    return copy
 }
 
 async function handleHtmlPageRequest(

--- a/site/DataPageV2.tsx
+++ b/site/DataPageV2.tsx
@@ -130,6 +130,16 @@ export const DataPageV2 = (props: {
                     />
                 )}
                 <IFrameDetector />
+                {/* Agents that don't negotiate content look for this link and
+                    fetch it as a second request; without it they only ever see
+                    the HTML, whose chart is client-rendered. Every published
+                    chart with indicator metadata renders through here rather
+                    than through GrapherPage, so the link has to be in both. */}
+                <link
+                    rel="alternate"
+                    type="text/markdown"
+                    href={`${canonicalUrl}.md`}
+                />
                 <link rel="preconnect" href={dataApiOrigin} />
                 {variableIds.flatMap((variableId) =>
                     [

--- a/site/GrapherPage.tsx
+++ b/site/GrapherPage.tsx
@@ -126,6 +126,14 @@ window.renderSingleGrapherOnGrapherPage({ config: jsonConfig, dataApiUrl: "${DAT
                     />
                 )}
                 <IFrameDetector />
+                {/* Agents that don't negotiate content look for this link and
+                    fetch it as a second request; without it they only ever see
+                    the HTML, whose chart is client-rendered. */}
+                <link
+                    rel="alternate"
+                    type="text/markdown"
+                    href={`${canonicalUrl}.md`}
+                />
                 <link rel="preconnect" href={dataApiOrigin} />
                 {variableIds.flatMap((variableId) =>
                     [

--- a/site/multiDim/MultiDimDataPage.tsx
+++ b/site/multiDim/MultiDimDataPage.tsx
@@ -98,6 +98,15 @@ export function MultiDimDataPage({
                 <meta property="og:image:width" content={imageWidth} />
                 <meta property="og:image:height" content={imageHeight} />
                 <IFrameDetector />
+                {/* See the note in DataPageV2: agents that don't negotiate
+                    content fetch this as a second request. The markdown
+                    endpoint resolves the view from the query string, but a
+                    static link can only carry the default one. */}
+                <link
+                    rel="alternate"
+                    type="text/markdown"
+                    href={`${canonicalUrl}.md`}
+                />
                 <noscript>
                     <style>{`
                     figure[data-grapher-src] { display: none !important; }


### PR DESCRIPTION
A chart page describes its indicator well — key insights, description, sources, citation all read cleanly as text — but it never states a number. The chart is client-rendered, so anything that doesn't run JavaScript reads our prose and then answers from its own priors. Cloudflare's markdown conversion is already on, so agents *do* fetch a text version of every chart page; it just has no data in it.

This serves an authored markdown rendering of the page, carrying the values the chart actually shows, at `/grapher/<slug>.md` **and at the page URL itself when the request's `Accept` header prefers `text/markdown` over `text/html`** — which is what Claude Code's fetcher sends, so agents get the numbers without knowing about the suffix. Browsers, `curl`, Googlebot and Gemini's fetcher all lead with HTML or `*/*` and are unaffected.

```
# Life expectancy

Period life expectancy is the number of years the average person born in a certain year would live…

Last updated: October 22, 2025
Next expected update: October 2026
Date range: 1543–2023
Unit: years

## Values shown in this view

Values at the years the chart starts and ends on. A year in brackets means that entity's data begins
or ends there instead, and the value is from that year.

**Life expectancy**, in years.

| Entity   | 1770        | 2023 |
| --- | ---: | ---: |
| World    | 28.5        | 73.2 |
| Europe   | 34.3        | 79.1 |
| Oceania  | 34.7 (1870) | 79.1 |

## Latest value for every entity

All entities in 2023.

| Entity | Life expectancy |
| --- | ---: |
| Afghanistan | 66 years |
| … 260 more rows

## Download
… the page's own ZIP, Data API and code-example content, plus a Query parameters block:
  `country=~USA~FRA` (ISO 3166-1 alpha-3; OWID_WRL etc. for aggregates), `time=1990..2023`,
  what `csvType=filtered` and `full` return, and this chart's entity count and time range.

## About this data · ## Frequently asked questions · ## Sources
```

Two value blocks, because they answer different questions. The first covers the entities the chart selects — its own default selection, or whatever `country=` asks for — so it matches what a reader at that URL sees. But that selection is an editorial choice about what to *draw*; on `life-expectancy` it is six world regions, which cannot answer "what is it in Czechia?" or "which country is highest?". The second block can, for about 1,500 tokens on a country-grained chart. The full time series was the other candidate and is not here — the narrowest gain for the most bytes, and it is what the CSV link is for.

Everything else on the page is kept rather than compressed: the Download section exists to help machines find the data, so the markdown carries its Data API URLs and code examples verbatim, along with the FAQ, the processing notes and the update dates. Gone are the chart image, the key insights and the related-charts lists.

Worth knowing for review:

- **Nothing new is computed.** Values come from the same `constructGrapherValuesJson` path `.values.json` already serves to the search-result cards (~1.6M requests/month), and the surrounding prose reuses the `readmeTools` generators.
- **Multi-dim views resolve correctly for free**, because `initGrapher` already does that for `.csv`. So this also gives agents correct per-view text for mdims, which the HTML currently does not (owid/owid-grapher#7222) — those are independent fixes.
- **Two representations of one URL.** Both carry `Vary: Accept`, and the markdown is cached for an hour keyed by the `.md` URL of the view. Verified on the Cloudflare preview: an agent `Accept` gets `text/markdown` (`cf-cache-status: HIT` on the second request), a browser `Accept` gets `text/html`, in either request order, and Cloudflare's own markdown conversion leaves our origin response alone. A chart whose data cannot be redistributed falls back to the HTML page rather than the 403 the data endpoints return.
- **Uncached assembly costs about 0.7–2 s** depending on the chart, down from 1.1–6 s: building the selected-values block via `prepareCalloutTable` once per request instead of `constructGrapherValuesJson` per entity removed roughly half of it. The rest is two data-API fetches that can't overlap, the same ones `.csv` pays.
- **Only the first indicator is tabulated per entity**, deliberately: the table says so in prose and points at the CSV. On a six-gas or nine-disaster-type chart that means an agent can read one series from the page and must fetch the others.
- **Row count is not capped.** Every published chart tested is country- or region-grained (180–270 entities, 13–48 KB documents), so this is a hedge nobody needs yet; a subnational chart would want one.
- **The markdown shape is a first proposal**, not a settled format. What belongs in an agent-facing rendering of a chart page is an editorial call; happy to move things around.

## Who actually reads this, and why it's now lower priority

**Measured since opening this PR: ChatGPT's live browsing fetcher will not use it.** `ChatGPT-User` fetches markdown on 0.1% of its requests, it sends a browser `Accept` with `text/html` first, and it doesn't ignore-then-follow our alternate link either. That matters because `ChatGPT-User` is ~78% of the answer-bot traffic on our chart pages, around 37,000 chart-page fetches a day. Two independent instrumented-log studies and two probes of my own agree, so I'd treat this as settled rather than provisional.

Markdown fetch rate by client, from two published edge-log studies on real sites:

| Client | Evil Martians, May–Jul 2026 | Buytaert, Feb–Mar 2026 | Reaches it via |
|---|---|---|---|
| Claude Code | 76% (17,814 / 23,300) | — | `Accept` negotiation |
| GPTBot (OpenAI training) | 31% | 34.8% | `<link rel="alternate">` |
| OAI-SearchBot (OpenAI index) | 26% | 22.7% | `<link rel="alternate">` |
| **ChatGPT-User (live browsing)** | **0.1%** (272 / 196,973) | **0.1%** (8 / 13,864) | neither |
| Perplexity | ~0% | ~0% | neither |

Sources: [Evil Martians, 21 Jul 2026](https://evilmartians.com/chronicles/which-ai-actually-reads-your-site-two-months-of-llm-traffic-measured), [dri.es, 5 Mar 2026](https://dri.es/markdown-llms-txt-and-ai-crawlers). Buytaert's conclusion on the other half of the mechanism is blunt: "No AI crawler uses content negotiation. Not one." Cloudflare's own launch post for Markdown for Agents names only Claude Code and OpenCode as clients that send the header, which is consistent.

Also worth knowing before anyone invests further: the only randomized trial of serving markdown ([Profound, 381 pages over 6 sites](https://www.tryprofound.com/blog/does-markdown-increase-ai-bot-traffic)) found a non-significant ~+20% for `ChatGPT-User` and concluded it could not say markdown drove more traffic; the median page gained one extra bot visit. And no published study measures any of this on data-heavy pages — both log studies are prose sites where the `.md` is a faithful conversion of the page, whereas ours is an editorial selection from a dataset, so their uptake figures may not transfer at all.

### What this PR still earns

- **Claude Code**, at 76% of its fetches, is the one client that genuinely wants this. Small volume on our site (~1,000 chart-page fetches a day across all Claude clients) but it is the population doing data work with our numbers.
- **OpenAI's index and training crawlers**, via the alternate link, at roughly a quarter to a third of their fetches. ChatGPT's answers mostly come from that index rather than from live browsing, so this is a plausible indirect path — unmeasured for our content type, so not a promise.
- **The assembly code.** `constructPageMarkdown` and the values assembly are the reusable core; rendering the same block into the page HTML would use them unchanged.

### What the eval measured, and what it implies

108 questions over 12 chart views, gold from the CSV endpoints, asked of Claude Sonnet 5 under three renderings of the same URL. Full write-up: [Agents Reading Grapher Pages](https://claude.ai/code/artifact/119465ef-b18e-46a6-b783-9e9abd57ab89); harness in #7245.

| Page text the agent reads | Correct | Traceable to a quote from the page |
|---|---|---|
| Today's page (Cloudflare's conversion) | 34% | 31% |
| This PR's markdown | 82% | 81% |
| No page at all (memory only) | 46% | 12% |

Paired difference +48 points [38, 58], with hallucination against the no-page control down 17 points. Most of those questions were written to be answerable from these tables, so the headline substantially measures "the table holds the number and the model can read a table" — the useful conclusion is not the size of the number but that **a text rendering of a chart page can carry a correct, quotable answer, where today's cannot.**

That conclusion is what argues for the next step, which is bigger than this PR: **render the values block into the page HTML.** It is the only change that reaches `ChatGPT-User`, since it neither negotiates nor executes JavaScript ([Vercel/MERJ](https://vercel.com/blog/the-rise-of-the-ai-crawler): "none of the major AI crawlers currently render JavaScript"). It also reaches Gemini's fetcher, `curl`, and search crawlers. That deserves its own proposal with bake-time and page-weight numbers, and the value check in #7245 should gate it.

The failure all of this is meant to prevent did show up unprompted, twice. Asked a generic question with no mention of us, an agent fetched this very grapher page, found no number, and cited the World Bank instead. On a different surface (the WebMCP spike, #7128) Gemini fabricated a citation for our own battery-price research while standing on the page containing it.

<sub>Correction to an earlier revision of this description: it claimed Codex follows `<link rel="alternate" type="text/markdown">`, attributed to Checkly's survey. Checkly never tested link-following; that claim traces to an unattributed community matrix which itself lists ChatGPT browse as HTML-only.</sub>
<details>
<summary>Details</summary>

### Files

| File | Change |
|---|---|
| `functions/_common/pageMarkdownTools.ts` | New. `constructPageMarkdown` — the pure assembly function, plus the selected-values, per-entity, download and about/FAQ section generators, and `prefersMarkdown` for the `Accept` header. |
| `functions/_common/pageMarkdownTools.test.ts` | New. Table rendering, bracketed years, query-string propagation, dod-link stripping, per-entity coverage, the shared-year case, the empty-values case, the download/FAQ/query-grammar content, `Accept` parsing, and the extension-ordering invariant below. |
| `functions/_common/downloadFunctions.ts` | `fetchMarkdownForGrapher` handler: view resolution, hour-long cache, batch values assembly. |
| `functions/_common/env.ts` | `markdown: ".md"` added to `extensions`. |
| `functions/grapher/[slug].ts` | The `.md` route, `Accept` negotiation on the page route, `Vary: Accept`, the HTML fallback for non-redistributable charts. |
| `functions/_common/grapherTools.ts` | Base URL handling so extensions land on the query-free URL. |
| `site/GrapherPage.tsx` | `<link rel="alternate" type="text/markdown">` in the head, which is how Codex reportedly finds it. |
| `docs/chart-api.openapi.yaml` | Documents the endpoint and the negotiation under Metadata. |

### The extension-ordering trap

`redirectTools` builds a regex from `Object.values(extensions)` to split a slug from its extension. Adding `.md` naively could split `life-expectancy.readme.md` into `life-expectancy.readme` + `.md`. Two things keep that from happening, and both are load-bearing:

1. `markdown: ".md"` is declared **after** `readme: ".readme.md"` in the `extensions` object.
2. The route is declared after the `.readme.md` route in `functions/grapher/[slug].ts`.

`pageMarkdownTools.test.ts` asserts the regex still resolves `life-expectancy.readme.md` to the readme extension, so a reordering fails a test rather than silently breaking readme downloads.

### Content negotiation and caching

- `prefersMarkdown` compares `text/markdown` against `text/html` by q-value, then by list order. Browsers never mention markdown; Claude Code's fetcher sends `text/markdown, text/html, */*`; `*/*` alone does not count. Unit-tested in both directions.
- The cache key is the `.md` URL of the resolved view, not the incoming request, so the page URL negotiated to markdown and the explicit `.md` URL share one entry and the HTML page's own entry can never be confused with it. That matters because Cloudflare's edge honours `Vary` for images only — though on the preview the two representations stayed separate in both request orders anyway.
- `nocache=1` bypasses the handler's cache and is stripped from the view, so it appears in neither the cache key nor the data URLs the document prints.
- The markdown path runs `ensureDownloadOfDataAllowed`, so a non-redistributable chart throws 403; on the page route that is caught and the HTML page served instead. Only a 404 keeps propagating to the redirect handling.

### Implementation notes

- The selected-values block uses `prepareCalloutTable` + `constructGrapherValuesJsonFromTable`, the batch pair written for gdoc callouts: one prepared table per request, then a lookup per entity. `constructGrapherValuesJson` reassigns `grapherState.selection` per entity, which invalidates Grapher's computed chain and re-runs the transform pipeline over the whole table each time — 44% of assembly time on a chart with seven selected entities. The batch form reads the input table rather than the chart-transformed one, so **relative-mode charts keep the per-entity path**, otherwise the table would print absolutes where the chart shows percentages. Output is byte-identical across all 12 chart views tested.
- A chart with no selection (a scatter plot, typically) skips the block entirely rather than preparing a table for zero lookups.
- Entities are filtered against `availableEntityNames`, so a stale or invalid `country=` yields a page without a values table rather than empty rows.
- Detail-on-demand links (`[terawatt-hours](#dod:watt-hours)`) are stripped, as in the readme — they are hover tooltips on the website and dead fragments in a standalone document.
- Columns with neither a source name nor origins (computed columns) are excluded from the About and Sources sections, matching `constructReadme`.
- The `search` string is passed through to every data URL so the CSV, metadata and image links resolve to the same view the markdown describes.
- The Download section reuses `makeDownloadCodeExamples` and `SERVER_SIDE_DOWNLOAD_HELP_TEXT` from `@ourworldindata/utils`, the same source the page's own section uses, so the two can't drift.

### The two value tables

- **Selected values.** Column headings are the chart's start and end years. An entity whose series starts later or ends earlier reports its own first or last value with that year in brackets — `| Oceania | 34.7 (1870) | 79.1 |`. Without the bracket the heading's year got attributed to it, and an agent duly answered "Oceania in 1770: 34.7 years"; on `child-mortality` every selected country but the US was mislabelled.
- **Per entity.** Each entity at **its own latest time at or before the chart's `endTime`**, taken as the last of its time-sorted `owidRows`, which sidesteps grapher's tolerance semantics rather than reimplementing them. The `Time` column appears only when entities disagree, so a country whose data stops early is never silently relabelled and a complete table doesn't repeat "2023" 261 times. Only the first y column is tabulated, stated in prose with a pointer to the CSV.
- **No row cap.** Every published chart tested is country- or region-grained: 180–270 entities, 13–48 KB documents. A subnational chart would want a cap; none appears to exist yet, and the constant would age badly, so it is left out deliberately.

### Not in scope

- The HTML page still renders the default mdim view (#7222).
- No `llms.txt`, and no `.md` for article or topic pages — those are baked static files, so they would be a baker change rather than an edge one.
- Nothing for explorers, whose markdown conversion collapses to ~700 bytes; they aren't a `GrapherState`, so they need their own treatment.
- Values are not rendered into the page HTML, which is the only thing that would reach `*/*` fetchers, browser-resident agents and crawlers. That's a bake-time decision worth its own proposal.
- `.readme.md` stays as it is. It gets ~1,000 requests a month because nothing links to it.

### Test plan

- `yarn typecheck`, `yarn testLintChanged`, `yarn testFormatChanged` — clean. `yarn test run` — full suite passes; 19 tests in `pageMarkdownTools.test.ts`.
- Driven against the branch's staging server across 12 chart views (line, map-default, scatter, stacked area, two mdim views, one with `country=`/`time=`): all 200, and a model-free check comparing every printed value with the CSV endpoint reports no mismatches.
- Negotiation and caching verified on the Cloudflare preview, both request orders, plus no-`Accept` and a Googlebot user agent — see the third review bullet above.
- Uncached timings before and after the batch change, three runs per view; the values-section output is byte-identical across all 12.
- The earlier round caught a bug the assertions did not: the About heading interpolated `titlePublicOrDisplayName`, an `IndicatorTitleWithFragments`, and printed `[object Object]`. Fixed, with a test.

</details>
