### PR TITLE
Lint against JSX text nodes that break under Google Translate

### DIFF
--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -148,6 +148,11 @@
         "import/no-named-as-default": "warn",
 
         "mobx/unconditional-make-observable": "error",
+        // Google Translate replaces text nodes with <font> wrappers, which
+        // breaks React when it later moves or removes a text node that has
+        // siblings (see site/hacks.ts)
+        "react-google-translate/no-conditional-text-nodes-with-siblings": "error",
+        "react-google-translate/no-return-text-nodes": "error",
 
         "react/display-name": "warn",
         "react/exhaustive-deps": "warn",
@@ -237,6 +242,7 @@
     },
     "jsPlugins": [
         "eslint-plugin-mobx",
+        "eslint-plugin-react-google-translate",
         { "name": "import-x-js", "specifier": "eslint-plugin-import-x" }
     ],
     "overrides": [
@@ -260,6 +266,14 @@
             "files": ["bespoke/**/vite.config.ts", "bespoke/vitest.config.ts"],
             "rules": {
                 "import-x-js/no-relative-packages": "off"
+            }
+        },
+        {
+            // the admin is an internal tool that nobody runs through Google Translate
+            "files": ["adminSiteClient/**/*", "adminSiteServer/**/*"],
+            "rules": {
+                "react-google-translate/no-conditional-text-nodes-with-siblings": "off",
+                "react-google-translate/no-return-text-nodes": "off"
             }
         },
         {

--- a/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
+++ b/bespoke/projects/demography/src/components/DemographyParameterEditor.tsx
@@ -1217,12 +1217,13 @@ function YAxisGridLines({
                             fontSize={fontSize}
                             fill={GRID_LABEL_COLOR}
                         >
-                            {Math.round(tick * displayScale * 100) / 100}
-                            {axisUnit === "%"
-                                ? "%"
-                                : tick === topTick
-                                  ? ` ${axisUnit}`
-                                  : ""}
+                            {`${Math.round(tick * displayScale * 100) / 100}${
+                                axisUnit === "%"
+                                    ? "%"
+                                    : tick === topTick
+                                      ? ` ${axisUnit}`
+                                      : ""
+                            }`}
                         </text>
                     )}
                 </g>

--- a/bespoke/projects/demography/src/components/SimulationContent.tsx
+++ b/bespoke/projects/demography/src/components/SimulationContent.tsx
@@ -504,9 +504,12 @@ function AssumptionsTable({ simulation }: { simulation: Simulation }) {
                     {visibleKeys.map((key) => {
                         return (
                             <th key={key}>
-                                {useShortTitles
-                                    ? parameterConfigByKey[key].extraShortTitle
-                                    : PARAMETER_TAB_LABELS[key]}
+                                <span>
+                                    {useShortTitles
+                                        ? parameterConfigByKey[key]
+                                              .extraShortTitle
+                                        : PARAMETER_TAB_LABELS[key]}
+                                </span>
                                 <span style={{ whiteSpace: "nowrap" }}>
                                     {"\u00a0"}
                                     <Tippy

--- a/bespoke/projects/food-trade/src/components/FoodTradeSplitSankey.tsx
+++ b/bespoke/projects/food-trade/src/components/FoodTradeSplitSankey.tsx
@@ -323,7 +323,7 @@ function getTradeLinkTooltip({
                 value={
                     <span>
                         {formatTrade(value)}
-                        {formattedShare && ` (${formattedShare})`}
+                        {formattedShare && <span> ({formattedShare})</span>}
                     </span>
                 }
             />
@@ -352,8 +352,7 @@ function OtherBreakdownContent({ breakdown }: { breakdown: EntityTotal[] }) {
             <TooltipTable columns={columns} rows={rows} />
             {hiddenCount > 0 && (
                 <div className="food-trade-sankey__tooltip-more">
-                    + {hiddenCount} more{" "}
-                    {hiddenCount === 1 ? "country" : "countries"}
+                    {`+ ${hiddenCount} more ${hiddenCount === 1 ? "country" : "countries"}`}
                 </div>
             )}
         </>

--- a/bespoke/projects/migration/src/components/MigrationSankey.tsx
+++ b/bespoke/projects/migration/src/components/MigrationSankey.tsx
@@ -422,7 +422,7 @@ function getMigrationLinkTooltip({
                 value={
                     <span>
                         {formatPeople(value)}
-                        {formattedShare && ` (${formattedShare})`}
+                        {formattedShare && <span> ({formattedShare})</span>}
                     </span>
                 }
             />
@@ -450,8 +450,7 @@ function OtherBreakdownContent({ breakdown }: { breakdown: EntityTotal[] }) {
             <TooltipTable columns={columns} rows={rows} />
             {hiddenCount > 0 && (
                 <div className="migration-sankey__tooltip-more">
-                    + {hiddenCount} more{" "}
-                    {hiddenCount === 1 ? "country" : "countries"}
+                    {`+ ${hiddenCount} more ${hiddenCount === 1 ? "country" : "countries"}`}
                 </div>
             )}
         </>

--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
         "eslint": "^10.0.3",
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-mobx": "^0.0.14",
+        "eslint-plugin-react-google-translate": "^1.0.4",
         "flag-icons": "^7.5.0",
         "happy-dom": "^20.8.9",
         "http-server": "^14.1.1",

--- a/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
+++ b/packages/@ourworldindata/components/src/IndicatorKeyData/IndicatorKeyData.tsx
@@ -39,9 +39,9 @@ export const makeSource = ({
                             {processingLevelPhrase}
                         </a>
                     ) : (
-                        processingLevelPhrase
+                        <span>{processingLevelPhrase}</span>
                     )}{" "}
-                    by Our World in Data
+                    <span>by Our World in Data</span>
                 </>
             )}
         </>

--- a/packages/@ourworldindata/components/src/NonRedistributableDataNotice/NonRedistributableDataNotice.tsx
+++ b/packages/@ourworldindata/components/src/NonRedistributableDataNotice/NonRedistributableDataNotice.tsx
@@ -12,11 +12,7 @@ export function NonRedistributableDataNotice({
             {sourceLinks && sourceLinks.length > 0 && (
                 <>
                     {" "}
-                    Please visit the
-                    {sourceLinks.length > 1
-                        ? " data publishers' websites "
-                        : " data publisher's website "}
-                    for more details:
+                    {`Please visit the ${sourceLinks.length > 1 ? "data publishers' websites" : "data publisher's website"} for more details:`}
                     <ul className={listClassName}>
                         {sourceLinks.map((link) => (
                             <li key={link}>

--- a/packages/@ourworldindata/explorer/src/Explorer.tsx
+++ b/packages/@ourworldindata/explorer/src/Explorer.tsx
@@ -1126,9 +1126,11 @@ export class Explorer
                 {showHeaderElement && this.renderHeaderElement()}
                 {showHeaderElement && this.renderControlBar()}
                 {showExplorerControls && this.renderEntityPicker()}
+                {/* oxlint-disable react-google-translate/no-conditional-text-nodes-with-siblings -- renders an element, not text */}
                 {showExplorerControls &&
                     this.isNarrow &&
                     this.mobileCustomizeButton}
+                {/* oxlint-enable react-google-translate/no-conditional-text-nodes-with-siblings */}
                 <div className="ExplorerFigure" ref={this.grapherContainerRef}>
                     <Grapher
                         ref={this.grapherRef}

--- a/packages/@ourworldindata/grapher/src/chart/StaticChartWrapper.tsx
+++ b/packages/@ourworldindata/grapher/src/chart/StaticChartWrapper.tsx
@@ -65,6 +65,7 @@ export class StaticChartWrapper extends React.Component<StaticChartWrapperProps>
                 height={height}
                 viewBox={`0 0 ${width} ${height}`}
             >
+                {/* oxlint-disable-next-line react-google-translate/no-conditional-text-nodes-with-siblings -- renders an element, not text */}
                 {includeFontsStyle && this.fonts}
                 <ChartPatternDefs />
                 {includeBackgroundRect && (

--- a/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
+++ b/packages/@ourworldindata/grapher/src/dataTable/DataTable.tsx
@@ -429,9 +429,11 @@ export class DataTable extends React.Component<DataTableProps> {
         ) : (
             <tr>
                 {this.entityHeader}
+                {/* oxlint-disable react-google-translate/no-conditional-text-nodes-with-siblings -- renders elements, not text */}
                 {hasSubheaders
                     ? this.dimensionSubheaders
                     : this.dimensionHeaders}
+                {/* oxlint-enable react-google-translate/no-conditional-text-nodes-with-siblings */}
             </tr>
         )
     }
@@ -610,8 +612,9 @@ export class DataTable extends React.Component<DataTableProps> {
                 {singleDimension.display.columnName.title}{" "}
                 <span className="title-fragments">
                     {titleFragments}
-                    {singleDimension.display.unit &&
-                        ` (${singleDimension.display.unit})`}
+                    {singleDimension.display.unit && (
+                        <span> ({singleDimension.display.unit})</span>
+                    )}
                 </span>
             </div>
         ) : null

--- a/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
+++ b/packages/@ourworldindata/grapher/src/entitySelector/EntitySelector.tsx
@@ -1543,8 +1543,9 @@ export class EntitySelector extends React.Component<EntitySelectorProps> {
                             <div className="entity-section__header">
                                 <div className="entity-section__title grapher_body-3-regular-italic grapher_light">
                                     Selection{" "}
-                                    {numSelectedEntities > 0 &&
-                                        `(${numSelectedEntities})`}
+                                    {numSelectedEntities > 0 && (
+                                        <span>({numSelectedEntities})</span>
+                                    )}
                                 </div>
                                 <button type="button" onClick={this.onClear}>
                                     Clear

--- a/packages/@ourworldindata/grapher/src/footer/Footer.tsx
+++ b/packages/@ourworldindata/grapher/src/footer/Footer.tsx
@@ -755,10 +755,14 @@ abstract class AbstractFooter<
                                     more information about how you may use,
                                     share, and adapt this material.
                                 </>
-                            )}{" "}
-                            Please bear in mind that the underlying source data
-                            for all our charts might be subject to different
-                            license terms from third-party authors.
+                            )}
+                            <span>
+                                {" "}
+                                Please bear in mind that the underlying source
+                                data for all our charts might be subject to
+                                different license terms from third-party
+                                authors.
+                            </span>
                         </p>
                     </Tooltip>
                 )}

--- a/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
+++ b/packages/@ourworldindata/grapher/src/modal/DownloadModal.tsx
@@ -582,6 +582,9 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
         </>
     ) : undefined
 
+    const providerPossessive =
+        sourceLinks.length === 1 ? "provider's" : "providers'"
+
     return (
         <div className="download-modal__data-section download-modal__sources">
             <h3 className="grapher_h3-semibold">Source and citation</h3>
@@ -598,8 +601,7 @@ const SourceAndCitationSection = ({ table }: { table?: OwidTable }) => {
                 <strong>Citation guidance:</strong> Please credit all sources
                 listed above. Data provided by third-party sources through Our
                 World in Data remains subject to the original{" "}
-                {sourceLinks.length === 1 ? "provider's" : "providers'"} license
-                terms.
+                {providerPossessive} license terms.
             </div>
         </div>
     )

--- a/packages/@ourworldindata/grapher/src/scatterCharts/NoDataSection.tsx
+++ b/packages/@ourworldindata/grapher/src/scatterCharts/NoDataSection.tsx
@@ -47,7 +47,7 @@ export function NoDataSection({
                         ))}
                     </ul>
                     {remaining > 0 && (
-                        <div>& {remaining === 1 ? "one" : remaining} more</div>
+                        <div>{`& ${remaining === 1 ? "one" : remaining} more`}</div>
                     )}
                 </div>
             </foreignObject>

--- a/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
+++ b/packages/@ourworldindata/grapher/src/stackedCharts/StackedAreaChart.tsx
@@ -617,6 +617,7 @@ export class StackedAreaChart
                     onMouseEnter={this.onAreaMouseEnter}
                     onMouseLeave={this.onAreaMouseLeave}
                 />
+                {/* oxlint-disable-next-line react-google-translate/no-conditional-text-nodes-with-siblings -- renders an element, not text */}
                 {this.isTooltipActive && this.activeXVerticalLine}
                 {this.tooltip}
             </g>

--- a/site/gdocs/components/Byline.tsx
+++ b/site/gdocs/components/Byline.tsx
@@ -20,8 +20,10 @@ export const Byline = ({
                     <Fragment key={name}>
                         <LinkedAuthor name={name} role={authorRoles?.[name]} />
                         {/* Use Oxford comma when there are more than two authors. */}
-                        {!isLast && names.length > 2 && ", "}
-                        {isSecondToLast && names.length > 1 && " and "}
+                        {!isLast && names.length > 2 && <span>{", "}</span>}
+                        {isSecondToLast && names.length > 1 && (
+                            <span>{" and "}</span>
+                        )}
                     </Fragment>
                 )
             })}

--- a/site/gdocs/components/Cta.tsx
+++ b/site/gdocs/components/Cta.tsx
@@ -18,7 +18,11 @@ export function Cta(props: {
     }
     return (
         <div className={cx(props.className, "cta")}>
-            {props.shouldRenderLinks ? <LinkedA span={asSpan} /> : props.text}
+            {props.shouldRenderLinks ? (
+                <LinkedA span={asSpan} />
+            ) : (
+                <span>{props.text}</span>
+            )}
             <FontAwesomeIcon icon={faArrowRight} />
         </div>
     )

--- a/site/gdocs/components/LinkedAuthor.tsx
+++ b/site/gdocs/components/LinkedAuthor.tsx
@@ -43,7 +43,7 @@ export default function LinkedAuthor({
                 {image}
                 {author.name}
             </a>
-            {displayRole && ` (${displayRole})`}
+            {displayRole && <span> ({displayRole})</span>}
         </span>
     )
 }

--- a/site/gdocs/pages/Profile.tsx
+++ b/site/gdocs/pages/Profile.tsx
@@ -63,9 +63,11 @@ export function Profile({ content, publishedAt, slug, tags }: ProfileProps) {
                         )}
                         <span className="profile-title__label h5-black-caps">
                             {instantiatedEntity?.name}{" "}
-                            {instantiatedEntity?.isCountry
-                                ? "Country Profile"
-                                : "Region Profile"}
+                            <span>
+                                {instantiatedEntity?.isCountry
+                                    ? "Country Profile"
+                                    : "Region Profile"}
+                            </span>
                         </span>
                     </div>
                     <h1 className="display-2-semibold">{content.title}</h1>

--- a/site/search/SearchChartHitDataTable.tsx
+++ b/site/search/SearchChartHitDataTable.tsx
@@ -142,8 +142,7 @@ function Row({
                         </span>
                         {row.time && (
                             <span className="search-chart-hit-table-row__time">
-                                {" "}
-                                {row.timePreposition ?? "in"} {row.time}
+                                {` ${row.timePreposition ?? "in"} ${row.time}`}
                             </span>
                         )}
                     </span>

--- a/site/search/SearchChartHitHeader.tsx
+++ b/site/search/SearchChartHitHeader.tsx
@@ -89,7 +89,7 @@ function SearchChartHitSubtitle({
                 </span>
             )}
             {/* Separator only when a subtitle follows the variant */}
-            {hit.titleVariant && hasSubtitle ? " – " : null}
+            {hit.titleVariant && hasSubtitle ? <span> – </span> : null}
             {shouldUseFreshSubtitle ? (
                 subtitle
             ) : hit.subtitle ? (

--- a/site/search/SearchDataTopic.tsx
+++ b/site/search/SearchDataTopic.tsx
@@ -56,8 +56,7 @@ export const SearchDataTopic = ({
                 <div className="search-data-topic__header">
                     <h2>{titleLabel}</h2>
                     <span className="search-data-topic__hit-count">
-                        {commafyNumber(charts.nbHits ?? 0)}{" "}
-                        {charts.nbHits === 1 ? "chart" : "charts"}
+                        {`${commafyNumber(charts.nbHits ?? 0)} ${charts.nbHits === 1 ? "chart" : "charts"}`}
                         <FontAwesomeIcon icon={faArrowRight} />
                     </span>
                 </div>

--- a/site/search/SearchResultHeader.tsx
+++ b/site/search/SearchResultHeader.tsx
@@ -11,7 +11,7 @@ export const SearchResultHeader = ({
         <div className="search-result-header">
             <h2 className="search-result-header__title">{children}</h2>
             <span className="search-result-header__count">
-                ({commafyNumber(count)} {count === 1 ? "result" : "results"})
+                {`(${commafyNumber(count)} ${count === 1 ? "result" : "results"})`}
             </span>
         </div>
     )

--- a/site/search/SearchTopicsRefinementList.tsx
+++ b/site/search/SearchTopicsRefinementList.tsx
@@ -28,11 +28,7 @@ export const SearchTopicsRefinementList = ({
     return selectableTopics.length > 0 && !query ? (
         <div className="search-topics-refinement-list">
             <h3 className="search-topics-refinement-list__heading h5-black-caps">
-                Filter by{" "}
-                {topicType === SearchTopicType.Area
-                    ? "topic"
-                    : "area of research"}
-                :
+                {`Filter by ${topicType === SearchTopicType.Area ? "topic" : "area of research"}:`}
             </h3>
             <button
                 aria-expanded={isExpanded}

--- a/site/slideshows/SlideshowPresentation.tsx
+++ b/site/slideshows/SlideshowPresentation.tsx
@@ -321,8 +321,10 @@ function AuthorByline(props: {
                         ) : (
                             <span>{name}</span>
                         )}
-                        {!isLast && names.length > 2 && ", "}
-                        {isSecondToLast && names.length > 1 && " and "}
+                        {!isLast && names.length > 2 && <span>{", "}</span>}
+                        {isSecondToLast && names.length > 1 && (
+                            <span>{" and "}</span>
+                        )}
                     </React.Fragment>
                 )
             })}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,14 +1603,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.8.0":
-  version: 4.9.1
-  resolution: "@eslint-community/eslint-utils@npm:4.9.1"
+"@eslint-community/eslint-utils@npm:^4.8.0, @eslint-community/eslint-utils@npm:^4.9.1":
+  version: 4.10.1
+  resolution: "@eslint-community/eslint-utils@npm:4.10.1"
   dependencies:
     eslint-visitor-keys: "npm:^3.4.3"
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-  checksum: 10/863b5467868551c9ae34d03eefe634633d08f623fc7b19d860f8f26eb6f303c1a5934253124163bee96181e45ed22bf27473dccc295937c3078493a4a8c9eddd
+  checksum: 10/61059b9f0192df5a86c441c03e0eedbda8c3810bb788775839afe4c5ec6bbdaa6433ac18001046b319390552435da3f6b8f5e18cca255993b3df37fe97a42b90
   languageName: node
   linkType: hard
 
@@ -5752,10 +5752,86 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:^8.56.0":
-  version: 8.57.0
-  resolution: "@typescript-eslint/types@npm:8.57.0"
-  checksum: 10/ba23a4deeb5a89b9b99fee35f58d662901f236000d0f6bcada5143a2ef5ec831c7909e9192def8a48d18f8c3327b78bf3e9c02d770b4a4d721a0422b97ca1e29
+"@typescript-eslint/project-service@npm:8.69.0":
+  version: 8.69.0
+  resolution: "@typescript-eslint/project-service@npm:8.69.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.69.0"
+    "@typescript-eslint/types": "npm:^8.69.0"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/55a07db29e9b5fac47c437913c5fad1857abbaa3204446abba0754eb0ab8515f74dda8358ba1f9a1a7d7ee3af9af328f7ac709ecba7b64e3476b5c7d90529309
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:8.69.0":
+  version: 8.69.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.69.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.69.0"
+    "@typescript-eslint/visitor-keys": "npm:8.69.0"
+  checksum: 10/6eafb382ad54848a796fe6ba6e29ff0f5db246d459a5c30a04a2144e3005d0ed0ee08e83abf2b943614ef02cc7f78358a722f028c87fbbee3a736a099b5b8bf1
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.69.0, @typescript-eslint/tsconfig-utils@npm:^8.69.0":
+  version: 8.69.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.69.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/e180d2c88ae043f2099fc0ef0cbb4ab3b839b24df33d1f30c473aaccadec367584762ba6553e41377beb2df7504c4e2b82c97e9b00f013b066c835de80d5e66d
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.69.0, @typescript-eslint/types@npm:^8.56.0, @typescript-eslint/types@npm:^8.69.0":
+  version: 8.69.0
+  resolution: "@typescript-eslint/types@npm:8.69.0"
+  checksum: 10/5a2c44249c8973b83e3cebfd6e968f545e1507e1b0dbf9f3bd672e6bad2f1d58167fa3d9af03fdd2df986cd19ad1aa9ce9fccc9504d25e068080d6e2b7471145
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.69.0":
+  version: 8.69.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.69.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.69.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.69.0"
+    "@typescript-eslint/types": "npm:8.69.0"
+    "@typescript-eslint/visitor-keys": "npm:8.69.0"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/5859a19c78abb689265fbb9a435def29ec6e50777b75729164fd3a65a668999d6708dfd5e27c871773ba33a405f820654c9dfda16f485a89413db059d048a2d7
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^8.54.0":
+  version: 8.69.0
+  resolution: "@typescript-eslint/utils@npm:8.69.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.69.0"
+    "@typescript-eslint/types": "npm:8.69.0"
+    "@typescript-eslint/typescript-estree": "npm:8.69.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10/6724b25b933dfd90437eb2747aae9448e312caabe949b7b7a9cfbee8b1554fef3e2db20162667f9379903bcc2faab5d77c7a0efa3eab9a5d857b76ae67a6b88f
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.69.0":
+  version: 8.69.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.69.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.69.0"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10/15096ea595db6c7571f2a2d6e20e55ff82409cd046af51bb7b9f9ac9fe74dba2fccc707c7a34040a028e126afc65ab3ee77f964a7cd4a0ffa26e9ceb17851b28
   languageName: node
   linkType: hard
 
@@ -8556,6 +8632,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-react-google-translate@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "eslint-plugin-react-google-translate@npm:1.0.4"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.54.0"
+  peerDependencies:
+    eslint: ">=8"
+  checksum: 10/6262e8fd4948101b4ef6919aa0c7d5e249134ad9572f66d08553498860204e35b543144d75a275cb970ca73441434497aaa19007793facc9cb7b6bb206d8623d
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^9.1.2":
   version: 9.1.2
   resolution: "eslint-scope@npm:9.1.2"
@@ -8575,7 +8662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^5.0.1":
+"eslint-visitor-keys@npm:^5.0.0, eslint-visitor-keys@npm:^5.0.1":
   version: 5.0.1
   resolution: "eslint-visitor-keys@npm:5.0.1"
   checksum: 10/f9cc1a57b75e0ef949545cac33d01e8367e302de4c1483266ed4d8646ee5c306376660196bbb38b004e767b7043d1e661cb4336b49eff634a1bbe75c1db709ec
@@ -9346,6 +9433,7 @@ __metadata:
     eslint: "npm:^10.0.3"
     eslint-plugin-import-x: "npm:^4.16.2"
     eslint-plugin-mobx: "npm:^0.0.14"
+    eslint-plugin-react-google-translate: "npm:^1.0.4"
     express: "npm:^5.2.1"
     figma-api: "npm:^2.2.1-beta"
     filenamify: "npm:^7.0.1"
@@ -13341,7 +13429,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.8.4":
+"semver@npm:^7.3.5, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.8.4":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -14016,7 +14104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:0.2.17, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.17":
+"tinyglobby@npm:0.2.17, tinyglobby@npm:^0.2.12, tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17":
   version: 0.2.17
   resolution: "tinyglobby@npm:0.2.17"
   dependencies:
@@ -14130,6 +14218,15 @@ __metadata:
   version: 2.2.0
   resolution: "trough@npm:2.2.0"
   checksum: 10/999c1cb3db6ec63e1663f911146a90125065da37f66ba342b031d53edb22a62f56c1f934bbc61a55b2b29dd74207544cfd78875b414665c1ffadcd9a9a009eeb
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^2.5.0":
+  version: 2.5.0
+  resolution: "ts-api-utils@npm:2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4"
+  checksum: 10/d5f1936f5618c6ab6942a97b78802217540ced00e7501862ae1f578d9a3aa189fc06050e64cb8951d21f7088e5fd35f53d2bf0d0370a883861c7b05e993ebc44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @marcelgerber at the wheel._

Chrome's built-in translation replaces every text node with a `<font>` wrapper and detaches the original. React keeps pointing at the detached node, so the next time it removes or inserts a *conditional* text node that has siblings, the DOM throws ([facebook/react#11538](https://github.com/facebook/react/issues/11538), still open). Our `site/hacks.ts` patch turns the crash into a silent no-op, which is why translated readers see stale or missing text instead of a blank page.

This PR catches the risky JSX shape at lint time via [`eslint-plugin-react-google-translate`](https://github.com/getcouped/eslint-plugin-react-google-translate), loaded as an oxlint JS plugin like `eslint-plugin-mobx`, and fixes the 45 existing occurrences in public-facing code.

Things to look at:

- **The admin is exempt** (`adminSiteClient/`, `adminSiteServer/`). It's internal and held 46 of the 91 hits; exempting it avoids churn for no reader benefit. Happy to include it if you'd rather have one rule everywhere.
- **Four `oxlint-disable` comments** for MobX getters that return elements (`this.fonts`, `this.dimensionHeaders`, `this.activeXVerticalLine`, `this.mobileCustomizeButton`). Without type information the plugin treats any member expression as text.
- **Fix style**: where an element's whole content is text, it's collapsed into one template literal (one text node, no siblings). Where text mixes with elements, the conditional text gets a `<span>`. None of the touched containers use flex gaps or child selectors, so layout is unchanged.

<details><summary>Details</summary>

**Config** (`.oxlintrc.jsonc`): plugin added to `jsPlugins`; both rules on as `error` (`no-conditional-text-nodes-with-siblings`, `no-return-text-nodes`); override turning both off for the admin.

**Plugin coverage under oxlint**: runs in pattern-matching mode (no typescript-eslint parser services), so it flags literals, template literals, member expressions and `toString`/`toLocaleString` calls in conditionals with siblings, plus static JSX text preceded by a conditional. It does not see typed identifiers or arbitrary function calls returning strings. `no-return-text-nodes` only inspects capitalised `function` declarations and had zero hits.

**Files changed** (24 code files):

- Template-literal collapse: `NonRedistributableDataNotice`, `NoDataSection`, `SearchDataTopic`, `SearchResultHeader`, `SearchTopicsRefinementList`, `SearchChartHitDataTable`, both Sankey tooltips, `DemographyParameterEditor` (SVG `<text>`, so a span wasn't an option).
- `<span>` wrap: `IndicatorKeyData`, `DataTable` unit suffix, `EntitySelector` count, `Footer` license tooltip, `Byline`, `SlideshowPresentation` byline, `Cta`, `LinkedAuthor`, `Profile`, `SearchChartHitHeader` separator, `SimulationContent` table header.
- `DownloadModal`: hoisted the possessive into a `const`; a non-conditional text expression can only go stale, not crash.
- Disables: `Explorer`, `StaticChartWrapper`, `DataTable` header row, `StackedAreaChart`.

**Verification**: `yarn testLint` (whole repo, `--deny-warnings`) and `yarn typecheck` pass; unit tests for DataTable, LinkedAuthor, Explorer, StackedAreaChart pass (48); `make svgtest` 4294 graphers, no differences.

**Not in this PR**: making `site/hacks.ts` redirect writes into the `<font>` wrapper instead of dropping them, and suppressing the Sentry noise from the expected translated case.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
