### PR TITLE
Tag translated pageviews in Sentry

### DIFF
--- a/site/SiteAnalytics.ts
+++ b/site/SiteAnalytics.ts
@@ -1,4 +1,5 @@
 import * as _ from "lodash-es"
+import * as Sentry from "@sentry/react"
 import { GrapherAnalytics, splitPathForGA4 } from "@ourworldindata/grapher"
 import {
     EventCategory,
@@ -415,6 +416,14 @@ export class SiteAnalytics extends GrapherAnalytics {
 
             // eslint-disable-next-line no-console
             console.info("Browser translation detected", ctx)
+
+            // Deliberately sticky for the rest of the pageview: readers toggle
+            // translation back off again, but a page that was translated once
+            // keeps hitting reconciliation errors afterwards.
+            Sentry.setTag("page_translated", "true")
+            if (newLang && newLang !== initialLang) {
+                Sentry.setTag("page_translated_to", newLang)
+            }
 
             this.logBrowserTranslationEvent(ctx)
         }


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @marcelgerber at the wheel._

We detect browser translation but only report it to GA4, so translation isn't queryable in Sentry at all — confirming that an error came from a translated page currently means opening breadcrumbs one issue at a time.

This sets `page_translated` on the Sentry scope, plus `page_translated_to` for the target language, making translation filterable in the issue stream and usable in Discover and alerts. The tag is deliberately sticky for the rest of the pageview: readers toggle translation back off, but a page that was translated once keeps hitting errors afterwards, so "was translated at some point" is the signal worth keeping.

Nine lines in `site/SiteAnalytics.ts`, no behaviour change for readers.

<details><summary>Details</summary>

### Why this is useful

Translation is the cause of two distinct error populations in the `website` project, and neither is currently filterable:

1. `RangeError: Maximum call stack size exceeded.` on WebKit — fragmented across 20+ issue groups because the minified symbol names shift underneath it. Confirmed translation-induced by sampling breadcrumbs in 9 of 9 groups, where a `Browser translation detected` console entry fires 6 ms–1 s before every error.
2. A much larger flood — ~250k events / ~2,700 users per 30 days — of `removeChild:`/`insertBefore: Cannot ...` messages that `site/hacks.ts` reports itself, on every engine, concentrated on `/grapher/*` in desktop Chrome.

With this tag, both become one query instead of a manual breadcrumb crawl.

### Implementation notes

- Tags are set in `sendTranslationAnalyticsEvent`, alongside the existing `console.info` and GA4 call, so there's a single place where translation is observed.
- `page_translated_to` is only set when the new language differs from the document's initial `lang`, so reverting to English doesn't overwrite it with `"en"`.
- `Sentry.setTag` is safe before/without `Sentry.init` — it writes to the current scope and is a no-op if nothing is sent — so no guard is needed for `LOAD_SENTRY=false`.

### Follow-up this enables

Once the tag is live, the RangeError can be fingerprinted on it in `beforeSend` so translated-page overflows group together while genuine stack overflows stay in their own group. Fingerprinting only affects new events; the existing groups would need Sentry's merge action.

### History

This PR started as a diagnostic branch to unminify the bundle and read the crash's stack traces. That work is preserved on `translate-crash-probe` and is worth keeping around — the on-device probe there is what established that the recursion is **not in our code**: the frames claim lines 196–232 of `/poverty` and `/search`, but those pages are 81 and 38 lines respectively, `owid.mjs` appears nowhere in the stack, and the recursion runs 250+ pairs deep against a DOM only 19 levels deep. It's the webview's injected translate script re-entering itself, which is why no source map will ever resolve those frames. See the comments below for the full trail.

Only the Sentry tag remains here, since it stands on its own.

</details>