### PR TITLE
Switch world map to Equal Earth projection

### DIFF
--- a/packages/@ourworldindata/grapher/src/mapCharts/MapProjections.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/MapProjections.ts
@@ -1,9 +1,14 @@
-import { geoConicConformal, geoAzimuthalEqualArea, GeoProjection } from "d3-geo"
-import { geoRobinson, geoPatterson } from "./d3-geo-projection.js"
+import {
+    geoConicConformal,
+    geoAzimuthalEqualArea,
+    geoEqualEarth,
+    GeoProjection,
+} from "d3-geo"
+import { geoPatterson } from "./d3-geo-projection.js"
 import { MapRegionName } from "@ourworldindata/types"
 
 export const MAP_PROJECTIONS: Record<MapRegionName, GeoProjection> = {
-    World: geoRobinson(),
+    World: geoEqualEarth(),
 
     Africa: geoConicConformal()
         .rotate([-25, 0])

--- a/packages/@ourworldindata/grapher/src/mapCharts/d3-geo-projection.ts
+++ b/packages/@ourworldindata/grapher/src/mapCharts/d3-geo-projection.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
 /*
-Duplication of d3-geo-projection.geoPatterson and d3-geo-projection.geoRobinson
+Duplication of d3-geo-projection.geoPatterson
 for webpack bundlesize purposes, as the original module wasn't tree-shakeable
 
 Copyright 2013-2021 Mike Bostock
@@ -45,11 +44,6 @@ THE SOFTWARE.
 import { geoProjection, GeoProjection } from "d3-geo"
 
 const epsilon = 1e-6
-const epsilon2 = 1e-12
-const pi = Math.PI
-const halfPi = pi / 2
-const degrees = 180 / pi
-const radians = pi / 180
 
 // https://github.com/d3/d3-geo-projection/blob/main/src/patterson.js
 const pattersonK1 = 1.0148,
@@ -99,100 +93,4 @@ pattersonRaw.invert = function (x: number, y: number): [number, number] {
 
 export function geoPatterson(): GeoProjection {
     return geoProjection(pattersonRaw).scale(139.319)
-}
-
-// https://github.com/d3/d3-geo-projection/blob/main/src/robinson.js
-const K = [
-    [0.9986, -0.062],
-    [1.0, 0.0],
-    [0.9986, 0.062],
-    [0.9954, 0.124],
-    [0.99, 0.186],
-    [0.9822, 0.248],
-    [0.973, 0.31],
-    [0.96, 0.372],
-    [0.9427, 0.434],
-    [0.9216, 0.4958],
-    [0.8962, 0.5571],
-    [0.8679, 0.6176],
-    [0.835, 0.6769],
-    [0.7986, 0.7346],
-    [0.7597, 0.7903],
-    [0.7186, 0.8435],
-    [0.6732, 0.8936],
-    [0.6213, 0.9394],
-    [0.5722, 0.9761],
-    [0.5322, 1.0],
-]
-
-K.forEach(function (d) {
-    d[1] *= 1.0144
-})
-
-export function robinsonRaw(lambda: number, phi: number): [number, number] {
-    let k
-    let i = Math.min(18, (Math.abs(phi) * 36) / pi),
-        i0 = Math.floor(i),
-        di = i - i0,
-        ax = (k = K[i0])[0],
-        ay = k[1],
-        bx = (k = K[++i0])[0],
-        by = k[1],
-        cx = (k = K[Math.min(19, ++i0)])[0],
-        cy = k[1]
-    return [
-        lambda *
-            (bx + (di * (cx - ax)) / 2 + (di * di * (cx - 2 * bx + ax)) / 2),
-        (phi > 0 ? halfPi : -halfPi) *
-            (by + (di * (cy - ay)) / 2 + (di * di * (cy - 2 * by + ay)) / 2),
-    ]
-}
-
-robinsonRaw.invert = function (x: number, y: number): [number, number] {
-    let yy = y / halfPi,
-        phi = yy * 90,
-        i = Math.min(18, Math.abs(phi / 5)),
-        i0 = Math.max(0, Math.floor(i))
-    do {
-        var ay = K[i0][1],
-            by = K[i0 + 1][1],
-            cy = K[Math.min(19, i0 + 2)][1],
-            u = cy - ay,
-            v = cy - 2 * by + ay,
-            t = (2 * (Math.abs(yy) - by)) / u,
-            c = v / u,
-            di = t * (1 - c * t * (1 - 2 * c * t))
-        if (di >= 0 || i0 === 1) {
-            phi = (y >= 0 ? 5 : -5) * (di + i)
-            var j = 50,
-                delta
-            do {
-                i = Math.min(18, Math.abs(phi) / 5)
-                i0 = Math.floor(i)
-                di = i - i0
-                ay = K[i0][1]
-                by = K[i0 + 1][1]
-                cy = K[Math.min(19, i0 + 2)][1]
-                phi -=
-                    (delta =
-                        (y >= 0 ? halfPi : -halfPi) *
-                            (by +
-                                (di * (cy - ay)) / 2 +
-                                (di * di * (cy - 2 * by + ay)) / 2) -
-                        y) * degrees
-            } while (Math.abs(delta) > epsilon2 && --j > 0)
-            break
-        }
-    } while (--i0 >= 0)
-    const ax = K[i0][0],
-        bx = K[i0 + 1][0],
-        cx = K[Math.min(19, i0 + 2)][0]
-    return [
-        x / (bx + (di * (cx - ax)) / 2 + (di * di * (cx - 2 * bx + ax)) / 2),
-        phi * radians,
-    ]
-}
-
-export function geoRobinson(): GeoProjection {
-    return geoProjection(robinsonRaw).scale(152.63)
 }


### PR DESCRIPTION
Switches the World map's default d3-geo projection from Robinson to [Equal Earth](https://en.wikipedia.org/wiki/Equal_Earth_projection), an equal-area projection that preserves relative land area (Robinson distorts area, especially near the poles). Side-by-side comparison: https://map-projections.net/compare.php?p1=equalearth&p2=robinson&w=1&sm=1&d=1

Equal Earth ships natively in `d3-geo`, so this also removes the hand-copied Robinson implementation in `d3-geo-projection.ts` that existed only for bundle-size reasons (the original `d3-geo-projection` package isn't tree-shakeable) — no longer needed since Equal Earth doesn't require that workaround.

Only the "World" region view is affected; the continent-level map regions (Africa, Asia, Europe, etc.) are unchanged.

<img width="1748" height="560" alt="image" src="https://github.com/user-attachments/assets/cf003523-e758-4db0-8778-69c8516a7658" />


<details><summary>Details</summary>

- `packages/@ourworldindata/grapher/src/mapCharts/MapProjections.ts`: `World` now uses `geoEqualEarth()` from `d3-geo` instead of the locally-defined `geoRobinson()`.
- `packages/@ourworldindata/grapher/src/mapCharts/d3-geo-projection.ts`: removed the now-unused Robinson projection code (raw projection function, inverse, and the `geoRobinson` export) and the constants only used by it. The `geoPatterson()` export (used for the Asia region) is untouched.
- `yarn typecheck` and `yarn testLintChanged` pass.
- `make svgtest`: 1779 of 4294 charts differ, and all 1779 are `WorldMap` chart type — spot-checked diffs show only the map's coordinate paths and pattern transforms changed (legend/labels/colors/title/axes byte-identical), consistent with a pure reprojection and no unrelated regression.

</details>