### PR TITLE
Add agent evals for the text an agent reads from chart pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ packageDocs/docs/schema-reference/
 packageDocs/site/
 packageDocs/.venv/
 packageDocs/.cache/
+
+# agent eval runs (inputs are committed, outputs are not)
+devTools/agentEvals/results/

--- a/devTools/agentEvals/README.md
+++ b/devTools/agentEvals/README.md
@@ -1,0 +1,116 @@
+# Agent evals: can an agent answer from our chart pages?
+
+Measures whether the text an agent gets from a `/grapher/<slug>` page lets it
+answer factual questions about the chart. Built to judge
+[#7224](https://github.com/owid/owid-grapher/pull/7224), which adds
+`/grapher/<slug>.md`, and reusable for anything else that changes what a
+non-JavaScript reader sees (llms.txt, page markdown, WebMCP text).
+
+Two layers, cheapest first:
+
+| Layer | Question | Model? | Script |
+| --- | --- | --- | --- |
+| 0. Value check | Does every number printed in the markdown match the chart's CSV? | no | `checkMarkdownValues.ts` |
+| 1. Document QA | Given the page text, does an agent answer correctly, and does it stop guessing? | yes | `buildCases.ts` → `runDocQa.ts` → `buildReport.ts` |
+
+Everything runs from the repo root with `yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/<script>`.
+
+## Conditions
+
+The same question is asked under three renderings of the same URL:
+
+- **today**: the production page fetched with `Accept: text/markdown`, which is Cloudflare's HTML→markdown conversion. This is what a crawler or LLM agent that does not run JavaScript reads now: description, sources, FAQ, but no numbers.
+- **pr**: `/grapher/<slug>.md` from the PR branch's staging server (`staging-site-<prBranch>` in `charts.json`).
+- **none**: no page at all. A control that shows how much of a correct answer comes from the model's memory rather than the page. It also shows what an agent does when the page is useless: guess, or say so.
+
+The agent is `claude -p` with no tools; the page is handed over in the user
+message as "the content I fetched", and the answer comes back as structured
+JSON (`answer_number`, `answer_entity`, `answer_text`, `found_in_page`,
+`evidence`). It runs on the developer's Claude subscription, so no API key is
+needed; the reported cost is what the calls would cost on the API.
+
+## Cases
+
+`buildCases.ts` derives ~110 questions from the views in `charts.json`, all
+with gold answers taken from the CSV and metadata endpoints, never from the
+markdown under test. Per chart view:
+
+| Type | Asks for | Answerable from the PR markdown via |
+| --- | --- | --- |
+| `point-latest` ×2 | a random country's value at its latest year | the per-entity table |
+| `point-selected` | a default-selected entity at the view's end year | either table |
+| `point-start` | the first selected entity at the view's start year | the selected-values table |
+| `change` | end minus start for that entity | the selected-values table |
+| `rank-max` / `rank-min` | the country with the highest / lowest value | the per-entity table |
+| `unanswerable-early` | a value for a year before the entity's data starts | nothing: the right answer is to decline |
+| `unanswerable-late` | a value for the view's end year from a country whose data stops earlier | nothing: the right answer is to decline |
+| `meta-unit` / `meta-source` | the unit and the data producers | the prose, present in both renderings |
+
+Sampling is seeded per chart, so re-running on unchanged data reproduces the
+set. `cases.json` is committed and is the thing to review: read the questions,
+and check a few gold values against the chart.
+
+## Grading
+
+Programmatic, no judge model:
+
+- **correct**: numbers within 1% of gold (plus a rounding allowance for
+  `change`), an accepted entity name for rankings, the unit or any producer
+  name for meta questions, and for unanswerable cases: no number given.
+- **from page**: correct, and the `evidence` the agent quoted occurs in the
+  page text. Separates "read it off the page" from "knew it anyway".
+- **hallucinated**: gave a specific wrong answer, or gave a number where the
+  page has none.
+- **abstained**: gave no number or entity.
+
+`buildReport.ts` recomputes grades from the stored answers, so a grader fix
+never requires re-running the model.
+
+## Running
+
+```sh
+# 0. Cheap and deterministic: compare every printed value to the CSV
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/checkMarkdownValues.ts --verbose
+
+# 1. Regenerate cases (only when charts.json or the data changed)
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/buildCases.ts
+
+# 2. Run: pilot on two charts, then everything
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runDocQa.ts --name pilot --model sonnet --filter '^(life-expectancy|population)/'
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runDocQa.ts --name sonnet-full --model sonnet --concurrency 3
+
+# 3. Report (opens in Chrome)
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/buildReport.ts --run sonnet-full
+```
+
+Useful flags on `runDocQa.ts`: `--conditions today,pr`, `--model haiku|sonnet|opus`,
+`--effort low`, `--reps 2`, `--filter '<regex over case ids>'`, `--limit N`,
+`--refresh-docs` (re-download the page snapshots).
+
+A run is resumable: results are appended per `(case, condition, rep)` as they
+complete, and restarting skips what is already there. Failed calls (timeouts,
+API errors) go to `errors.jsonl`, never into the scores. Keep `--concurrency`
+at 3 or so on a laptop that already runs other Claude sessions; each call is a
+separate `claude` process.
+
+## Layout
+
+```
+charts.json          chart views under test + the PR branch whose staging serves them
+cases.json           generated questions with gold (committed; review this)
+lib/                 fetching, CSV/markdown parsing, number parsing, view loading
+results/             gitignored: inputs/ (CSV + metadata snapshots), docs/ (page snapshots per condition), runs/<name>/, check/
+```
+
+## Caveats
+
+- The `today` snapshot comes from production and the `pr` snapshot and gold
+  from staging. `checkMarkdownValues.ts` reports `csv-parity` when the two
+  CSVs differ; treat cases on such charts with care.
+- Questions are template-generated, not real user questions. They cover the
+  lookups the PR's markdown is designed to answer; they say nothing about
+  discovery (will an agent find `.md` at all?) or about prose-only content
+  such as key insights, which the PR markdown does not carry.
+- One rep per case gives a noise floor of roughly ±10 points on a pass rate
+  at n ≈ 110. Paired differences between conditions on the same cases are
+  much tighter; the report gives bootstrap intervals for those.

--- a/devTools/agentEvals/README.md
+++ b/devTools/agentEvals/README.md
@@ -8,10 +8,10 @@ non-JavaScript reader sees (llms.txt, page markdown, WebMCP text).
 
 Two layers, cheapest first:
 
-| Layer | Question | Model? | Script |
-| --- | --- | --- | --- |
-| 0. Value check | Does every number printed in the markdown match the chart's CSV? | no | `checkMarkdownValues.ts` |
-| 1. Document QA | Given the page text, does an agent answer correctly, and does it stop guessing? | yes | `buildCases.ts` → `runDocQa.ts` → `buildReport.ts` |
+| Layer          | Question                                                                        | Model? | Script                                             |
+| -------------- | ------------------------------------------------------------------------------- | ------ | -------------------------------------------------- |
+| 0. Value check | Does every number printed in the markdown match the chart's CSV?                | no     | `checkMarkdownValues.ts`                           |
+| 1. Document QA | Given the page text, does an agent answer correctly, and does it stop guessing? | yes    | `buildCases.ts` → `runDocQa.ts` → `buildReport.ts` |
 
 Everything runs from the repo root with `yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/<script>`.
 
@@ -35,16 +35,16 @@ needed; the reported cost is what the calls would cost on the API.
 with gold answers taken from the CSV and metadata endpoints, never from the
 markdown under test. Per chart view:
 
-| Type | Asks for | Answerable from the PR markdown via |
-| --- | --- | --- |
-| `point-latest` ×2 | a random country's value at its latest year | the per-entity table |
-| `point-selected` | a default-selected entity at the view's end year | either table |
-| `point-start` | the first selected entity at the view's start year | the selected-values table |
-| `change` | end minus start for that entity | the selected-values table |
-| `rank-max` / `rank-min` | the country with the highest / lowest value | the per-entity table |
-| `unanswerable-early` | a value for a year before the entity's data starts | nothing: the right answer is to decline |
-| `unanswerable-late` | a value for the view's end year from a country whose data stops earlier | nothing: the right answer is to decline |
-| `meta-unit` / `meta-source` | the unit and the data producers | the prose, present in both renderings |
+| Type                        | Asks for                                                                | Answerable from the PR markdown via     |
+| --------------------------- | ----------------------------------------------------------------------- | --------------------------------------- |
+| `point-latest` ×2           | a random country's value at its latest year                             | the per-entity table                    |
+| `point-selected`            | a default-selected entity at the view's end year                        | either table                            |
+| `point-start`               | the first selected entity at the view's start year                      | the selected-values table               |
+| `change`                    | end minus start for that entity                                         | the selected-values table               |
+| `rank-max` / `rank-min`     | the country with the highest / lowest value                             | the per-entity table                    |
+| `unanswerable-early`        | a value for a year before the entity's data starts                      | nothing: the right answer is to decline |
+| `unanswerable-late`         | a value for the view's end year from a country whose data stops earlier | nothing: the right answer is to decline |
+| `meta-unit` / `meta-source` | the unit and the data producers                                         | the prose, present in both renderings   |
 
 Sampling is seeded per chart, so re-running on unchanged data reproduces the
 set. `cases.json` is committed and is the thing to review: read the questions,
@@ -114,3 +114,35 @@ results/             gitignored: inputs/ (CSV + metadata snapshots), docs/ (page
 - One rep per case gives a noise floor of roughly ±10 points on a pass rate
   at n ≈ 110. Paired differences between conditions on the same cases are
   much tighter; the report gives bootstrap intervals for those.
+
+## Agents with tools, and the open web
+
+Two extensions to the same runner, both cheap enough to run on a handful of
+cases and both meant for reading transcripts rather than computing rates:
+
+- **`+tools` conditions** (`--conditions today+tools,pr+tools`): the agent gets
+  Claude Code's default tools and may follow the page's links. Rows gain
+  `tool_calls`, `num_turns` and whether the evidence came from a tool result.
+  A `custom` page condition reads `results/docs/custom/<chart>.md`, a
+  hand-edited snapshot, for wording experiments ("does documenting the query
+  grammar change how the agent fetches?").
+- **`runOpenWeb.ts`**: generic questions with no mention of Our World in Data
+  and no URL; the agent (`--agent claude` or `--agent gemini`, the latter via
+  Gemini CLI with `GOOGLE_API_KEY`) has web search and fetch and must name its
+  source. Records searches, fetched domains, the cited source and whether the
+  number matches our CSV. Both agents run with a private home directory and
+  `--setting-sources project`, so none of the developer's skills, memory files
+  or hooks are in play; an early run without that had the OWID skills loaded,
+  which changed where the agent went.
+
+```sh
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runDocQa.ts --name tools --conditions 'today+tools' --filter 'life-expectancy/(point-latest-1|rank-max-1)'
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runOpenWeb.ts --name open-web
+yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runOpenWeb.ts --agent gemini --model gemini-3.8-flash --name open-web-gemini
+```
+
+Fetcher behaviour worth knowing when interpreting results: Claude Code's
+`WebFetch` sends `Accept: text/markdown, text/html, */*`; Gemini CLI's
+`web_fetch` and `curl` send `*/*`. So the "today" condition (Cloudflare's
+markdown conversion of the HTML) is what Claude-class fetchers actually read
+from a chart page, while Gemini-class fetchers read the HTML.

--- a/devTools/agentEvals/buildCases.ts
+++ b/devTools/agentEvals/buildCases.ts
@@ -1,0 +1,405 @@
+#!/usr/bin/env tsx
+/**
+ * Generate the question set for the document-QA eval from the charts in
+ * charts.json. Every gold answer is derived from the chart's CSV and metadata
+ * endpoints, never from the markdown under test, and the sampling is seeded so
+ * re-running on unchanged data reproduces the same cases.
+ *
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/buildCases.ts
+ */
+import fs from "fs"
+import path from "path"
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import { EVALS_DIR, loadCharts, prodPageUrl } from "./lib/charts.js"
+import { Random, hashString } from "./lib/random.js"
+import { ChartView, loadView, sourceNames } from "./lib/view.js"
+
+export type CaseType =
+    | "point-latest"
+    | "point-selected"
+    | "point-start"
+    | "change"
+    | "rank-max"
+    | "rank-min"
+    | "unanswerable-early"
+    | "unanswerable-late"
+    | "meta-unit"
+    | "meta-source"
+
+export interface Gold {
+    kind: "number" | "entity" | "none" | "unit" | "sources"
+    number?: number
+    relTol?: number
+    absTol?: number
+    /** Accepted entity names (ties, or two defensible readings of "latest"). */
+    entities?: string[]
+    unitTokens?: string[]
+    sources?: string[]
+}
+
+export interface EvalCase {
+    id: string
+    chart: string
+    url: string
+    type: CaseType
+    question: string
+    gold: Gold
+    tags: string[]
+    meta: Record<string, unknown>
+}
+
+const REL_TOL = 0.01
+
+function describeYear(year: number): string {
+    return year < 0 ? `the year ${year} (${-year} BCE)` : String(year)
+}
+
+function indicator(
+    view: ChartView,
+    column: string,
+    { article = true } = {}
+): string {
+    const title = view.meta.columns[column]?.titleShort ?? column
+    if (view.columns.length > 1) return `"${title}"`
+    return article ? `the ${lowerFirst(title)}` : lowerFirst(title)
+}
+
+/**
+ * Values far below the column's typical magnitude print as "0" or "<0.01" on
+ * the page, so no reader could recover them; exact zeros are fine.
+ */
+function isRepresentable(
+    view: ChartView,
+    column: string,
+    year: number,
+    value: number
+): boolean {
+    if (value === 0) return true
+    const magnitudes = view.full
+        .countries()
+        .map((e) => view.full.valueAt(e, column, year))
+        .filter((v): v is number => v !== undefined && v !== 0)
+        .map(Math.abs)
+        .sort((a, b) => a - b)
+    const median = magnitudes[Math.floor(magnitudes.length / 2)] ?? 0
+    return Math.abs(value) >= 0.01 * median
+}
+
+function lowerFirst(s: string): string {
+    // Keep acronyms ("GDP per capita") intact.
+    return /^[A-Z][a-z]/.test(s) ? s[0].toLowerCase() + s.slice(1) : s
+}
+
+function unitHint(view: ChartView, column: string): string {
+    const unit = view.meta.columns[column]?.unit?.trim()
+    return unit ? ` Give the number in ${unit}.` : ""
+}
+
+function pointQuestion(
+    view: ChartView,
+    column: string,
+    entity: string,
+    year: number
+): string {
+    return (
+        `According to this chart, what was ${indicator(view, column)} for ${entity} in ${describeYear(year)}?` +
+        unitHint(view, column)
+    )
+}
+
+function numberGold(value: number, absTol = 0): Gold {
+    return { kind: "number", number: value, relTol: REL_TOL, absTol }
+}
+
+function unitTokens(unit: string, shortUnit: string): string[] {
+    const tokens = unit
+        .toLowerCase()
+        .split(/[^a-z0-9$%]+/)
+        .filter((t) => t.length >= 3 || t === "$" || t === "%")
+    if (shortUnit.trim()) tokens.push(shortUnit.trim().toLowerCase())
+    return [...new Set(tokens)]
+}
+
+function buildCasesForView(view: ChartView): EvalCase[] {
+    const rng = new Random(hashString(view.spec.key))
+    const cases: EvalCase[] = []
+    const url = prodPageUrl(view.spec)
+    const { full, selection, viewStart, viewEnd } = view
+    const counters = new Map<CaseType, number>()
+
+    const add = (
+        type: CaseType,
+        question: string,
+        gold: Gold,
+        meta: Record<string, unknown>
+    ): void => {
+        const n = (counters.get(type) ?? 0) + 1
+        counters.set(type, n)
+        cases.push({
+            id: `${view.spec.key}/${type}-${n}`,
+            chart: view.spec.key,
+            url,
+            type,
+            question,
+            gold,
+            tags: [type, view.spec.key],
+            meta,
+        })
+    }
+
+    if (view.columns.length === 0 || viewEnd === undefined) return cases
+    const randomColumn = (): string => rng.pick(view.columns)!
+    const usedEntities = new Set<string>()
+
+    // point-latest: two countries at their own latest year at or before the view's end.
+    {
+        const column = randomColumn()
+        const candidates = full.countries().filter((e) => {
+            const obs = full.latest(e, column, viewEnd)
+            return (
+                obs !== undefined &&
+                isRepresentable(view, column, obs.year, obs.value)
+            )
+        })
+        for (const entity of rng.sample(candidates, 2)) {
+            const obs = full.latest(entity, column, viewEnd)!
+            usedEntities.add(entity)
+            add(
+                "point-latest",
+                pointQuestion(view, column, entity, obs.year),
+                numberGold(obs.value),
+                { column, entity, year: obs.year }
+            )
+        }
+    }
+
+    // point-selected: a default-selected entity at the view's end year.
+    {
+        const column = randomColumn()
+        const candidates = selection.filter(
+            (e) => full.valueAt(e, column, viewEnd) !== undefined
+        )
+        const entity = rng.pick(
+            candidates.length > 1 ? candidates.slice(1) : candidates
+        )
+        if (entity) {
+            usedEntities.add(entity)
+            add(
+                "point-selected",
+                pointQuestion(view, column, entity, viewEnd),
+                numberGold(full.valueAt(entity, column, viewEnd)!),
+                { column, entity, year: viewEnd }
+            )
+        }
+    }
+
+    // point-start and change: the first selected entity across the view's time range.
+    if (viewStart !== undefined && viewStart !== viewEnd) {
+        const column = randomColumn()
+        const entity = selection.find(
+            (e) =>
+                full.valueAt(e, column, viewStart) !== undefined &&
+                full.valueAt(e, column, viewEnd) !== undefined
+        )
+        if (entity) {
+            const v0 = full.valueAt(entity, column, viewStart)!
+            const v1 = full.valueAt(entity, column, viewEnd)!
+            add(
+                "point-start",
+                pointQuestion(view, column, entity, viewStart),
+                numberGold(v0),
+                { column, entity, year: viewStart }
+            )
+            add(
+                "change",
+                `According to this chart, by how much did ${indicator(view, column)} for ${entity} change between ${describeYear(viewStart)} and ${describeYear(viewEnd)}? Give the absolute change (end value minus start value)${unitHint(view, column).replace(" Give the number", ",")}`,
+                numberGold(
+                    v1 - v0,
+                    0.005 * Math.max(Math.abs(v0), Math.abs(v1))
+                ),
+                { column, entity, from: viewStart, to: viewEnd, v0, v1 }
+            )
+        }
+    }
+
+    // rank-max / rank-min among countries.
+    {
+        const column = randomColumn()
+        const atEnd = full
+            .countries()
+            .map((e) => ({
+                entity: e,
+                value: full.valueAt(e, column, viewEnd),
+            }))
+            .filter(
+                (r): r is { entity: string; value: number } =>
+                    r.value !== undefined
+            )
+        const latest = full
+            .countries()
+            .map((e) => ({ entity: e, obs: full.latest(e, column, viewEnd) }))
+            .filter((r) => r.obs !== undefined)
+            .map((r) => ({ entity: r.entity, value: r.obs!.value }))
+        const pool = atEnd.length >= 10 ? atEnd : latest
+        for (const [type, sign] of [
+            ["rank-max", 1],
+            ["rank-min", -1],
+        ] as const) {
+            const best = (
+                rows: { entity: string; value: number }[]
+            ): string[] => {
+                if (rows.length === 0) return []
+                const extreme = Math.max(...rows.map((r) => sign * r.value))
+                return rows
+                    .filter((r) => sign * r.value === extreme)
+                    .map((r) => r.entity)
+            }
+            const entities = [...new Set([...best(pool), ...best(latest)])]
+            if (entities.length === 0 || entities.length > 5) continue
+            const word = sign > 0 ? "highest" : "lowest"
+            add(
+                type,
+                `According to this chart, which country had the ${word} ${indicator(view, column, { article: false })} in ${describeYear(viewEnd)}? Consider countries only, not regions, income groups or the world as a whole.`,
+                { kind: "entity", entities },
+                {
+                    column,
+                    year: viewEnd,
+                    pool: atEnd.length >= 10 ? "at-end" : "latest",
+                }
+            )
+        }
+    }
+
+    // unanswerable-early: an entity with no value at the view's start year.
+    if (viewStart !== undefined && viewStart !== viewEnd) {
+        const column = randomColumn()
+        const fromSelection = selection.filter(
+            (e) =>
+                full.valueAt(e, column, viewStart) === undefined &&
+                full.latest(e, column, viewEnd) !== undefined
+        )
+        const fromCountries = full
+            .countries()
+            .filter(
+                (e) =>
+                    !usedEntities.has(e) &&
+                    full.valueAt(e, column, viewStart) === undefined &&
+                    full.latest(e, column, viewEnd) !== undefined
+            )
+        const entity = rng.pick(fromSelection) ?? rng.pick(fromCountries)
+        if (entity) {
+            add(
+                "unanswerable-early",
+                pointQuestion(view, column, entity, viewStart),
+                { kind: "none" },
+                {
+                    column,
+                    entity,
+                    year: viewStart,
+                    firstYear: full.earliest(entity, column)?.year,
+                    selected: selection.includes(entity),
+                }
+            )
+        }
+    }
+
+    // unanswerable-late: a country whose data stops before the view's end year.
+    {
+        const column = randomColumn()
+        const stale = full.countries().filter((e) => {
+            const obs = full.latest(e, column, viewEnd)
+            return (
+                obs !== undefined && obs.year < viewEnd && !usedEntities.has(e)
+            )
+        })
+        const entity = rng.pick(stale)
+        if (entity) {
+            add(
+                "unanswerable-late",
+                pointQuestion(view, column, entity, viewEnd),
+                { kind: "none" },
+                {
+                    column,
+                    entity,
+                    year: viewEnd,
+                    lastYear: full.latest(entity, column, viewEnd)?.year,
+                }
+            )
+        } else {
+            const any = rng.pick(
+                full.countries().filter((e) => !usedEntities.has(e))
+            )
+            if (any && full.maxYear(column) === viewEnd) {
+                add(
+                    "unanswerable-late",
+                    pointQuestion(view, column, any, viewEnd + 1),
+                    { kind: "none" },
+                    { column, entity: any, year: viewEnd + 1 }
+                )
+            }
+        }
+    }
+
+    // meta-unit
+    {
+        const column = randomColumn()
+        const col = view.meta.columns[column]
+        const tokens = unitTokens(col?.unit ?? "", col?.shortUnit ?? "")
+        if (tokens.length > 0) {
+            add(
+                "meta-unit",
+                `What unit is ${indicator(view, column)} measured in on this page?`,
+                { kind: "unit", unitTokens: tokens },
+                { column, unit: col.unit, shortUnit: col.shortUnit }
+            )
+        }
+    }
+
+    // meta-source
+    {
+        const sources = sourceNames(view)
+        if (sources.length > 0) {
+            add(
+                "meta-source",
+                "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+                { kind: "sources", sources },
+                { sources }
+            )
+        }
+    }
+
+    return cases
+}
+
+async function main(): Promise<void> {
+    const argv = await yargs(hideBin(process.argv))
+        .option("out", {
+            type: "string",
+            default: path.join(EVALS_DIR, "cases.json"),
+        })
+        .option("branch", {
+            type: "string",
+            describe:
+                "PR branch whose staging server serves the data endpoints",
+        })
+        .parse()
+
+    const charts = loadCharts()
+    const branch = argv.branch ?? charts.prBranch
+    const all: EvalCase[] = []
+    for (const spec of charts.charts) {
+        const view = await loadView(spec, branch)
+        const cases = buildCasesForView(view)
+        console.log(
+            `${spec.key}: ${cases.length} cases (columns=${view.columns.length}, selection=${view.selection.length}, ${view.viewStart}..${view.viewEnd})`
+        )
+        all.push(...cases)
+    }
+    fs.writeFileSync(argv.out, JSON.stringify(all, null, 2) + "\n")
+    console.log(
+        `\nWrote ${all.length} cases to ${path.relative(process.cwd(), argv.out)}`
+    )
+}
+
+void main()

--- a/devTools/agentEvals/buildReport.ts
+++ b/devTools/agentEvals/buildReport.ts
@@ -1,0 +1,332 @@
+#!/usr/bin/env tsx
+/**
+ * Render one document-QA run as a self-contained HTML report and open it.
+ * Grades are recomputed from the stored answers, so a grader fix does not
+ * require re-running the model.
+ *
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/buildReport.ts --run sonnet-full
+ */
+import { execFileSync } from "child_process"
+import fs from "fs"
+import path from "path"
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import { EVALS_DIR, RESULTS_DIR } from "./lib/charts.js"
+import type { EvalCase } from "./buildCases.js"
+import { Condition, Grade, ResultRow, grade } from "./runDocQa.js"
+
+interface ErrorRow {
+    case_id: string
+    condition: Condition
+    rep: number
+    class: string
+    message: string
+}
+
+const CONDITION_LABEL: Record<Condition, string> = {
+    today: "Today (Cloudflare markdown)",
+    pr: "PR (/grapher/<slug>.md)",
+    none: "No page (memory only)",
+}
+
+function readJsonl<T>(file: string): T[] {
+    if (!fs.existsSync(file)) return []
+    return fs
+        .readFileSync(file, "utf8")
+        .split("\n")
+        .filter(Boolean)
+        .map((l) => JSON.parse(l) as T)
+}
+
+function esc(s: unknown): string {
+    return String(s ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+}
+
+function pct(x: number, n: number): string {
+    return n === 0 ? "–" : `${Math.round((100 * x) / n)}%`
+}
+
+function mean(xs: number[]): number {
+    return xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length
+}
+
+function median(xs: number[]): number {
+    if (xs.length === 0) return 0
+    const s = [...xs].sort((a, b) => a - b)
+    return s[Math.floor(s.length / 2)]
+}
+
+/** Paired bootstrap CI for the mean per-case difference b − a of a metric. */
+function pairedDiff(
+    rows: ResultRow[],
+    a: Condition,
+    b: Condition,
+    metric: keyof Grade
+): { diff: number; lo: number; hi: number; n: number } | undefined {
+    const byCase = new Map<string, { a: number[]; b: number[] }>()
+    for (const r of rows) {
+        if (r.condition !== a && r.condition !== b) continue
+        const e = byCase.get(r.case_id) ?? { a: [], b: [] }
+        e[r.condition === a ? "a" : "b"].push(r.grade[metric])
+        byCase.set(r.case_id, e)
+    }
+    const diffs = [...byCase.values()]
+        .filter((e) => e.a.length > 0 && e.b.length > 0)
+        .map((e) => mean(e.b) - mean(e.a))
+    if (diffs.length < 2) return undefined
+    let seed = 12345
+    const rnd = (): number => {
+        seed = (seed * 1664525 + 1013904223) >>> 0
+        return seed / 4294967296
+    }
+    const samples: number[] = []
+    for (let i = 0; i < 2000; i++) {
+        let s = 0
+        for (const _ of diffs) s += diffs[Math.floor(rnd() * diffs.length)]
+        samples.push(s / diffs.length)
+    }
+    samples.sort((x, y) => x - y)
+    return {
+        diff: mean(diffs),
+        lo: samples[Math.floor(0.025 * samples.length)],
+        hi: samples[Math.floor(0.975 * samples.length)],
+        n: diffs.length,
+    }
+}
+
+function cell(r: ResultRow | undefined, err: ErrorRow | undefined): string {
+    if (!r && err)
+        return `<td class="c err" title="${esc(err.class + ": " + err.message)}">!</td>`
+    if (!r) return `<td class="c"></td>`
+    const g = r.grade
+    const cls = g.correct
+        ? g.grounded
+            ? "ok"
+            : "okmem"
+        : g.abstained
+          ? "abst"
+          : "wrong"
+    const sym = g.correct ? "✓" : g.abstained ? "∅" : "✗"
+    const tip = [
+        r.explanation,
+        `answer: ${r.answer.answer_text}`,
+        r.answer.evidence ? `evidence: ${r.answer.evidence}` : "",
+        `found_in_page: ${r.answer.found_in_page}`,
+    ]
+        .filter(Boolean)
+        .join("\n")
+    return `<td class="c ${cls}" title="${esc(tip)}">${sym}</td>`
+}
+
+async function main(): Promise<void> {
+    const argv = await yargs(hideBin(process.argv))
+        .option("run", { type: "string", demandOption: true })
+        .option("open", { type: "boolean", default: true })
+        .parse()
+
+    const runDir = path.join(RESULTS_DIR, "runs", argv.run)
+    const config = JSON.parse(
+        fs.readFileSync(path.join(runDir, "config.json"), "utf8")
+    ) as Record<string, unknown>
+    const cases = JSON.parse(
+        fs.readFileSync(path.join(EVALS_DIR, "cases.json"), "utf8")
+    ) as EvalCase[]
+    const caseById = new Map(cases.map((c) => [c.id, c]))
+    const charts = JSON.parse(
+        fs.readFileSync(path.join(EVALS_DIR, "charts.json"), "utf8")
+    ) as {
+        charts: { key: string; path: string; note?: string }[]
+    }
+
+    // Re-grade from stored answers against the cached page snapshots.
+    const docCache = new Map<string, string>()
+    const doc = (chart: string, condition: Condition): string => {
+        if (condition === "none") return ""
+        const key = `${chart}|${condition}`
+        if (!docCache.has(key)) {
+            const f = path.join(RESULTS_DIR, "docs", condition, `${chart}.md`)
+            docCache.set(
+                key,
+                fs.existsSync(f) ? fs.readFileSync(f, "utf8") : ""
+            )
+        }
+        return docCache.get(key)!
+    }
+    const rows = readJsonl<ResultRow>(path.join(runDir, "results.jsonl")).map(
+        (r) => {
+            const c = caseById.get(r.case_id)
+            if (!c) return r
+            const g = grade(c, r.answer, doc(c.chart, r.condition))
+            return { ...r, grade: g.grade, explanation: g.explanation }
+        }
+    )
+    const errors = readJsonl<ErrorRow>(path.join(runDir, "errors.jsonl"))
+    const conditions = (config.conditions as Condition[]).filter((c) =>
+        rows.some((r) => r.condition === c)
+    )
+
+    // Summary per condition.
+    const summary = conditions.map((cond) => {
+        const rs = rows.filter((r) => r.condition === cond)
+        const n = rs.length
+        const sum = (k: keyof Grade): number =>
+            rs.reduce((a, r) => a + r.grade[k], 0)
+        return {
+            cond,
+            n,
+            errors: errors.filter((e) => e.condition === cond).length,
+            correct: sum("correct"),
+            grounded: sum("grounded"),
+            hallucinated: sum("hallucinated"),
+            abstained: sum("abstained"),
+            latency: median(rs.map((r) => r.latency_s)),
+            docChars: median(rs.map((r) => r.doc_chars)),
+            cost: rs.reduce((a, r) => a + r.cost_usd, 0),
+            inputTokens: mean(
+                rs.map(
+                    (r) =>
+                        r.usage.input_tokens +
+                        r.usage.cache_read_input_tokens +
+                        r.usage.cache_creation_input_tokens
+                )
+            ),
+        }
+    })
+
+    const types = [...new Set(cases.map((c) => c.type))]
+    const byType = (cond: Condition, type: string, k: keyof Grade): string => {
+        const rs = rows.filter(
+            (r) => r.condition === cond && r.tags[0] === type
+        )
+        return pct(
+            rs.reduce((a, r) => a + r.grade[k], 0),
+            rs.length
+        )
+    }
+
+    const diffs = ["correct", "grounded", "hallucinated"].map((m) => ({
+        metric: m,
+        prVsToday: pairedDiff(rows, "today", "pr", m as keyof Grade),
+        prVsNone: pairedDiff(rows, "none", "pr", m as keyof Grade),
+    }))
+
+    const reps = Math.max(1, ...rows.map((r) => r.rep + 1))
+    const rowFor = (id: string, cond: Condition): ResultRow | undefined =>
+        rows.find(
+            (r) => r.case_id === id && r.condition === cond && r.rep === 0
+        )
+    const errFor = (id: string, cond: Condition): ErrorRow | undefined =>
+        errors.find((e) => e.case_id === id && e.condition === cond)
+
+    const fmtDiff = (d: ReturnType<typeof pairedDiff>): string =>
+        d
+            ? `${d.diff >= 0 ? "+" : ""}${Math.round(100 * d.diff)} pts <span class="ci">[${Math.round(100 * d.lo)}, ${Math.round(100 * d.hi)}]</span>`
+            : "–"
+
+    const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Agent eval · ${esc(argv.run)}</title>
+<style>
+  :root { color-scheme: light; }
+  body { font: 14px/1.45 -apple-system, "Segoe UI", Helvetica, Arial, sans-serif; color: #1a1a1a; background: #fff; margin: 0; padding: 32px 40px 64px; max-width: 1400px; }
+  h1 { font-size: 22px; margin: 0 0 4px; } h2 { font-size: 17px; margin: 36px 0 10px; }
+  .muted { color: #666; } .small { font-size: 12.5px; }
+  table { border-collapse: collapse; margin: 8px 0 4px; } th, td { padding: 5px 10px; border-bottom: 1px solid #e6e6e6; text-align: left; vertical-align: top; }
+  th { background: #f6f6f4; font-weight: 600; font-size: 12.5px; text-transform: uppercase; letter-spacing: .02em; color: #444; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .ci { color: #777; font-size: 12px; }
+  td.c { text-align: center; width: 34px; font-weight: 700; cursor: help; }
+  td.ok { background: #d7efd9; color: #1e6b2b; } td.okmem { background: #eef6d9; color: #5e7a12; }
+  td.wrong { background: #f8d7d7; color: #9b1c1c; } td.abst { background: #eeeeee; color: #666; } td.err { background: #e8d9f5; color: #5b2d91; }
+  .legend span { display: inline-block; padding: 1px 8px; margin-right: 8px; border-radius: 3px; font-size: 12.5px; }
+  tr.chart td { background: #fafaf8; font-weight: 600; }
+  td.q { max-width: 620px; }
+  .gold { color: #555; font-size: 12px; }
+  code { background: #f2f2f0; padding: 0 4px; border-radius: 3px; font-size: 12.5px; }
+</style></head><body>
+<h1>Agent eval: does the page text let an agent answer? · <code>${esc(argv.run)}</code></h1>
+<p class="muted">Model <code>${esc(config.model)}</code>${config.effort ? `, effort ${esc(config.effort)}` : ""} · ${cases.length} cases over ${charts.charts.length} chart views · ${reps} rep(s) · ${rows.length} graded answers, ${errors.length} failed calls · started ${esc(config.startedAt)}.<br>
+The agent gets the question plus the page text (or nothing) and must answer only from it. Gold comes from the chart's CSV endpoints, never from the page under test.</p>
+
+<h2>Headline</h2>
+<table>
+<tr><th>Condition</th><th class="num">n</th><th class="num">Correct</th><th class="num">Correct &amp; from page</th><th class="num">Hallucinated</th><th class="num">Abstained</th><th class="num">Failed calls</th><th class="num">Median latency</th><th class="num">Median page chars</th><th class="num">Mean input tokens</th><th class="num">Cost (API-equiv.)</th></tr>
+${summary
+    .map(
+        (s) =>
+            `<tr><td>${esc(CONDITION_LABEL[s.cond])}</td><td class="num">${s.n}</td><td class="num"><b>${pct(s.correct, s.n)}</b></td><td class="num">${pct(s.grounded, s.n)}</td><td class="num">${pct(s.hallucinated, s.n)}</td><td class="num">${pct(s.abstained, s.n)}</td><td class="num">${s.errors}</td><td class="num">${s.latency.toFixed(0)} s</td><td class="num">${Math.round(s.docChars).toLocaleString()}</td><td class="num">${Math.round(s.inputTokens).toLocaleString()}</td><td class="num">$${s.cost.toFixed(2)}</td></tr>`
+    )
+    .join("\n")}
+</table>
+<p class="small muted">Correct: answer matches gold (numbers within 1%, or the accepted entity, or the page has no value and the agent declined). From page: correct and the quoted evidence occurs in the page text. Hallucinated: gave a specific answer that is wrong, or gave a number where the page has none. Abstained: gave no number/entity. Cost is what the same calls would cost on the API (they ran on a Claude subscription via <code>claude -p</code>); it includes Claude Code's ~9k-token system prompt on every call.</p>
+
+<h2>Paired differences (mean per-case change, 95% bootstrap CI over cases)</h2>
+<table>
+<tr><th>Metric</th><th>PR vs today</th><th>PR vs no page</th></tr>
+${diffs.map((d) => `<tr><td>${esc(d.metric)}</td><td>${fmtDiff(d.prVsToday)}</td><td>${fmtDiff(d.prVsNone)}</td></tr>`).join("\n")}
+</table>
+<p class="small muted">Noise floor for a single pass-rate at n = ${cases.length}, ${reps} rep(s): about ±${Math.round(100 / Math.sqrt(cases.length * reps))} pts. Differences whose interval excludes 0 are the ones to act on.</p>
+
+<h2>By question type (correct · from page · hallucinated)</h2>
+<table>
+<tr><th>Type</th><th class="num">cases</th>${conditions.map((c) => `<th>${esc(c)}</th>`).join("")}</tr>
+${types
+    .map(
+        (t) =>
+            `<tr><td>${esc(t)}</td><td class="num">${cases.filter((c) => c.type === t).length}</td>${conditions
+                .map(
+                    (c) =>
+                        `<td>${byType(c, t, "correct")} · ${byType(c, t, "grounded")} · <span class="muted">${byType(c, t, "hallucinated")}</span></td>`
+                )
+                .join("")}</tr>`
+    )
+    .join("\n")}
+</table>
+
+<h2>Every case</h2>
+<p class="legend"><span class="ok" style="background:#d7efd9">✓ correct, from page</span><span style="background:#eef6d9">✓ correct, not traceable to page</span><span style="background:#f8d7d7">✗ wrong</span><span style="background:#eeeeee">∅ abstained</span><span style="background:#e8d9f5">! call failed</span> · hover a cell for the answer and evidence</p>
+<table>
+<tr><th>Case</th><th>Question</th>${conditions.map((c) => `<th>${esc(c)}</th>`).join("")}</tr>
+${charts.charts
+    .map((ch) => {
+        const cs = cases.filter((c) => c.chart === ch.key)
+        if (cs.length === 0) return ""
+        return (
+            `<tr class="chart"><td colspan="${2 + conditions.length}">${esc(ch.key)} <span class="muted small">· <a href="https://ourworldindata.org/grapher/${esc(ch.path)}">${esc(ch.path)}</a>${ch.note ? ` · ${esc(ch.note)}` : ""}</span></td></tr>` +
+            cs
+                .map(
+                    (c) =>
+                        `<tr><td class="small muted">${esc(c.type)}</td><td class="q">${esc(c.question)}<br><span class="gold">gold: ${esc(
+                            c.gold.kind === "number"
+                                ? c.gold.number
+                                : c.gold.kind === "entity"
+                                  ? c.gold.entities?.join(" / ")
+                                  : c.gold.kind === "none"
+                                    ? "no value on the page"
+                                    : c.gold.kind === "unit"
+                                      ? c.gold.unitTokens?.join(", ")
+                                      : c.gold.sources?.join("; ")
+                        )}</span></td>${conditions.map((cond) => cell(rowFor(c.id, cond), errFor(c.id, cond))).join("")}</tr>`
+                )
+                .join("\n")
+        )
+    })
+    .join("\n")}
+</table>
+</body></html>`
+
+    const out = path.join(runDir, "report.html")
+    fs.writeFileSync(out, html)
+    console.log(`Wrote ${path.relative(process.cwd(), out)}`)
+    for (const s of summary)
+        console.log(
+            `${s.cond.padEnd(6)} n=${String(s.n).padStart(3)}  correct ${pct(s.correct, s.n).padStart(4)}  from-page ${pct(s.grounded, s.n).padStart(4)}  hallucinated ${pct(s.hallucinated, s.n).padStart(4)}  abstained ${pct(s.abstained, s.n).padStart(4)}  errors ${s.errors}`
+        )
+    if (argv.open && process.platform === "darwin")
+        execFileSync("open", ["-a", "Google Chrome", out])
+}
+
+void main()

--- a/devTools/agentEvals/buildReport.ts
+++ b/devTools/agentEvals/buildReport.ts
@@ -13,7 +13,7 @@ import yargs from "yargs"
 import { hideBin } from "yargs/helpers"
 import { EVALS_DIR, RESULTS_DIR } from "./lib/charts.js"
 import type { EvalCase } from "./buildCases.js"
-import { Condition, Grade, ResultRow, grade } from "./runDocQa.js"
+import { Condition, Grade, ResultRow, grade, pageOf } from "./runDocQa.js"
 
 interface ErrorRow {
     case_id: string
@@ -23,10 +23,15 @@ interface ErrorRow {
     message: string
 }
 
-const CONDITION_LABEL: Record<Condition, string> = {
+const CONDITION_LABEL: Partial<Record<Condition, string>> = {
     today: "Today (Cloudflare markdown)",
     pr: "PR (/grapher/<slug>.md)",
     none: "No page (memory only)",
+    "today+tools": "Today + tools (shell, web fetch)",
+    "pr+tools": "PR + tools (shell, web fetch)",
+    "none+tools": "No page + tools",
+    custom: "Custom page variant",
+    "custom+tools": "Custom page variant + tools",
 }
 
 function readJsonl<T>(file: string): T[] {
@@ -160,7 +165,12 @@ async function main(): Promise<void> {
         (r) => {
             const c = caseById.get(r.case_id)
             if (!c) return r
-            const g = grade(c, r.answer, doc(c.chart, r.condition))
+            const g = grade(
+                c,
+                r.answer,
+                doc(c.chart, pageOf(r.condition)),
+                r.evidence_in_tool_output ?? false
+            )
             return { ...r, grade: g.grade, explanation: g.explanation }
         }
     )
@@ -257,7 +267,7 @@ The agent gets the question plus the page text (or nothing) and must answer only
 ${summary
     .map(
         (s) =>
-            `<tr><td>${esc(CONDITION_LABEL[s.cond])}</td><td class="num">${s.n}</td><td class="num"><b>${pct(s.correct, s.n)}</b></td><td class="num">${pct(s.grounded, s.n)}</td><td class="num">${pct(s.hallucinated, s.n)}</td><td class="num">${pct(s.abstained, s.n)}</td><td class="num">${s.errors}</td><td class="num">${s.latency.toFixed(0)} s</td><td class="num">${Math.round(s.docChars).toLocaleString()}</td><td class="num">${Math.round(s.inputTokens).toLocaleString()}</td><td class="num">$${s.cost.toFixed(2)}</td></tr>`
+            `<tr><td>${esc(CONDITION_LABEL[s.cond] ?? s.cond)}</td><td class="num">${s.n}</td><td class="num"><b>${pct(s.correct, s.n)}</b></td><td class="num">${pct(s.grounded, s.n)}</td><td class="num">${pct(s.hallucinated, s.n)}</td><td class="num">${pct(s.abstained, s.n)}</td><td class="num">${s.errors}</td><td class="num">${s.latency.toFixed(0)} s</td><td class="num">${Math.round(s.docChars).toLocaleString()}</td><td class="num">${Math.round(s.inputTokens).toLocaleString()}</td><td class="num">$${s.cost.toFixed(2)}</td></tr>`
     )
     .join("\n")}
 </table>

--- a/devTools/agentEvals/cases.json
+++ b/devTools/agentEvals/cases.json
@@ -1,0 +1,2129 @@
+[
+    {
+        "id": "life-expectancy/point-latest-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "point-latest",
+        "question": "According to this chart, what was the life expectancy for Zimbabwe in 2023? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 62.7748,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Zimbabwe",
+            "year": 2023
+        }
+    },
+    {
+        "id": "life-expectancy/point-latest-2",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "point-latest",
+        "question": "According to this chart, what was the life expectancy for Saint Barthelemy in 2023? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 84.2901,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Saint Barthelemy",
+            "year": 2023
+        }
+    },
+    {
+        "id": "life-expectancy/point-selected-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "point-selected",
+        "question": "According to this chart, what was the life expectancy for Europe in 2023? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 79.0594,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Europe",
+            "year": 2023
+        }
+    },
+    {
+        "id": "life-expectancy/point-start-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "point-start",
+        "question": "According to this chart, what was the life expectancy for World in 1770? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 28.5,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "World",
+            "year": 1770
+        }
+    },
+    {
+        "id": "life-expectancy/change-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "change",
+        "question": "According to this chart, by how much did the life expectancy for World change between 1770 and 2023? Give the absolute change (end value minus start value), in years.",
+        "gold": {
+            "kind": "number",
+            "number": 44.669399999999996,
+            "relTol": 0.01,
+            "absTol": 0.365847
+        },
+        "tags": ["change", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "World",
+            "from": 1770,
+            "to": 2023,
+            "v0": 28.5,
+            "v1": 73.1694
+        }
+    },
+    {
+        "id": "life-expectancy/rank-max-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest life expectancy in 2023? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Monaco"]
+        },
+        "tags": ["rank-max", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "year": 2023,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "life-expectancy/rank-min-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest life expectancy in 2023? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Nigeria"]
+        },
+        "tags": ["rank-min", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "year": 2023,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "life-expectancy/unanswerable-early-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the life expectancy for Oceania in 1770? Give the number in years.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Oceania",
+            "year": 1770,
+            "firstYear": 1870,
+            "selected": true
+        }
+    },
+    {
+        "id": "life-expectancy/unanswerable-late-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the life expectancy for Morocco in 2024? Give the number in years.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Morocco",
+            "year": 2024
+        }
+    },
+    {
+        "id": "life-expectancy/meta-unit-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "meta-unit",
+        "question": "What unit is the life expectancy measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["years"]
+        },
+        "tags": ["meta-unit", "life-expectancy"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "unit": "years",
+            "shortUnit": "years"
+        }
+    },
+    {
+        "id": "life-expectancy/meta-source-1",
+        "chart": "life-expectancy",
+        "url": "https://ourworldindata.org/grapher/life-expectancy",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["Riley", "Zijdeman et al.", "HMD", "UN WPP"]
+        },
+        "tags": ["meta-source", "life-expectancy"],
+        "meta": {
+            "sources": ["Riley", "Zijdeman et al.", "HMD", "UN WPP"]
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/point-latest-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "point-latest",
+        "question": "According to this chart, what was the life expectancy for Vatican in 2023? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 82.9848,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Vatican",
+            "year": 2023
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/point-latest-2",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "point-latest",
+        "question": "According to this chart, what was the life expectancy for Somalia in 2023? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 58.8158,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Somalia",
+            "year": 2023
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/point-selected-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "point-selected",
+        "question": "According to this chart, what was the life expectancy for Slovakia in 2023? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 78.3414,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Slovakia",
+            "year": 2023
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/point-start-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "point-start",
+        "question": "According to this chart, what was the life expectancy for Czechia in 1990? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 71.4086,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Czechia",
+            "year": 1990
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/change-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "change",
+        "question": "According to this chart, by how much did the life expectancy for Czechia change between 1990 and 2023? Give the absolute change (end value minus start value), in years.",
+        "gold": {
+            "kind": "number",
+            "number": 8.4255,
+            "relTol": 0.01,
+            "absTol": 0.39917050000000004
+        },
+        "tags": ["change", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Czechia",
+            "from": 1990,
+            "to": 2023,
+            "v0": 71.4086,
+            "v1": 79.8341
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/rank-max-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest life expectancy in 2023? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Monaco"]
+        },
+        "tags": ["rank-max", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "year": 2023,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/rank-min-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest life expectancy in 2023? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Nigeria"]
+        },
+        "tags": ["rank-min", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "year": 2023,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/unanswerable-late-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the life expectancy for United States in 2024? Give the number in years.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "United States",
+            "year": 2024
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/meta-unit-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "meta-unit",
+        "question": "What unit is the life expectancy measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["years"]
+        },
+        "tags": ["meta-unit", "life-expectancy-cze-svk"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "unit": "years",
+            "shortUnit": "years"
+        }
+    },
+    {
+        "id": "life-expectancy-cze-svk/meta-source-1",
+        "chart": "life-expectancy-cze-svk",
+        "url": "https://ourworldindata.org/grapher/life-expectancy?country=~CZE~SVK&time=1990..2023",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["Riley", "Zijdeman et al.", "HMD", "UN WPP"]
+        },
+        "tags": ["meta-source", "life-expectancy-cze-svk"],
+        "meta": {
+            "sources": ["Riley", "Zijdeman et al.", "HMD", "UN WPP"]
+        }
+    },
+    {
+        "id": "population/point-latest-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "point-latest",
+        "question": "According to this chart, what was the population for Mauritania in 2023? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 5022442,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "population"],
+        "meta": {
+            "column": "population_historical",
+            "entity": "Mauritania",
+            "year": 2023
+        }
+    },
+    {
+        "id": "population/point-latest-2",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "point-latest",
+        "question": "According to this chart, what was the population for Slovakia in 2023? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 5518057,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "population"],
+        "meta": {
+            "column": "population_historical",
+            "entity": "Slovakia",
+            "year": 2023
+        }
+    },
+    {
+        "id": "population/point-selected-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "point-selected",
+        "question": "According to this chart, what was the population for World in 2023? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 8091734933,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "population"],
+        "meta": {
+            "column": "population_historical",
+            "entity": "World",
+            "year": 2023
+        }
+    },
+    {
+        "id": "population/point-start-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "point-start",
+        "question": "According to this chart, what was the population for North America in the year -10000 (10000 BCE)? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 1184755,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "population"],
+        "meta": {
+            "column": "population_historical",
+            "entity": "North America",
+            "year": -10000
+        }
+    },
+    {
+        "id": "population/change-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "change",
+        "question": "According to this chart, by how much did the population for North America change between the year -10000 (10000 BCE) and 2023? Give the absolute change (end value minus start value), in people.",
+        "gold": {
+            "kind": "number",
+            "number": 607585792,
+            "relTol": 0.01,
+            "absTol": 3043852.735
+        },
+        "tags": ["change", "population"],
+        "meta": {
+            "column": "population_historical",
+            "entity": "North America",
+            "from": -10000,
+            "to": 2023,
+            "v0": 1184755,
+            "v1": 608770547
+        }
+    },
+    {
+        "id": "population/rank-max-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest population in 2023? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["India"]
+        },
+        "tags": ["rank-max", "population"],
+        "meta": {
+            "column": "population_historical",
+            "year": 2023,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "population/rank-min-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest population in 2023? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Vatican"]
+        },
+        "tags": ["rank-min", "population"],
+        "meta": {
+            "column": "population_historical",
+            "year": 2023,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "population/unanswerable-early-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the population for Turks and Caicos Islands in the year -10000 (10000 BCE)? Give the number in people.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "population"],
+        "meta": {
+            "column": "population_historical",
+            "entity": "Turks and Caicos Islands",
+            "year": -10000,
+            "firstYear": 1100,
+            "selected": false
+        }
+    },
+    {
+        "id": "population/unanswerable-late-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the population for Netherlands Antilles in 2023? Give the number in people.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "population"],
+        "meta": {
+            "column": "population_historical",
+            "entity": "Netherlands Antilles",
+            "year": 2023,
+            "lastYear": 2010
+        }
+    },
+    {
+        "id": "population/meta-unit-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "meta-unit",
+        "question": "What unit is the population measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["people"]
+        },
+        "tags": ["meta-unit", "population"],
+        "meta": {
+            "column": "population_historical",
+            "unit": "people",
+            "shortUnit": ""
+        }
+    },
+    {
+        "id": "population/meta-source-1",
+        "chart": "population",
+        "url": "https://ourworldindata.org/grapher/population",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["HYDE", "Gapminder", "UN WPP"]
+        },
+        "tags": ["meta-source", "population"],
+        "meta": {
+            "sources": ["HYDE", "Gapminder", "UN WPP"]
+        }
+    },
+    {
+        "id": "child-mortality/point-latest-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "point-latest",
+        "question": "According to this chart, what was the child mortality rate for Argentina in 2024? Give the number in deaths per 100 live births.",
+        "gold": {
+            "kind": "number",
+            "number": 0.95,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "entity": "Argentina",
+            "year": 2024
+        }
+    },
+    {
+        "id": "child-mortality/point-latest-2",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "point-latest",
+        "question": "According to this chart, what was the child mortality rate for Guyana in 2024? Give the number in deaths per 100 live births.",
+        "gold": {
+            "kind": "number",
+            "number": 2.52,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "entity": "Guyana",
+            "year": 2024
+        }
+    },
+    {
+        "id": "child-mortality/point-selected-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "point-selected",
+        "question": "According to this chart, what was the child mortality rate for Ghana in 2024? Give the number in deaths per 100 live births.",
+        "gold": {
+            "kind": "number",
+            "number": 3.59,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "entity": "Ghana",
+            "year": 2024
+        }
+    },
+    {
+        "id": "child-mortality/point-start-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "point-start",
+        "question": "According to this chart, what was the child mortality rate for Sweden in 1800? Give the number in deaths per 100 live births.",
+        "gold": {
+            "kind": "number",
+            "number": 38.11,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "entity": "Sweden",
+            "year": 1800
+        }
+    },
+    {
+        "id": "child-mortality/change-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "change",
+        "question": "According to this chart, by how much did the child mortality rate for Sweden change between 1800 and 2024? Give the absolute change (end value minus start value), in deaths per 100 live births.",
+        "gold": {
+            "kind": "number",
+            "number": -37.87,
+            "relTol": 0.01,
+            "absTol": 0.19055
+        },
+        "tags": ["change", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "entity": "Sweden",
+            "from": 1800,
+            "to": 2024,
+            "v0": 38.11,
+            "v1": 0.24
+        }
+    },
+    {
+        "id": "child-mortality/rank-max-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest child mortality rate in 2024? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Nigeria"]
+        },
+        "tags": ["rank-max", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "year": 2024,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "child-mortality/rank-min-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest child mortality rate in 2024? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["San Marino"]
+        },
+        "tags": ["rank-min", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "year": 2024,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "child-mortality/unanswerable-early-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the child mortality rate for Brazil in 1800? Give the number in deaths per 100 live births.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "entity": "Brazil",
+            "year": 1800,
+            "firstYear": 1931,
+            "selected": true
+        }
+    },
+    {
+        "id": "child-mortality/unanswerable-late-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the child mortality rate for Taiwan in 2024? Give the number in deaths per 100 live births.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "entity": "Taiwan",
+            "year": 2024,
+            "lastYear": 2010
+        }
+    },
+    {
+        "id": "child-mortality/meta-unit-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "meta-unit",
+        "question": "What unit is the child mortality rate measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["deaths", "per", "100", "live", "births", "%"]
+        },
+        "tags": ["meta-unit", "child-mortality"],
+        "meta": {
+            "column": "child_mortality_rate",
+            "unit": "deaths per 100 live births",
+            "shortUnit": "%"
+        }
+    },
+    {
+        "id": "child-mortality/meta-source-1",
+        "chart": "child-mortality",
+        "url": "https://ourworldindata.org/grapher/child-mortality",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": [
+                "Gapminder",
+                "UN Inter-agency Group for Child Mortality Estimation"
+            ]
+        },
+        "tags": ["meta-source", "child-mortality"],
+        "meta": {
+            "sources": [
+                "Gapminder",
+                "UN Inter-agency Group for Child Mortality Estimation"
+            ]
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/point-latest-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "point-latest",
+        "question": "According to this chart, what was the CO₂ emissions per capita for Namibia in 2024? Give the number in tonnes per person.",
+        "gold": {
+            "kind": "number",
+            "number": 1.1448735,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "entity": "Namibia",
+            "year": 2024
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/point-latest-2",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "point-latest",
+        "question": "According to this chart, what was the CO₂ emissions per capita for Uruguay in 2024? Give the number in tonnes per person.",
+        "gold": {
+            "kind": "number",
+            "number": 2.35437,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "entity": "Uruguay",
+            "year": 2024
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/point-selected-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "point-selected",
+        "question": "According to this chart, what was the CO₂ emissions per capita for United States in 2024? Give the number in tonnes per person.",
+        "gold": {
+            "kind": "number",
+            "number": 14.197287,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "entity": "United States",
+            "year": 2024
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/point-start-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "point-start",
+        "question": "According to this chart, what was the CO₂ emissions per capita for World in 1750? Give the number in tonnes per person.",
+        "gold": {
+            "kind": "number",
+            "number": 0.0123539,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "entity": "World",
+            "year": 1750
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/change-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "change",
+        "question": "According to this chart, by how much did the CO₂ emissions per capita for World change between 1750 and 2024? Give the absolute change (end value minus start value), in tonnes per person.",
+        "gold": {
+            "kind": "number",
+            "number": 4.7167211,
+            "relTol": 0.01,
+            "absTol": 0.023645375
+        },
+        "tags": ["change", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "entity": "World",
+            "from": 1750,
+            "to": 2024,
+            "v0": 0.0123539,
+            "v1": 4.729075
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/rank-max-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest CO₂ emissions per capita in 2024? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Qatar"]
+        },
+        "tags": ["rank-max", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "year": 2024,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/rank-min-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest CO₂ emissions per capita in 2024? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Democratic Republic of Congo"]
+        },
+        "tags": ["rank-min", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "year": 2024,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/unanswerable-early-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the CO₂ emissions per capita for South Africa in 1750? Give the number in tonnes per person.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "entity": "South Africa",
+            "year": 1750,
+            "firstYear": 1884,
+            "selected": true
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/unanswerable-late-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the CO₂ emissions per capita for Haiti in 2025? Give the number in tonnes per person.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "entity": "Haiti",
+            "year": 2025
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/meta-unit-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "meta-unit",
+        "question": "What unit is the CO₂ emissions per capita measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["tonnes", "per", "person", "t/person"]
+        },
+        "tags": ["meta-unit", "co-emissions-per-capita"],
+        "meta": {
+            "column": "emissions_total_per_capita",
+            "unit": "tonnes per person",
+            "shortUnit": "t/person"
+        }
+    },
+    {
+        "id": "co-emissions-per-capita/meta-source-1",
+        "chart": "co-emissions-per-capita",
+        "url": "https://ourworldindata.org/grapher/co-emissions-per-capita",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["Global Carbon Budget"]
+        },
+        "tags": ["meta-source", "co-emissions-per-capita"],
+        "meta": {
+            "sources": ["Global Carbon Budget"]
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/point-latest-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "point-latest",
+        "question": "According to this chart, what was the GDP per capita for Serbia in 2025? Give the number in international-$ in 2021 prices.",
+        "gold": {
+            "kind": "number",
+            "number": 27603.393,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "entity": "Serbia",
+            "year": 2025
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/point-latest-2",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "point-latest",
+        "question": "According to this chart, what was the GDP per capita for Botswana in 2025? Give the number in international-$ in 2021 prices.",
+        "gold": {
+            "kind": "number",
+            "number": 17687.205,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "entity": "Botswana",
+            "year": 2025
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/point-selected-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "point-selected",
+        "question": "According to this chart, what was the GDP per capita for Ethiopia in 2025? Give the number in international-$ in 2021 prices.",
+        "gold": {
+            "kind": "number",
+            "number": 3094.8682,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "entity": "Ethiopia",
+            "year": 2025
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/point-start-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "point-start",
+        "question": "According to this chart, what was the GDP per capita for United States in 1990? Give the number in international-$ in 2021 prices.",
+        "gold": {
+            "kind": "number",
+            "number": 44384.21,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "entity": "United States",
+            "year": 1990
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/change-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "change",
+        "question": "According to this chart, by how much did the GDP per capita for United States change between 1990 and 2025? Give the absolute change (end value minus start value), in international-$ in 2021 prices.",
+        "gold": {
+            "kind": "number",
+            "number": 32547.1,
+            "relTol": 0.01,
+            "absTol": 384.65655
+        },
+        "tags": ["change", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "entity": "United States",
+            "from": 1990,
+            "to": 2025,
+            "v0": 44384.21,
+            "v1": 76931.31
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/rank-max-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest GDP per capita in 2025? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Singapore"]
+        },
+        "tags": ["rank-max", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "year": 2025,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/rank-min-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest GDP per capita in 2025? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Burundi"]
+        },
+        "tags": ["rank-min", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "year": 2025,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/unanswerable-early-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the GDP per capita for United States Virgin Islands in 1990? Give the number in international-$ in 2021 prices.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "entity": "United States Virgin Islands",
+            "year": 1990,
+            "firstYear": 2002,
+            "selected": false
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/unanswerable-late-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the GDP per capita for Faroe Islands in 2025? Give the number in international-$ in 2021 prices.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "entity": "Faroe Islands",
+            "year": 2025,
+            "lastYear": 2024
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/meta-unit-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "meta-unit",
+        "question": "What unit is the GDP per capita measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["international", "$", "2021", "prices"]
+        },
+        "tags": ["meta-unit", "gdp-per-capita-worldbank"],
+        "meta": {
+            "column": "ny_gdp_pcap_pp_kd",
+            "unit": "international-$ in 2021 prices",
+            "shortUnit": "$"
+        }
+    },
+    {
+        "id": "gdp-per-capita-worldbank/meta-source-1",
+        "chart": "gdp-per-capita-worldbank",
+        "url": "https://ourworldindata.org/grapher/gdp-per-capita-worldbank",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["Eurostat", "OECD", "IMF", "World Bank"]
+        },
+        "tags": ["meta-source", "gdp-per-capita-worldbank"],
+        "meta": {
+            "sources": ["Eurostat", "OECD", "IMF", "World Bank"]
+        }
+    },
+    {
+        "id": "extreme-poverty/point-latest-1",
+        "chart": "extreme-poverty",
+        "url": "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
+        "type": "point-latest",
+        "question": "According to this chart, what was the share of population in poverty ($3 a day) for Liberia in 2016? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 33.558934926986694,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "extreme-poverty"],
+        "meta": {
+            "column": "headcount_ratio__ppp_version_2021__poverty_line_300__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells",
+            "entity": "Liberia",
+            "year": 2016
+        }
+    },
+    {
+        "id": "extreme-poverty/point-latest-2",
+        "chart": "extreme-poverty",
+        "url": "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
+        "type": "point-latest",
+        "question": "According to this chart, what was the share of population in poverty ($3 a day) for Pakistan in 2024? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 22.956307232379913,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "extreme-poverty"],
+        "meta": {
+            "column": "headcount_ratio__ppp_version_2021__poverty_line_300__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells",
+            "entity": "Pakistan",
+            "year": 2024
+        }
+    },
+    {
+        "id": "extreme-poverty/rank-max-1",
+        "chart": "extreme-poverty",
+        "url": "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest share of population in poverty ($3 a day) in 2026? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Democratic Republic of Congo"]
+        },
+        "tags": ["rank-max", "extreme-poverty"],
+        "meta": {
+            "column": "headcount_ratio__ppp_version_2021__poverty_line_300__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells",
+            "year": 2026,
+            "pool": "latest"
+        }
+    },
+    {
+        "id": "extreme-poverty/unanswerable-early-1",
+        "chart": "extreme-poverty",
+        "url": "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the share of population in poverty ($3 a day) for Nigeria in 1990? Give the number in %.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "extreme-poverty"],
+        "meta": {
+            "column": "headcount_ratio__ppp_version_2021__poverty_line_300__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells",
+            "entity": "Nigeria",
+            "year": 1990,
+            "firstYear": 1985,
+            "selected": true
+        }
+    },
+    {
+        "id": "extreme-poverty/unanswerable-late-1",
+        "chart": "extreme-poverty",
+        "url": "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the share of population in poverty ($3 a day) for Burkina Faso in 2026? Give the number in %.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "extreme-poverty"],
+        "meta": {
+            "column": "headcount_ratio__ppp_version_2021__poverty_line_300__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells",
+            "entity": "Burkina Faso",
+            "year": 2026,
+            "lastYear": 2021
+        }
+    },
+    {
+        "id": "extreme-poverty/meta-unit-1",
+        "chart": "extreme-poverty",
+        "url": "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
+        "type": "meta-unit",
+        "question": "What unit is the share of population in poverty ($3 a day) measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["%"]
+        },
+        "tags": ["meta-unit", "extreme-poverty"],
+        "meta": {
+            "column": "headcount_ratio__ppp_version_2021__poverty_line_300__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells",
+            "unit": "%",
+            "shortUnit": "%"
+        }
+    },
+    {
+        "id": "extreme-poverty/meta-source-1",
+        "chart": "extreme-poverty",
+        "url": "https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["World Bank Poverty", "Inequality Platform"]
+        },
+        "tags": ["meta-source", "extreme-poverty"],
+        "meta": {
+            "sources": ["World Bank Poverty", "Inequality Platform"]
+        }
+    },
+    {
+        "id": "life-expectancy-vs-gdp/point-latest-1",
+        "chart": "life-expectancy-vs-gdp",
+        "url": "https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita",
+        "type": "point-latest",
+        "question": "According to this chart, what was \"Life expectancy\" for Greece in 2022? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 79.9441,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "life-expectancy-vs-gdp"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Greece",
+            "year": 2022
+        }
+    },
+    {
+        "id": "life-expectancy-vs-gdp/point-latest-2",
+        "chart": "life-expectancy-vs-gdp",
+        "url": "https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita",
+        "type": "point-latest",
+        "question": "According to this chart, what was \"Life expectancy\" for Vatican in 2022? Give the number in years.",
+        "gold": {
+            "kind": "number",
+            "number": 83.3354,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "life-expectancy-vs-gdp"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "entity": "Vatican",
+            "year": 2022
+        }
+    },
+    {
+        "id": "life-expectancy-vs-gdp/rank-max-1",
+        "chart": "life-expectancy-vs-gdp",
+        "url": "https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest \"GDP per capita\" in 2022? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Qatar"]
+        },
+        "tags": ["rank-max", "life-expectancy-vs-gdp"],
+        "meta": {
+            "column": "gdp_per_capita",
+            "year": 2022,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "life-expectancy-vs-gdp/rank-min-1",
+        "chart": "life-expectancy-vs-gdp",
+        "url": "https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest \"GDP per capita\" in 2022? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Central African Republic"]
+        },
+        "tags": ["rank-min", "life-expectancy-vs-gdp"],
+        "meta": {
+            "column": "gdp_per_capita",
+            "year": 2022,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "life-expectancy-vs-gdp/meta-unit-1",
+        "chart": "life-expectancy-vs-gdp",
+        "url": "https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita",
+        "type": "meta-unit",
+        "question": "What unit is \"Life expectancy\" measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["years"]
+        },
+        "tags": ["meta-unit", "life-expectancy-vs-gdp"],
+        "meta": {
+            "column": "life_expectancy_0",
+            "unit": "years",
+            "shortUnit": "years"
+        }
+    },
+    {
+        "id": "life-expectancy-vs-gdp/meta-source-1",
+        "chart": "life-expectancy-vs-gdp",
+        "url": "https://ourworldindata.org/grapher/life-expectancy-vs-gdp-per-capita",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": [
+                "Riley",
+                "Zijdeman et al.",
+                "HMD",
+                "UN WPP",
+                "Bolt",
+                "van Zanden – Maddison Project Database 2023"
+            ]
+        },
+        "tags": ["meta-source", "life-expectancy-vs-gdp"],
+        "meta": {
+            "sources": [
+                "Riley",
+                "Zijdeman et al.",
+                "HMD",
+                "UN WPP",
+                "Bolt",
+                "van Zanden – Maddison Project Database 2023"
+            ]
+        }
+    },
+    {
+        "id": "global-warming-by-gas/point-latest-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "point-latest",
+        "question": "According to this chart, what was \"Change in global mean surface temperature caused by CO₂ emissions from agriculture and land use\" for Mongolia in 2024? Give the number in °C.",
+        "gold": {
+            "kind": "number",
+            "number": 0.0017126487,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_co2_land",
+            "entity": "Mongolia",
+            "year": 2024
+        }
+    },
+    {
+        "id": "global-warming-by-gas/point-latest-2",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "point-latest",
+        "question": "According to this chart, what was \"Change in global mean surface temperature caused by CO₂ emissions from agriculture and land use\" for Kyrgyzstan in 2024? Give the number in °C.",
+        "gold": {
+            "kind": "number",
+            "number": 0.00025717766,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_co2_land",
+            "entity": "Kyrgyzstan",
+            "year": 2024
+        }
+    },
+    {
+        "id": "global-warming-by-gas/point-selected-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "point-selected",
+        "question": "According to this chart, what was \"Change in global mean surface temperature caused by CO₂ emissions from fossil fuels and industry\" for World in 2024? Give the number in °C.",
+        "gold": {
+            "kind": "number",
+            "number": 0.80984825,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_co2_fossil",
+            "entity": "World",
+            "year": 2024
+        }
+    },
+    {
+        "id": "global-warming-by-gas/point-start-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "point-start",
+        "question": "According to this chart, what was \"Change in global mean surface temperature caused by methane emissions from fossil fuels and industry\" for World in 1851? Give the number in °C.",
+        "gold": {
+            "kind": "number",
+            "number": 0.0001776375,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_ch4_fossil",
+            "entity": "World",
+            "year": 1851
+        }
+    },
+    {
+        "id": "global-warming-by-gas/change-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "change",
+        "question": "According to this chart, by how much did \"Change in global mean surface temperature caused by methane emissions from fossil fuels and industry\" for World change between 1851 and 2024? Give the absolute change (end value minus start value), in °C.",
+        "gold": {
+            "kind": "number",
+            "number": 0.2164121125,
+            "relTol": 0.01,
+            "absTol": 0.00108294875
+        },
+        "tags": ["change", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_ch4_fossil",
+            "entity": "World",
+            "from": 1851,
+            "to": 2024,
+            "v0": 0.0001776375,
+            "v1": 0.21658975
+        }
+    },
+    {
+        "id": "global-warming-by-gas/rank-max-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest \"Change in global mean surface temperature caused by CO₂ emissions from agriculture and land use\" in 2024? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Brazil"]
+        },
+        "tags": ["rank-max", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_co2_land",
+            "year": 2024,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "global-warming-by-gas/rank-min-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest \"Change in global mean surface temperature caused by CO₂ emissions from agriculture and land use\" in 2024? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["France"]
+        },
+        "tags": ["rank-min", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_co2_land",
+            "year": 2024,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "global-warming-by-gas/unanswerable-late-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was \"Change in global mean surface temperature caused by CO₂ emissions from fossil fuels and industry\" for Ireland in 2025? Give the number in °C.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_co2_fossil",
+            "entity": "Ireland",
+            "year": 2025
+        }
+    },
+    {
+        "id": "global-warming-by-gas/meta-unit-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "meta-unit",
+        "question": "What unit is \"Change in global mean surface temperature caused by methane emissions from agriculture and land use\" measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["°c"]
+        },
+        "tags": ["meta-unit", "global-warming-by-gas"],
+        "meta": {
+            "column": "temperature_response_ch4_land",
+            "unit": "°C",
+            "shortUnit": "°C"
+        }
+    },
+    {
+        "id": "global-warming-by-gas/meta-source-1",
+        "chart": "global-warming-by-gas",
+        "url": "https://ourworldindata.org/grapher/global-warming-by-gas-and-source",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["Jones et al."]
+        },
+        "tags": ["meta-source", "global-warming-by-gas"],
+        "meta": {
+            "sources": ["Jones et al."]
+        }
+    },
+    {
+        "id": "electricity-renewables/point-latest-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "point-latest",
+        "question": "According to this chart, what was the share of electricity generated by renewables for Saint Helena in 2023? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 0,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "entity": "Saint Helena",
+            "year": 2023
+        }
+    },
+    {
+        "id": "electricity-renewables/point-latest-2",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "point-latest",
+        "question": "According to this chart, what was the share of electricity generated by renewables for Guinea-Bissau in 2024? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 0,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "entity": "Guinea-Bissau",
+            "year": 2024
+        }
+    },
+    {
+        "id": "electricity-renewables/point-selected-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "point-selected",
+        "question": "According to this chart, what was the share of electricity generated by renewables for Brazil in 2025? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 86.60146,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "entity": "Brazil",
+            "year": 2025
+        }
+    },
+    {
+        "id": "electricity-renewables/point-start-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "point-start",
+        "question": "According to this chart, what was the share of electricity generated by renewables for World in 1900? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 41.22445,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "entity": "World",
+            "year": 1900
+        }
+    },
+    {
+        "id": "electricity-renewables/change-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "change",
+        "question": "According to this chart, by how much did the share of electricity generated by renewables for World change between 1900 and 2025? Give the absolute change (end value minus start value), in %.",
+        "gold": {
+            "kind": "number",
+            "number": -7.463994,
+            "relTol": 0.01,
+            "absTol": 0.20612224999999998
+        },
+        "tags": ["change", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "entity": "World",
+            "from": 1900,
+            "to": 2025,
+            "v0": 41.22445,
+            "v1": 33.760456
+        }
+    },
+    {
+        "id": "electricity-renewables/unanswerable-early-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the share of electricity generated by renewables for India in 1900? Give the number in %.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "entity": "India",
+            "year": 1900,
+            "firstYear": 1985,
+            "selected": true
+        }
+    },
+    {
+        "id": "electricity-renewables/unanswerable-late-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the share of electricity generated by renewables for Cote d'Ivoire in 2025? Give the number in %.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "entity": "Cote d'Ivoire",
+            "year": 2025,
+            "lastYear": 2024
+        }
+    },
+    {
+        "id": "electricity-renewables/meta-unit-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "meta-unit",
+        "question": "What unit is the share of electricity generated by renewables measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["%"]
+        },
+        "tags": ["meta-unit", "electricity-renewables"],
+        "meta": {
+            "column": "renewable_share_of_electricity__pct",
+            "unit": "%",
+            "shortUnit": "%"
+        }
+    },
+    {
+        "id": "electricity-renewables/meta-source-1",
+        "chart": "electricity-renewables",
+        "url": "https://ourworldindata.org/grapher/electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["Ember"]
+        },
+        "tags": ["meta-source", "electricity-renewables"],
+        "meta": {
+            "sources": ["Ember"]
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/point-latest-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "point-latest",
+        "question": "According to this chart, what was \"Annual number of deaths from floods\" for Colombia in 2025? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 130,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_flood_yearly",
+            "entity": "Colombia",
+            "year": 2025
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/point-latest-2",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "point-latest",
+        "question": "According to this chart, what was \"Annual number of deaths from floods\" for Croatia in 2025? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 0,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_flood_yearly",
+            "entity": "Croatia",
+            "year": 2025
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/point-selected-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "point-selected",
+        "question": "According to this chart, what was \"Annual number of deaths from extreme temperatures\" for World in 2025? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 0,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_extreme_temperature_yearly",
+            "entity": "World",
+            "year": 2025
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/point-start-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "point-start",
+        "question": "According to this chart, what was \"Annual number of deaths from storms\" for World in 2000? Give the number in people.",
+        "gold": {
+            "kind": "number",
+            "number": 1344,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_extreme_weather_yearly",
+            "entity": "World",
+            "year": 2000
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/change-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "change",
+        "question": "According to this chart, by how much did \"Annual number of deaths from storms\" for World change between 2000 and 2025? Give the absolute change (end value minus start value), in people.",
+        "gold": {
+            "kind": "number",
+            "number": 2297,
+            "relTol": 0.01,
+            "absTol": 18.205000000000002
+        },
+        "tags": ["change", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_extreme_weather_yearly",
+            "entity": "World",
+            "from": 2000,
+            "to": 2025,
+            "v0": 1344,
+            "v1": 3641
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/rank-max-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "rank-max",
+        "question": "According to this chart, which country had the highest \"Annual number of deaths from volcanoes\" in 2025? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Martinique"]
+        },
+        "tags": ["rank-max", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_volcanic_activity_yearly",
+            "year": 2025,
+            "pool": "latest"
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/unanswerable-early-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was \"Annual number of deaths from floods\" for Grenada in 2000? Give the number in people.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_flood_yearly",
+            "entity": "Grenada",
+            "year": 2000,
+            "firstYear": 1975,
+            "selected": false
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/unanswerable-late-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was \"Annual number of deaths from volcanoes\" for El Salvador in 2025? Give the number in people.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_volcanic_activity_yearly",
+            "entity": "El Salvador",
+            "year": 2025,
+            "lastYear": 2013
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/meta-unit-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "meta-unit",
+        "question": "What unit is \"Annual number of deaths from volcanoes\" measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["people"]
+        },
+        "tags": ["meta-unit", "natural-disasters-deaths"],
+        "meta": {
+            "column": "total_dead_volcanic_activity_yearly",
+            "unit": "people"
+        }
+    },
+    {
+        "id": "natural-disasters-deaths/meta-source-1",
+        "chart": "natural-disasters-deaths",
+        "url": "https://ourworldindata.org/grapher/natural-disasters-deaths",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["EM-DAT", "CRED", "UCLouvain"]
+        },
+        "tags": ["meta-source", "natural-disasters-deaths"],
+        "meta": {
+            "sources": ["EM-DAT", "CRED", "UCLouvain"]
+        }
+    },
+    {
+        "id": "literacy-women/point-latest-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "point-latest",
+        "question": "According to this chart, what was the literacy rate among adult women aged 15+ for Burundi in 2020? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 66.11045,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "entity": "Burundi",
+            "year": 2020
+        }
+    },
+    {
+        "id": "literacy-women/point-latest-2",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "point-latest",
+        "question": "According to this chart, what was the literacy rate among adult women aged 15+ for Brunei in 2011? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 94.65,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-latest", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "entity": "Brunei",
+            "year": 2011
+        }
+    },
+    {
+        "id": "literacy-women/point-selected-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "point-selected",
+        "question": "According to this chart, what was the literacy rate among adult women aged 15+ for India in 2024? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 70.73868,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-selected", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "entity": "India",
+            "year": 2024
+        }
+    },
+    {
+        "id": "literacy-women/point-start-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "point-start",
+        "question": "According to this chart, what was the literacy rate among adult women aged 15+ for Mali in 1976? Give the number in %.",
+        "gold": {
+            "kind": "number",
+            "number": 5.74,
+            "relTol": 0.01,
+            "absTol": 0
+        },
+        "tags": ["point-start", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "entity": "Mali",
+            "year": 1976
+        }
+    },
+    {
+        "id": "literacy-women/change-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "change",
+        "question": "According to this chart, by how much did the literacy rate among adult women aged 15+ for Mali change between 1976 and 2024? Give the absolute change (end value minus start value), in %.",
+        "gold": {
+            "kind": "number",
+            "number": 22,
+            "relTol": 0.01,
+            "absTol": 0.1387
+        },
+        "tags": ["change", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "entity": "Mali",
+            "from": 1976,
+            "to": 2024,
+            "v0": 5.74,
+            "v1": 27.74
+        }
+    },
+    {
+        "id": "literacy-women/rank-min-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "rank-min",
+        "question": "According to this chart, which country had the lowest literacy rate among adult women aged 15+ in 2024? Consider countries only, not regions, income groups or the world as a whole.",
+        "gold": {
+            "kind": "entity",
+            "entities": ["Mali", "Chad"]
+        },
+        "tags": ["rank-min", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "year": 2024,
+            "pool": "at-end"
+        }
+    },
+    {
+        "id": "literacy-women/unanswerable-early-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "unanswerable-early",
+        "question": "According to this chart, what was the literacy rate among adult women aged 15+ for India in 1976? Give the number in %.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-early", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "entity": "India",
+            "year": 1976,
+            "firstYear": 1981,
+            "selected": true
+        }
+    },
+    {
+        "id": "literacy-women/unanswerable-late-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "unanswerable-late",
+        "question": "According to this chart, what was the literacy rate among adult women aged 15+ for Nicaragua in 2024? Give the number in %.",
+        "gold": {
+            "kind": "none"
+        },
+        "tags": ["unanswerable-late", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "entity": "Nicaragua",
+            "year": 2024,
+            "lastYear": 2014
+        }
+    },
+    {
+        "id": "literacy-women/meta-unit-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "meta-unit",
+        "question": "What unit is the literacy rate among adult women aged 15+ measured in on this page?",
+        "gold": {
+            "kind": "unit",
+            "unitTokens": ["%"]
+        },
+        "tags": ["meta-unit", "literacy-women"],
+        "meta": {
+            "column": "adult_literacy_rate__population_15plus_years__female__pct__lr_ag15t99_f",
+            "unit": "%",
+            "shortUnit": "%"
+        }
+    },
+    {
+        "id": "literacy-women/meta-source-1",
+        "chart": "literacy-women",
+        "url": "https://ourworldindata.org/grapher/literacy?age_group=adult&sex=female",
+        "type": "meta-source",
+        "question": "Which organisations or researchers produced the data shown in this chart? Name the original data providers.",
+        "gold": {
+            "kind": "sources",
+            "sources": ["UNESCO Institute for Statistics"]
+        },
+        "tags": ["meta-source", "literacy-women"],
+        "meta": {
+            "sources": ["UNESCO Institute for Statistics"]
+        }
+    }
+]

--- a/devTools/agentEvals/charts.json
+++ b/devTools/agentEvals/charts.json
@@ -1,0 +1,65 @@
+{
+    "prBranch": "grapher-md-endpoint",
+    "charts": [
+        {
+            "key": "life-expectancy",
+            "path": "life-expectancy",
+            "note": "Line chart; six world regions selected by default"
+        },
+        {
+            "key": "life-expectancy-cze-svk",
+            "path": "life-expectancy?country=~CZE~SVK&time=1990..2023",
+            "note": "Same chart with an entity and time selection in the URL"
+        },
+        {
+            "key": "population",
+            "path": "population",
+            "note": "Values in millions and billions; the series starts in -10000"
+        },
+        {
+            "key": "child-mortality",
+            "path": "child-mortality",
+            "note": "Small percentages"
+        },
+        {
+            "key": "co-emissions-per-capita",
+            "path": "co-emissions-per-capita",
+            "note": "Nine countries selected"
+        },
+        {
+            "key": "gdp-per-capita-worldbank",
+            "path": "gdp-per-capita-worldbank",
+            "note": "Opens on the map tab; currency unit"
+        },
+        {
+            "key": "extreme-poverty",
+            "path": "share-of-population-in-extreme-poverty",
+            "note": "Opens on the map tab; three dimensions"
+        },
+        {
+            "key": "life-expectancy-vs-gdp",
+            "path": "life-expectancy-vs-gdp-per-capita",
+            "note": "Scatter plot with no default selection"
+        },
+        {
+            "key": "global-warming-by-gas",
+            "path": "global-warming-by-gas-and-source",
+            "note": "Stacked area chart: one entity, six columns"
+        },
+        {
+            "key": "electricity-renewables",
+            "path": "electricity-mix?frequency=annual&metric=share_of_generation&source=renewables",
+            "note": "Multi-dimensional chart, view selected by query params"
+        },
+        {
+            "key": "natural-disasters-deaths",
+            "path": "natural-disasters-deaths",
+            "note": "Multi-dimensional chart, default view"
+        },
+        {
+            "key": "literacy-women",
+            "path": "literacy?age_group=adult&sex=female",
+            "note": "Multi-dimensional chart, view selected by query params"
+        }
+    ]
+}

--- a/devTools/agentEvals/checkMarkdownValues.ts
+++ b/devTools/agentEvals/checkMarkdownValues.ts
@@ -1,0 +1,396 @@
+#!/usr/bin/env tsx
+/**
+ * Layer 0, no model involved: does every number printed in /grapher/<slug>.md
+ * match the chart's CSV? Parses the two value tables of each chart's markdown
+ * and compares each cell with the CSV endpoint of the same view.
+ *
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/checkMarkdownValues.ts
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/checkMarkdownValues.ts --chart life-expectancy --verbose
+ */
+import crypto from "crypto"
+import fs from "fs"
+import path from "path"
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import {
+    PROD_ORIGIN,
+    RESULTS_DIR,
+    grapherUrl,
+    loadCharts,
+    stagingOrigin,
+} from "./lib/charts.js"
+import { fetchText } from "./lib/http.js"
+import { MarkdownTable, parseMarkdownTables } from "./lib/markdownTables.js"
+import {
+    approxEqual,
+    displayedHalfUnit,
+    parseFormattedNumber,
+    parseUpperBound,
+} from "./lib/numbers.js"
+import { ChartView, loadView } from "./lib/view.js"
+
+interface Finding {
+    chart: string
+    table: "selected" | "all-entities"
+    kind:
+        | "value-differs"
+        | "year-differs"
+        | "value-without-data"
+        | "missing-value"
+        | "entity-not-in-csv"
+        | "column-unmatched"
+        | "csv-column-not-shown"
+        | "entities-missing"
+        | "csv-parity"
+    entity?: string
+    column?: string
+    year?: number
+    shown?: string
+    expected?: string
+    note?: string
+}
+
+function norm(s: string): string {
+    return s
+        .toLowerCase()
+        .replace(/\(.*?\)/g, "")
+        .replace(/[^a-z0-9]+/g, " ")
+        .trim()
+}
+
+/** Map a markdown column label to a CSV column, by title or by elimination. */
+function matchColumn(view: ChartView, label: string): string | undefined {
+    if (view.columns.length === 1) return view.columns[0]
+    const n = norm(label)
+    for (const c of view.columns) {
+        const m = view.meta.columns[c]
+        const names = [m?.titleShort, m?.titleLong, c]
+            .filter((x): x is string => !!x)
+            .map(norm)
+        if (names.some((x) => x === n || x.includes(n) || n.includes(x)))
+            return c
+    }
+    return undefined
+}
+
+function compare(shown: string, expected: number, relTol = 0.011): boolean {
+    const bound = parseUpperBound(shown)
+    if (bound !== undefined) return expected >= 0 && expected < bound
+    const v = parseFormattedNumber(shown)
+    if (v === undefined) return false
+    // Printed values are rounded, so allow half a unit of the last digit or 1.1%.
+    return approxEqual(v, expected, relTol, displayedHalfUnit(shown) * 1.01)
+}
+
+function checkAllEntitiesTable(
+    view: ChartView,
+    table: MarkdownTable,
+    findings: Finding[]
+): void {
+    const chart = view.spec.key
+    const headers = table.headers
+    const timeIdx = headers.findIndex((h) => /^(year|time|day)$/i.test(h))
+    const valueIdx = headers
+        .map((_, i) => i)
+        .filter((i) => i > 0 && i !== timeIdx)
+    const columnFor = new Map<number, string | undefined>()
+    for (const i of valueIdx) {
+        const col = matchColumn(view, headers[i])
+        columnFor.set(i, col)
+        if (!col)
+            findings.push({
+                chart,
+                table: "all-entities",
+                kind: "column-unmatched",
+                column: headers[i],
+            })
+    }
+    const shownColumns = new Set([...columnFor.values()].filter(Boolean))
+    for (const c of view.columns)
+        if (!shownColumns.has(c))
+            findings.push({
+                chart,
+                table: "all-entities",
+                kind: "csv-column-not-shown",
+                column: view.meta.columns[c]?.titleShort ?? c,
+            })
+
+    const endYear = view.viewEnd
+    const seen = new Set<string>()
+    for (const row of table.rows) {
+        const entity = row[0]
+        seen.add(entity)
+        if (!view.full.byEntity.has(entity)) {
+            findings.push({
+                chart,
+                table: "all-entities",
+                kind: "entity-not-in-csv",
+                entity,
+            })
+            continue
+        }
+        const shownYear = timeIdx >= 0 ? Number(row[timeIdx]) : undefined
+        for (const i of valueIdx) {
+            const col = columnFor.get(i)
+            if (!col) continue
+            const shown = row[i] ?? ""
+            const expected = view.full.latest(entity, col, endYear)
+            if (!expected) {
+                if (shown)
+                    findings.push({
+                        chart,
+                        table: "all-entities",
+                        kind: "value-without-data",
+                        entity,
+                        column: col,
+                        shown,
+                    })
+                continue
+            }
+            if (!shown) {
+                findings.push({
+                    chart,
+                    table: "all-entities",
+                    kind: "missing-value",
+                    entity,
+                    column: col,
+                    expected: String(expected.value),
+                    year: expected.year,
+                })
+                continue
+            }
+            if (!compare(shown, expected.value))
+                findings.push({
+                    chart,
+                    table: "all-entities",
+                    kind: "value-differs",
+                    entity,
+                    column: col,
+                    shown,
+                    expected: String(expected.value),
+                    year: expected.year,
+                })
+            if (
+                shownYear !== undefined &&
+                Number.isFinite(shownYear) &&
+                shownYear !== expected.year
+            )
+                findings.push({
+                    chart,
+                    table: "all-entities",
+                    kind: "year-differs",
+                    entity,
+                    column: col,
+                    shown: String(shownYear),
+                    expected: String(expected.year),
+                })
+        }
+    }
+    const missing = view.full
+        .entities()
+        .filter(
+            (e) =>
+                !seen.has(e) &&
+                view.columns.some((c) => view.full.latest(e, c, endYear))
+        )
+    if (missing.length > 0)
+        findings.push({
+            chart,
+            table: "all-entities",
+            kind: "entities-missing",
+            note: `${missing.length} entities with data are not in the table (e.g. ${missing.slice(0, 3).join(", ")})`,
+        })
+}
+
+function checkSelectedTable(
+    view: ChartView,
+    table: MarkdownTable,
+    findings: Finding[]
+): void {
+    const chart = view.spec.key
+    const label = table.intro.replace(/,\s*in .*$/, "").replace(/\.$/, "")
+    const col = matchColumn(view, label)
+    if (!col) {
+        findings.push({
+            chart,
+            table: "selected",
+            kind: "column-unmatched",
+            column: label,
+        })
+        return
+    }
+    const years = table.headers.slice(1).map(Number)
+    for (const row of table.rows) {
+        const entity = row[0]
+        if (!view.full.byEntity.has(entity)) {
+            findings.push({
+                chart,
+                table: "selected",
+                kind: "entity-not-in-csv",
+                entity,
+            })
+            continue
+        }
+        years.forEach((year, i) => {
+            const shown = row[i + 1] ?? ""
+            if (!Number.isFinite(year)) return
+            const expected = view.full.valueAt(entity, col, year)
+            if (expected === undefined) {
+                if (shown)
+                    findings.push({
+                        chart,
+                        table: "selected",
+                        kind: "value-without-data",
+                        entity,
+                        column: col,
+                        year,
+                        shown,
+                        note: `CSV has no ${year} value; nearest is ${view.full.latest(entity, col, year)?.year ?? view.full.earliest(entity, col)?.year}`,
+                    })
+                return
+            }
+            if (!shown) {
+                findings.push({
+                    chart,
+                    table: "selected",
+                    kind: "missing-value",
+                    entity,
+                    column: col,
+                    year,
+                    expected: String(expected),
+                })
+                return
+            }
+            if (!compare(shown, expected))
+                findings.push({
+                    chart,
+                    table: "selected",
+                    kind: "value-differs",
+                    entity,
+                    column: col,
+                    year,
+                    shown,
+                    expected: String(expected),
+                })
+        })
+    }
+}
+
+async function main(): Promise<void> {
+    const argv = await yargs(hideBin(process.argv))
+        .option("chart", { type: "string", describe: "Only this chart key" })
+        .option("branch", { type: "string" })
+        .option("verbose", { type: "boolean", default: false })
+        .parse()
+
+    const charts = loadCharts()
+    const branch = argv.branch ?? charts.prBranch
+    const specs = charts.charts.filter(
+        (c) => !argv.chart || c.key === argv.chart
+    )
+    fs.mkdirSync(path.join(RESULTS_DIR, "check"), { recursive: true })
+    const findings: Finding[] = []
+    const summary: Record<string, Record<string, number>> = {}
+
+    for (const spec of specs) {
+        const view = await loadView(spec, branch)
+        const mdUrl = grapherUrl(
+            stagingOrigin(branch),
+            view.slug,
+            ".md",
+            view.params
+        )
+        const md = await fetchText(mdUrl)
+        if (md.status !== 200) {
+            console.log(`${spec.key}: ${md.status} from ${mdUrl}`)
+            continue
+        }
+        fs.mkdirSync(path.join(RESULTS_DIR, "check"), { recursive: true })
+        fs.writeFileSync(
+            path.join(RESULTS_DIR, "check", `${spec.key}.md`),
+            md.body
+        )
+
+        // Does the staging data match production? Gold for the QA eval comes
+        // from staging, the "today" pages from production.
+        const prodCsv = await fetchText(
+            grapherUrl(PROD_ORIGIN, view.slug, ".csv", view.params, {
+                csvType: "full",
+                useColumnShortNames: "true",
+            })
+        )
+        const stagingCsv = fs.readFileSync(
+            path.join(RESULTS_DIR, "inputs", spec.key, "full.csv"),
+            "utf8"
+        )
+        const md5 = (s: string): string =>
+            crypto.createHash("md5").update(s).digest("hex")
+        if (prodCsv.status !== 200 || md5(prodCsv.body) !== md5(stagingCsv))
+            findings.push({
+                chart: spec.key,
+                table: "all-entities",
+                kind: "csv-parity",
+                note:
+                    prodCsv.status === 200
+                        ? "staging and production CSVs differ"
+                        : `production CSV returned ${prodCsv.status}`,
+            })
+
+        const before = findings.length
+        const tables = parseMarkdownTables(md.body)
+        for (const t of tables) {
+            if (/^Latest value/i.test(t.heading))
+                checkAllEntitiesTable(view, t, findings)
+            else if (/^Values shown/i.test(t.heading))
+                checkSelectedTable(view, t, findings)
+        }
+        if (!tables.some((t) => /^Latest value/i.test(t.heading)))
+            findings.push({
+                chart: spec.key,
+                table: "all-entities",
+                kind: "entities-missing",
+                note: "no per-entity table in the markdown",
+            })
+
+        const mine = findings.slice(before)
+        const counts: Record<string, number> = {}
+        for (const f of mine) counts[f.kind] = (counts[f.kind] ?? 0) + 1
+        summary[spec.key] = counts
+        const rows =
+            tables.find((t) => /^Latest value/i.test(t.heading))?.rows.length ??
+            0
+        console.log(
+            `${spec.key.padEnd(26)} ${String(rows).padStart(4)} rows  ${md.body.length.toString().padStart(6)} chars  ${
+                mine.length === 0
+                    ? "ok"
+                    : Object.entries(counts)
+                          .map(([k, v]) => `${k}=${v}`)
+                          .join(" ")
+            }`
+        )
+        if (argv.verbose)
+            for (const f of mine.slice(0, 15))
+                console.log(
+                    `    ${f.table}/${f.kind}: ${[f.entity, f.column, f.year, f.shown && `shown=${f.shown}`, f.expected && `expected=${f.expected}`, f.note].filter(Boolean).join("  ")}`
+                )
+    }
+
+    const out = path.join(RESULTS_DIR, "check", "findings.json")
+    fs.writeFileSync(
+        out,
+        JSON.stringify(
+            { branch, checkedAt: new Date().toISOString(), summary, findings },
+            null,
+            2
+        ) + "\n"
+    )
+    const serious = findings.filter((f) =>
+        ["value-differs", "value-without-data", "year-differs"].includes(f.kind)
+    )
+    console.log(
+        `\n${findings.length} findings (${serious.length} value/year mismatches) → ${path.relative(process.cwd(), out)}`
+    )
+    process.exitCode = serious.length > 0 ? 1 : 0
+}
+
+void main()

--- a/devTools/agentEvals/checkMarkdownValues.ts
+++ b/devTools/agentEvals/checkMarkdownValues.ts
@@ -231,9 +231,14 @@ function checkSelectedTable(
             })
             continue
         }
-        years.forEach((year, i) => {
-            const shown = row[i + 1] ?? ""
-            if (!Number.isFinite(year)) return
+        years.forEach((headingYear, i) => {
+            const cell = row[i + 1] ?? ""
+            if (!Number.isFinite(headingYear)) return
+            // "34.7 (1870)" means the entity's own first or last value, from that
+            // year rather than the heading's; check it against that year.
+            const bracket = cell.match(/^(.*?)\s*\((-?\d+)\)$/)
+            const shown = bracket ? bracket[1] : cell
+            const year = bracket ? Number(bracket[2]) : headingYear
             const expected = view.full.valueAt(entity, col, year)
             if (expected === undefined) {
                 if (shown)

--- a/devTools/agentEvals/lib/charts.ts
+++ b/devTools/agentEvals/lib/charts.ts
@@ -1,0 +1,67 @@
+import fs from "fs"
+import path from "path"
+import { fileURLToPath } from "url"
+import { getContainerName } from "../../stagingHostname.js"
+
+export interface ChartSpec {
+    /** Short identifier used in case ids and file names. */
+    key: string
+    /** Path under /grapher/, including any query string. */
+    path: string
+    note?: string
+    /** Restrict questions to these CSV columns (short names); default: every numeric column. */
+    columns?: string[]
+}
+
+export interface ChartsFile {
+    prBranch: string
+    charts: ChartSpec[]
+}
+
+export const PROD_ORIGIN = "https://ourworldindata.org"
+
+export const EVALS_DIR = path.dirname(
+    path.dirname(fileURLToPath(import.meta.url))
+)
+export const RESULTS_DIR = path.join(EVALS_DIR, "results")
+
+export function loadCharts(): ChartsFile {
+    const file = path.join(EVALS_DIR, "charts.json")
+    return JSON.parse(fs.readFileSync(file, "utf8")) as ChartsFile
+}
+
+export function stagingOrigin(branch: string): string {
+    return `http://${getContainerName(branch)}`
+}
+
+export interface SplitPath {
+    slug: string
+    params: URLSearchParams
+}
+
+export function splitPath(chartPath: string): SplitPath {
+    const [slug, search = ""] = chartPath.split("?")
+    return { slug, params: new URLSearchParams(search) }
+}
+
+/**
+ * URL of a grapher resource: `grapherUrl(origin, "life-expectancy", ".csv",
+ * params, { csvType: "full" })`. Extra params are merged after the view params.
+ */
+export function grapherUrl(
+    origin: string,
+    slug: string,
+    extension: string,
+    params: URLSearchParams,
+    extra: Record<string, string> = {}
+): string {
+    const merged = new URLSearchParams(params)
+    for (const [k, v] of Object.entries(extra)) merged.set(k, v)
+    const search = merged.size > 0 ? `?${merged.toString()}` : ""
+    return `${origin}/grapher/${slug}${extension}${search}`
+}
+
+/** The public page URL a reader (or agent) would arrive at. */
+export function prodPageUrl(spec: ChartSpec): string {
+    return `${PROD_ORIGIN}/grapher/${spec.path}`
+}

--- a/devTools/agentEvals/lib/csv.ts
+++ b/devTools/agentEvals/lib/csv.ts
@@ -1,0 +1,136 @@
+import Papa from "papaparse"
+
+export interface CsvRow {
+    entity: string
+    code: string
+    year: number
+    values: Record<string, number | undefined>
+}
+
+export interface Observation {
+    year: number
+    value: number
+}
+
+/** A grapher CSV (`Entity,Code,Year,<columns…>`) indexed for lookups. */
+export class Dataset {
+    readonly columns: string[]
+    readonly rows: CsvRow[]
+    readonly byEntity = new Map<string, CsvRow[]>()
+    private readonly codes = new Map<string, string>()
+
+    constructor(columns: string[], rows: CsvRow[]) {
+        this.columns = columns
+        this.rows = rows
+        for (const row of rows) {
+            const list = this.byEntity.get(row.entity) ?? []
+            list.push(row)
+            this.byEntity.set(row.entity, list)
+            if (row.code) this.codes.set(row.entity, row.code)
+        }
+        for (const list of this.byEntity.values())
+            list.sort((a, b) => a.year - b.year)
+    }
+
+    entities(): string[] {
+        return [...this.byEntity.keys()].sort()
+    }
+
+    /**
+     * Countries carry a three-letter ISO code. Aggregates (World, continents,
+     * income groups, "Asia (UN)") have no code or a synthetic one (OWID_WRL, UN_ASI).
+     */
+    isAggregate(entity: string): boolean {
+        const code = this.codes.get(entity) ?? ""
+        return !/^[A-Z]{3}$/.test(code)
+    }
+
+    countries(): string[] {
+        return this.entities().filter((e) => !this.isAggregate(e))
+    }
+
+    /** Columns where most cells that are filled parse as numbers. */
+    numericColumns(): string[] {
+        return this.columns.filter((column) => {
+            let filled = 0
+            let numeric = 0
+            for (const row of this.rows) {
+                const v = row.values[column]
+                if (v === undefined) continue
+                filled++
+                if (Number.isFinite(v)) numeric++
+            }
+            return filled > 0 && numeric / filled > 0.5
+        })
+    }
+
+    observations(entity: string, column: string): Observation[] {
+        return (this.byEntity.get(entity) ?? [])
+            .filter((row) => row.values[column] !== undefined)
+            .map((row) => ({ year: row.year, value: row.values[column]! }))
+    }
+
+    valueAt(entity: string, column: string, year: number): number | undefined {
+        return this.observations(entity, column).find((o) => o.year === year)
+            ?.value
+    }
+
+    /** Latest observation at or before `maxYear` (or overall). */
+    latest(
+        entity: string,
+        column: string,
+        maxYear?: number
+    ): Observation | undefined {
+        const obs = this.observations(entity, column).filter(
+            (o) => maxYear === undefined || o.year <= maxYear
+        )
+        return obs.at(-1)
+    }
+
+    earliest(entity: string, column: string): Observation | undefined {
+        return this.observations(entity, column)[0]
+    }
+
+    years(column?: string): number[] {
+        const set = new Set<number>()
+        for (const row of this.rows) {
+            if (column === undefined || row.values[column] !== undefined)
+                set.add(row.year)
+        }
+        return [...set].sort((a, b) => a - b)
+    }
+
+    maxYear(column?: string): number | undefined {
+        return this.years(column).at(-1)
+    }
+
+    minYear(column?: string): number | undefined {
+        return this.years(column)[0]
+    }
+}
+
+export function parseDataset(csv: string): Dataset {
+    const parsed = Papa.parse<string[]>(csv.trim(), { skipEmptyLines: true })
+    const [header, ...body] = parsed.data
+    if (!header || header[0].toLowerCase() !== "entity")
+        throw new Error(
+            `Not a grapher CSV (header starts with ${JSON.stringify(header?.[0])})`
+        )
+    const columns = header.slice(3)
+    const rows: CsvRow[] = body.map((cells) => {
+        const values: Record<string, number | undefined> = {}
+        columns.forEach((column, i) => {
+            const cell = cells[i + 3]
+            if (cell === undefined || cell === "") return
+            const n = Number(cell)
+            values[column] = Number.isFinite(n) ? n : NaN
+        })
+        return {
+            entity: cells[0],
+            code: cells[1] ?? "",
+            year: Number(cells[2]),
+            values,
+        }
+    })
+    return new Dataset(columns, rows)
+}

--- a/devTools/agentEvals/lib/http.ts
+++ b/devTools/agentEvals/lib/http.ts
@@ -1,0 +1,68 @@
+import fs from "fs"
+import path from "path"
+
+export interface FetchTextResult {
+    status: number
+    contentType: string
+    body: string
+    url: string
+}
+
+export interface FetchTextOptions {
+    accept?: string
+    timeoutMs?: number
+    retries?: number
+}
+
+/** GET a text resource with a wall-clock timeout and a couple of retries on 5xx. */
+export async function fetchText(
+    url: string,
+    { accept, timeoutMs = 90_000, retries = 2 }: FetchTextOptions = {}
+): Promise<FetchTextResult> {
+    let lastError: unknown
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        const controller = new AbortController()
+        const timer = setTimeout(() => controller.abort(), timeoutMs)
+        try {
+            const response = await fetch(url, {
+                headers: accept ? { accept } : {},
+                signal: controller.signal,
+                redirect: "follow",
+            })
+            const body = await response.text()
+            if (response.status >= 500 && attempt < retries) {
+                lastError = new Error(`${response.status} from ${url}`)
+                continue
+            }
+            return {
+                status: response.status,
+                contentType: response.headers.get("content-type") ?? "",
+                body,
+                url,
+            }
+        } catch (error) {
+            lastError = error
+        } finally {
+            clearTimeout(timer)
+        }
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)))
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError))
+}
+
+/** Like fetchText, but stores the body on disk and reuses it on later runs. */
+export async function fetchTextCached(
+    url: string,
+    cacheFile: string,
+    options: FetchTextOptions = {}
+): Promise<string> {
+    if (fs.existsSync(cacheFile)) return fs.readFileSync(cacheFile, "utf8")
+    const result = await fetchText(url, options)
+    if (result.status !== 200)
+        throw new Error(
+            `${result.status} from ${url}: ${result.body.slice(0, 200)}`
+        )
+    fs.mkdirSync(path.dirname(cacheFile), { recursive: true })
+    fs.writeFileSync(cacheFile, result.body)
+    return result.body
+}

--- a/devTools/agentEvals/lib/markdownTables.ts
+++ b/devTools/agentEvals/lib/markdownTables.ts
@@ -1,0 +1,53 @@
+export interface MarkdownTable {
+    /** Text of the nearest preceding heading (any level), without the hashes. */
+    heading: string
+    /** The last non-empty line before the table, with bold markers stripped — e.g. "Life expectancy, in years." */
+    intro: string
+    headers: string[]
+    rows: string[][]
+}
+
+function splitRow(line: string): string[] {
+    return line
+        .trim()
+        .replace(/^\|/, "")
+        .replace(/\|$/, "")
+        .split("|")
+        .map((cell) => cell.trim())
+}
+
+function isSeparator(line: string): boolean {
+    return /^\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)*\|?\s*$/.test(line)
+}
+
+export function parseMarkdownTables(markdown: string): MarkdownTable[] {
+    const lines = markdown.split("\n")
+    const tables: MarkdownTable[] = []
+    let heading = ""
+    let lastText = ""
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+        const h = line.match(/^#{1,6}\s+(.*)$/)
+        if (h) {
+            heading = h[1].trim()
+            lastText = ""
+            continue
+        }
+        if (line.trim().startsWith("|") && isSeparator(lines[i + 1] ?? "")) {
+            const headers = splitRow(line)
+            const intro = lastText.replace(/\*\*/g, "").trim()
+            const rows: string[][] = []
+            let j = i + 2
+            while (j < lines.length && lines[j].trim().startsWith("|")) {
+                rows.push(splitRow(lines[j]))
+                j++
+            }
+            tables.push({ heading, intro, headers, rows })
+            i = j - 1
+            lastText = ""
+            continue
+        }
+        if (line.trim()) lastText = line
+    }
+    return tables
+}

--- a/devTools/agentEvals/lib/numbers.ts
+++ b/devTools/agentEvals/lib/numbers.ts
@@ -1,0 +1,58 @@
+// Grapher spells multipliers out; single letters would collide with units
+// such as "t" for tonnes.
+const MULTIPLIERS: Record<string, number> = {
+    thousand: 1e3,
+    million: 1e6,
+    billion: 1e9,
+    trillion: 1e12,
+}
+
+/**
+ * Parse a number the way grapher prints it: "79.6 years", "1.18 million",
+ * "$1,234", "12.5%", "−3.2", "609 million people". Returns undefined for
+ * anything that is not a single number (empty cells, "<0.1", text).
+ */
+export function parseFormattedNumber(input: string): number | undefined {
+    let s = input.trim().replace(/−/g, "-").replace(/,/g, "")
+    if (!s) return undefined
+    // Strip a leading currency symbol.
+    s = s.replace(/^[$€£¥]\s*/, "")
+    const match = s.match(/^(-?\d+(?:\.\d+)?)(?:\s*([a-zA-Z]+))?/)
+    if (!match) return undefined
+    let value = Number(match[1])
+    if (!Number.isFinite(value)) return undefined
+    const word = match[2]?.toLowerCase()
+    if (word && word in MULTIPLIERS) value *= MULTIPLIERS[word]
+    return value
+}
+
+/**
+ * Half a unit of the last printed digit, scaled by any multiplier word — the
+ * largest rounding error a displayed value can carry.
+ */
+export function displayedHalfUnit(display: string): number {
+    const s = display.trim().replace(/−/g, "-").replace(/,/g, "")
+    const match = s.match(/^[$€£¥]?\s*-?(\d+)(?:\.(\d+))?(?:\s*([a-zA-Z]+))?/)
+    if (!match) return 0
+    const decimals = match[2]?.length ?? 0
+    const word = match[3]?.toLowerCase()
+    const multiplier = word && word in MULTIPLIERS ? MULTIPLIERS[word] : 1
+    return (0.5 * multiplier) / 10 ** decimals
+}
+
+/** "<0.01 °C" → 0.01: the bound grapher prints for values below its display precision. */
+export function parseUpperBound(input: string): number | undefined {
+    const s = input.trim()
+    if (!s.startsWith("<")) return undefined
+    return parseFormattedNumber(s.slice(1))
+}
+
+export function approxEqual(
+    a: number,
+    b: number,
+    relTol: number,
+    absTol = 0
+): boolean {
+    const tol = Math.max(relTol * Math.abs(b), absTol)
+    return Math.abs(a - b) <= tol
+}

--- a/devTools/agentEvals/lib/random.ts
+++ b/devTools/agentEvals/lib/random.ts
@@ -1,0 +1,41 @@
+/** Small seeded PRNG (mulberry32) so case generation is reproducible. */
+export class Random {
+    private state: number
+
+    constructor(seed: number) {
+        this.state = seed >>> 0
+    }
+
+    next(): number {
+        this.state = (this.state + 0x6d2b79f5) >>> 0
+        let t = this.state
+        t = Math.imul(t ^ (t >>> 15), t | 1)
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+    }
+
+    pick<T>(items: readonly T[]): T | undefined {
+        if (items.length === 0) return undefined
+        return items[Math.floor(this.next() * items.length)]
+    }
+
+    /** Up to `n` distinct items, in random order. */
+    sample<T>(items: readonly T[], n: number): T[] {
+        const pool = [...items]
+        const out: T[] = []
+        while (pool.length > 0 && out.length < n) {
+            const i = Math.floor(this.next() * pool.length)
+            out.push(pool.splice(i, 1)[0])
+        }
+        return out
+    }
+}
+
+export function hashString(s: string): number {
+    let h = 2166136261
+    for (let i = 0; i < s.length; i++) {
+        h ^= s.charCodeAt(i)
+        h = Math.imul(h, 16777619)
+    }
+    return h >>> 0
+}

--- a/devTools/agentEvals/lib/view.ts
+++ b/devTools/agentEvals/lib/view.ts
@@ -1,0 +1,161 @@
+import path from "path"
+import { Dataset, parseDataset } from "./csv.js"
+import { fetchTextCached } from "./http.js"
+import {
+    ChartSpec,
+    RESULTS_DIR,
+    grapherUrl,
+    splitPath,
+    stagingOrigin,
+} from "./charts.js"
+
+export interface ColumnMeta {
+    titleShort: string
+    titleLong: string
+    unit: string
+    shortUnit: string
+    citationShort: string
+    type: string
+}
+
+export interface ChartMetadata {
+    chart: { title: string; selection: string[]; citation: string }
+    columns: Record<string, ColumnMeta>
+}
+
+/**
+ * Everything the case builder and the value checker know about one chart view,
+ * read from the pre-existing data endpoints (not from the markdown under test):
+ * the full CSV (every entity), the filtered CSV (the view's selection and time
+ * range) and the metadata JSON.
+ */
+export interface ChartView {
+    spec: ChartSpec
+    slug: string
+    params: URLSearchParams
+    origin: string
+    full: Dataset
+    filtered: Dataset
+    meta: ChartMetadata
+    /** Numeric columns present in both the CSV and the metadata. */
+    columns: string[]
+    selection: string[]
+    viewStart: number | undefined
+    viewEnd: number | undefined
+}
+
+export async function loadView(
+    spec: ChartSpec,
+    branch: string
+): Promise<ChartView> {
+    const origin = stagingOrigin(branch)
+    const { slug, params } = splitPath(spec.path)
+    const dir = path.join(RESULTS_DIR, "inputs", spec.key)
+    const shortNames = { useColumnShortNames: "true" }
+
+    const [fullCsv, filteredCsv, metaJson] = await Promise.all([
+        fetchTextCached(
+            grapherUrl(origin, slug, ".csv", params, {
+                ...shortNames,
+                csvType: "full",
+            }),
+            path.join(dir, "full.csv")
+        ),
+        fetchTextCached(
+            grapherUrl(origin, slug, ".csv", params, {
+                ...shortNames,
+                csvType: "filtered",
+            }),
+            path.join(dir, "filtered.csv")
+        ),
+        fetchTextCached(
+            grapherUrl(origin, slug, ".metadata.json", params, shortNames),
+            path.join(dir, "metadata.json")
+        ),
+    ])
+
+    const full = parseDataset(fullCsv)
+    const filtered = parseDataset(filteredCsv)
+    const meta = JSON.parse(metaJson) as ChartMetadata
+    let columns = full
+        .numericColumns()
+        .filter((c) => meta.columns[c] && meta.columns[c].type !== "String")
+    // On charts about something else, the population column is only there to
+    // size scatter points or annotate tooltips; nobody asks the chart for it.
+    if (columns.length > 1)
+        columns = columns.filter((c) => c !== "population_historical")
+    if (spec.columns) columns = columns.filter((c) => spec.columns!.includes(c))
+    // A country= param replaces the chart's default selection; the filtered CSV
+    // is exactly that selection.
+    const selection = (
+        params.has("country")
+            ? filtered.entities()
+            : (meta.chart.selection ?? [])
+    ).filter((e) => full.byEntity.has(e))
+
+    // The years the chart displays for its selection. Grapher decides these
+    // (config min/max time, the first selected entity's data range), so read
+    // them back from the pre-existing values.json endpoint rather than guessing
+    // from the CSV; an explicit time= param wins.
+    let viewStart = filtered.minYear() ?? full.minYear()
+    let viewEnd = filtered.maxYear() ?? full.maxYear()
+    const timeParam = params.get("time")?.match(/^(-?\d+)\.\.(-?\d+)$/)
+    if (timeParam) {
+        viewStart = Number(timeParam[1])
+        viewEnd = Number(timeParam[2])
+    } else {
+        const valuesJson = await fetchTextCached(
+            grapherUrl(origin, slug, ".values.json", params),
+            path.join(dir, "values.json")
+        )
+        const values = JSON.parse(valuesJson) as {
+            startTime?: number
+            endTime?: number
+        }
+        if (typeof values.startTime === "number") viewStart = values.startTime
+        if (typeof values.endTime === "number") viewEnd = values.endTime
+    }
+
+    return {
+        spec,
+        slug,
+        params,
+        origin,
+        full,
+        filtered,
+        meta,
+        columns,
+        selection,
+        viewStart,
+        viewEnd,
+    }
+}
+
+/**
+ * Producer names from a citationShort like
+ * "Riley (2005); Zijdeman et al. (2015); HMD (2025) – with major processing by Our World in Data".
+ */
+export function producersFromCitation(citation: string): string[] {
+    const withoutProcessing = citation.split(/\s[–-]\s(?:with|processed)/i)[0]
+    const noise = /^(and )?(other|various) sources$|^population based on/i
+    return withoutProcessing
+        .split(/;|,|\/|\band\b/)
+        .map((part) =>
+            part
+                .replace(/\([^)]*\)/g, "")
+                .replace(/\s+/g, " ")
+                .trim()
+        )
+        .filter((name) => name.length > 1 && !noise.test(name))
+}
+
+export function sourceNames(view: ChartView): string[] {
+    const names = new Set<string>()
+    for (const column of view.columns) {
+        for (const name of producersFromCitation(
+            view.meta.columns[column]?.citationShort ?? ""
+        ))
+            names.add(name)
+    }
+    return [...names]
+}

--- a/devTools/agentEvals/runDocQa.ts
+++ b/devTools/agentEvals/runDocQa.ts
@@ -1,0 +1,749 @@
+#!/usr/bin/env tsx
+/**
+ * Document-QA eval: ask an agent questions about a chart page under different
+ * text renderings of that page, and grade the answers against gold values
+ * derived from the CSV endpoints (see buildCases.ts).
+ *
+ * Conditions:
+ *   today – the production page fetched with `Accept: text/markdown`, i.e.
+ *           Cloudflare's HTML→markdown conversion: what an agent that doesn't
+ *           run JavaScript reads today.
+ *   pr    – the PR's /grapher/<slug>.md from the branch's staging server.
+ *   none  – no page at all: what the model answers from memory. A control
+ *           that shows how much of a correct answer the page contributed.
+ *
+ * The agent is `claude -p` with no tools; the page is handed over as a fetched
+ * document and the answer comes back as structured JSON.
+ *
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runDocQa.ts --name pilot --limit 10
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runDocQa.ts --name full --model sonnet --reps 2
+ */
+import { spawn } from "child_process"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import { pathToFileURL } from "url"
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import {
+    EVALS_DIR,
+    RESULTS_DIR,
+    ChartSpec,
+    grapherUrl,
+    loadCharts,
+    prodPageUrl,
+    splitPath,
+    stagingOrigin,
+} from "./lib/charts.js"
+import { fetchTextCached } from "./lib/http.js"
+import { approxEqual } from "./lib/numbers.js"
+import type { EvalCase, Gold } from "./buildCases.js"
+
+export type Condition = "today" | "pr" | "none"
+const CONDITIONS: Condition[] = ["today", "pr", "none"]
+
+export interface AgentAnswer {
+    answer_number: number | null
+    answer_entity: string | null
+    answer_text: string
+    found_in_page: boolean
+    evidence: string
+}
+
+export interface Grade {
+    correct: number
+    grounded: number
+    hallucinated: number
+    abstained: number
+}
+
+export interface ResultRow {
+    prompt_id: string
+    case_id: string
+    condition: Condition
+    rep: number
+    prompt: string
+    tags: string[]
+    status: "ok"
+    stop_reason: string | null
+    grade: Grade
+    explanation: string
+    answer: AgentAnswer
+    gold: Gold
+    model: string
+    usage: {
+        input_tokens: number
+        output_tokens: number
+        cache_read_input_tokens: number
+        cache_creation_input_tokens: number
+    }
+    cost_usd: number
+    latency_s: number
+    attempts: number
+    doc_chars: number
+    meta: Record<string, unknown>
+}
+
+interface ErrorRow {
+    case_id: string
+    condition: Condition
+    rep: number
+    class: "api_error" | "timeout" | "unparseable" | "spawn_error"
+    attempts: number
+    message: string
+    model?: string
+    usage?: ResultRow["usage"]
+}
+
+const ANSWER_SCHEMA = {
+    type: "object",
+    properties: {
+        answer_number: { type: ["number", "null"] },
+        answer_entity: { type: ["string", "null"] },
+        answer_text: { type: "string" },
+        found_in_page: { type: "boolean" },
+        evidence: { type: "string" },
+    },
+    required: [
+        "answer_number",
+        "answer_entity",
+        "answer_text",
+        "found_in_page",
+        "evidence",
+    ],
+    additionalProperties: false,
+}
+
+const SYSTEM_PROMPT_WITH_PAGE = `You are a careful research assistant answering a user's question about data published by Our World in Data.
+
+The user's tooling has already fetched the relevant page and pasted its text content into the message. You have no other tools and no internet access.
+
+Rules:
+- Answer only from the page content provided. If the page does not contain the information needed, say so: set found_in_page to false and leave answer_number and answer_entity null. Do not fill gaps from memory and do not estimate from other figures on the page.
+- If the page does contain the answer, put the exact fragment you relied on into evidence: a verbatim copy of one table row or sentence from the page, with no commentary around it.
+- answer_number is a plain number in the unit the question asks for (write 609000000, not "609 million"; write 12.5 for 12.5%). answer_entity is the entity's name when the question asks which country or region.
+- answer_text is one or two sentences for the user.`
+
+const SYSTEM_PROMPT_WITHOUT_PAGE = `You are a careful research assistant answering a user's question about data published by Our World in Data.
+
+The user's tooling tried to fetch the relevant page but got no usable text. You have no tools and no internet access.
+
+Rules:
+- Set found_in_page to false and leave evidence empty, since no page content is available.
+- If you know the answer with reasonable confidence, give it: answer_number as a plain number in the unit the question asks for (write 609000000, not "609 million"; write 12.5 for 12.5%), or answer_entity when the question asks which country or region. If you do not know, leave them null and say so.
+- answer_text is one or two sentences for the user.`
+
+function normalize(s: string): string {
+    return s
+        .normalize("NFKD")
+        .replace(/[̀-ͯ]/g, "")
+        .toLowerCase()
+        .replace(/per ?cent/g, "%")
+        .replace(/[^a-z0-9%$°]+/g, " ")
+        .trim()
+}
+
+/**
+ * The model is asked to quote the page verbatim, but often wraps the quote in
+ * a sentence or two. Accept the whole string, any quoted fragment, or any line
+ * of it, as long as one of them appears in the page.
+ */
+function evidenceIsInDoc(evidence: string, doc: string): boolean {
+    const haystack = normalize(doc)
+    const candidates = [
+        evidence,
+        ...(evidence.match(/["“]([^"”]{6,})["”]/g) ?? []).map((q) =>
+            q.slice(1, -1)
+        ),
+        ...evidence.split(/\n|\||: /),
+    ]
+    return candidates.some((c) => {
+        const n = normalize(c)
+        return n.length >= 6 && haystack.includes(n)
+    })
+}
+
+/**
+ * The page prints rounded values ("0.9%" for 0.95), so an answer copied from
+ * it can miss a 1% tolerance while being exactly what the page says. Accept an
+ * answer that equals gold rounded to the answer's own precision, as long as
+ * that rounding step is small relative to the value (so "0" or "0.01" never
+ * passes for 0.0017).
+ */
+function matchesAtOwnPrecision(answer: number, gold: number): boolean {
+    if (answer === 0 || gold === 0) return false
+    const decimals = (String(answer).split(".")[1] ?? "").length
+    const halfUnit = 0.5 / 10 ** decimals
+    if (halfUnit > 0.1 * Math.abs(gold)) return false
+    return Math.abs(answer - gold) <= halfUnit
+}
+
+export function grade(
+    evalCase: EvalCase,
+    answer: AgentAnswer,
+    doc: string
+): { grade: Grade; explanation: string } {
+    const gold = evalCase.gold
+    const text = normalize(answer.answer_text ?? "")
+    const grounded =
+        answer.found_in_page && evidenceIsInDoc(answer.evidence ?? "", doc)
+
+    let answered: boolean
+    let correct: boolean
+    let explanation: string
+    switch (gold.kind) {
+        case "number": {
+            answered = answer.answer_number !== null
+            correct =
+                answered &&
+                (approxEqual(
+                    answer.answer_number!,
+                    gold.number!,
+                    gold.relTol ?? 0.01,
+                    gold.absTol ?? 0
+                ) ||
+                    matchesAtOwnPrecision(answer.answer_number!, gold.number!))
+            explanation = `expected ${gold.number}, got ${answer.answer_number}`
+            break
+        }
+        case "entity": {
+            const entity = normalize(answer.answer_entity ?? "")
+            answered = entity.length > 0
+            correct =
+                answered &&
+                gold.entities!.some((e) => {
+                    const n = normalize(e)
+                    return (
+                        entity === n || entity.includes(n) || n.includes(entity)
+                    )
+                })
+            explanation = `expected one of ${gold.entities!.join(" / ")}, got ${answer.answer_entity}`
+            break
+        }
+        case "none": {
+            // Unanswerable cases are all numeric lookups; models routinely echo
+            // the asked-about entity into answer_entity, which is not an answer.
+            answered = answer.answer_number !== null
+            correct = !answered
+            explanation = answered
+                ? `page has no value here, but got ${answer.answer_number}`
+                : "correctly declined"
+            break
+        }
+        case "unit": {
+            answered = text.length > 0
+            const tokens = gold.unitTokens!.map(normalize).filter(Boolean)
+            const hits = tokens.filter((t) => text.includes(t))
+            correct =
+                answered &&
+                (hits.some((t) => t.length <= 2) ||
+                    hits.length * 2 >= tokens.length)
+            explanation = `unit tokens ${JSON.stringify(tokens)}, matched ${JSON.stringify(hits)}`
+            break
+        }
+        case "sources": {
+            answered = text.length > 0
+            const hits = gold.sources!.filter((s) =>
+                text.includes(normalize(s))
+            )
+            correct = answered && hits.length > 0
+            explanation = `sources ${JSON.stringify(gold.sources)}, matched ${JSON.stringify(hits)}`
+            break
+        }
+    }
+
+    const isUnanswerable = gold.kind === "none"
+    return {
+        grade: {
+            correct: correct ? 1 : 0,
+            grounded: correct && (isUnanswerable || grounded) ? 1 : 0,
+            hallucinated: (isUnanswerable ? answered : answered && !correct)
+                ? 1
+                : 0,
+            abstained: answered ? 0 : 1,
+        },
+        explanation,
+    }
+}
+
+interface ClaudeResult {
+    is_error: boolean
+    result?: string
+    structured_output?: AgentAnswer
+    stop_reason?: string | null
+    api_error_status?: number | null
+    modelUsage?: Record<string, unknown>
+    usage?: Record<string, number>
+    total_cost_usd?: number
+    duration_api_ms?: number
+    duration_ms?: number
+}
+
+interface RunOptions {
+    model: string
+    effort?: string
+    timeoutMs: number
+    cwd: string
+    systemPromptFile: string
+}
+
+class CallError extends Error {
+    constructor(
+        readonly cls: ErrorRow["class"],
+        message: string,
+        readonly retryable: boolean,
+        readonly parsed?: ClaudeResult
+    ) {
+        super(message)
+    }
+}
+
+function runClaude(
+    userMessage: string,
+    options: RunOptions
+): Promise<ClaudeResult> {
+    const args = [
+        "-p",
+        "--system-prompt-file",
+        options.systemPromptFile,
+        "--tools",
+        "",
+        "--model",
+        options.model,
+        "--output-format",
+        "json",
+        "--json-schema",
+        JSON.stringify(ANSWER_SCHEMA),
+        "--no-session-persistence",
+        "--strict-mcp-config",
+    ]
+    if (options.effort) args.push("--effort", options.effort)
+
+    return new Promise((resolve, reject) => {
+        const child = spawn("claude", args, {
+            cwd: options.cwd,
+            stdio: ["pipe", "pipe", "pipe"],
+        })
+        let stdout = ""
+        let stderr = ""
+        let timedOut = false
+        const timer = setTimeout(() => {
+            timedOut = true
+            child.kill("SIGKILL")
+        }, options.timeoutMs)
+        child.stdout.on("data", (d) => (stdout += d))
+        child.stderr.on("data", (d) => (stderr += d))
+        child.on("error", (err) => {
+            clearTimeout(timer)
+            reject(new CallError("spawn_error", err.message, false))
+        })
+        child.on("close", (code) => {
+            clearTimeout(timer)
+            // A hung CLI start (no output at all) has been seen to clear on the
+            // next attempt, so a timeout is retried once; attempts are recorded.
+            if (timedOut)
+                return reject(
+                    new CallError(
+                        "timeout",
+                        `killed after ${options.timeoutMs} ms; stdout: ${stdout.slice(0, 200)}; stderr: ${stderr.slice(0, 300)}`,
+                        true
+                    )
+                )
+            let parsed: ClaudeResult
+            try {
+                parsed = JSON.parse(stdout) as ClaudeResult
+            } catch {
+                return reject(
+                    new CallError(
+                        "unparseable",
+                        `exit ${code}; stdout: ${stdout.slice(0, 300)}; stderr: ${stderr.slice(0, 300)}`,
+                        code !== 0
+                    )
+                )
+            }
+            if (parsed.is_error) {
+                const status = parsed.api_error_status ?? 0
+                const retryable =
+                    [429, 500, 502, 503, 529].includes(status) ||
+                    /rate limit|overloaded|529|timeout/i.test(
+                        parsed.result ?? ""
+                    )
+                return reject(
+                    new CallError(
+                        "api_error",
+                        `${status}: ${(parsed.result ?? "").slice(0, 300)}`,
+                        retryable,
+                        parsed
+                    )
+                )
+            }
+            if (!parsed.structured_output)
+                return reject(
+                    new CallError(
+                        "unparseable",
+                        `no structured_output; result: ${(parsed.result ?? "").slice(0, 300)}`,
+                        false,
+                        parsed
+                    )
+                )
+            resolve(parsed)
+        })
+        child.stdin.end(userMessage)
+    })
+}
+
+function usageOf(parsed: ClaudeResult | undefined): ResultRow["usage"] {
+    const u = parsed?.usage ?? {}
+    return {
+        input_tokens: u.input_tokens ?? 0,
+        output_tokens: u.output_tokens ?? 0,
+        cache_read_input_tokens: u.cache_read_input_tokens ?? 0,
+        cache_creation_input_tokens: u.cache_creation_input_tokens ?? 0,
+    }
+}
+
+function servedModel(parsed: ClaudeResult | undefined): string {
+    return Object.keys(parsed?.modelUsage ?? {}).join("+") || "unknown"
+}
+
+function userMessage(
+    evalCase: EvalCase,
+    condition: Condition,
+    doc: string
+): string {
+    if (condition === "none")
+        return `I tried to fetch ${evalCase.url} but got no usable text back (the chart needs JavaScript).\n\nQuestion: ${evalCase.question}`
+    return `I fetched the page ${evalCase.url} from ourworldindata.org. Here is its text content:\n\n<page_content>\n${doc}\n</page_content>\n\nQuestion: ${evalCase.question}`
+}
+
+async function fetchDoc(
+    spec: ChartSpec,
+    condition: Condition,
+    branch: string
+): Promise<string> {
+    if (condition === "none") return ""
+    const file = path.join(RESULTS_DIR, "docs", condition, `${spec.key}.md`)
+    if (condition === "today") {
+        const body = await fetchTextCached(prodPageUrl(spec), file, {
+            accept: "text/markdown",
+        })
+        if (/^\s*<(!doctype|html)/i.test(body)) {
+            fs.rmSync(file, { force: true })
+            throw new Error(
+                `${prodPageUrl(spec)} returned HTML, not markdown — is Cloudflare's markdown conversion still on?`
+            )
+        }
+        return body
+    }
+    const { slug, params } = splitPath(spec.path)
+    return fetchTextCached(
+        grapherUrl(stagingOrigin(branch), slug, ".md", params),
+        file
+    )
+}
+
+function appendJsonl(file: string, row: unknown): void {
+    fs.appendFileSync(file, JSON.stringify(row) + "\n")
+}
+
+function readJsonl<T>(file: string): T[] {
+    if (!fs.existsSync(file)) return []
+    return fs
+        .readFileSync(file, "utf8")
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as T)
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms))
+}
+
+async function main(): Promise<void> {
+    const argv = await yargs(hideBin(process.argv))
+        .option("cases", {
+            type: "string",
+            default: path.join(EVALS_DIR, "cases.json"),
+        })
+        .option("name", {
+            type: "string",
+            default: new Date()
+                .toISOString()
+                .slice(0, 16)
+                .replace(/[:T]/g, "-"),
+            describe: "Run name; results land in results/runs/<name>/",
+        })
+        .option("conditions", {
+            type: "string",
+            default: CONDITIONS.join(","),
+        })
+        .option("model", {
+            type: "string",
+            default: "sonnet",
+            describe: "Model alias or id passed to claude --model",
+        })
+        .option("effort", { type: "string" })
+        .option("reps", { type: "number", default: 1 })
+        .option("concurrency", { type: "number", default: 5 })
+        .option("filter", {
+            type: "string",
+            describe:
+                "Regex over case ids (e.g. 'life-expectancy/' or 'rank-')",
+        })
+        .option("limit", { type: "number" })
+        .option("branch", { type: "string" })
+        .option("timeout-s", { type: "number", default: 300 })
+        .option("refresh-docs", {
+            type: "boolean",
+            default: false,
+            describe:
+                "Re-download the page snapshots instead of reusing cached ones",
+        })
+        .parse()
+
+    const charts = loadCharts()
+    const branch = argv.branch ?? charts.prBranch
+    const conditions = argv.conditions.split(",") as Condition[]
+    for (const c of conditions)
+        if (!CONDITIONS.includes(c)) throw new Error(`unknown condition ${c}`)
+
+    let cases = JSON.parse(fs.readFileSync(argv.cases, "utf8")) as EvalCase[]
+    if (argv.filter) {
+        const re = new RegExp(argv.filter)
+        cases = cases.filter((c) => re.test(c.id))
+    }
+    if (argv.limit) cases = cases.slice(0, argv.limit)
+
+    const runDir = path.join(RESULTS_DIR, "runs", argv.name)
+    fs.mkdirSync(runDir, { recursive: true })
+    // An empty directory outside the repo, so the agent picks up no CLAUDE.md,
+    // project settings or hooks from this checkout.
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "agent-evals-"))
+    if (argv.refreshDocs)
+        fs.rmSync(path.join(RESULTS_DIR, "docs"), {
+            recursive: true,
+            force: true,
+        })
+
+    // Page snapshots, one per chart and condition, fetched up front so a broken
+    // endpoint fails the run before any model call is made.
+    const specsByKey = new Map(charts.charts.map((s) => [s.key, s]))
+    const docs = new Map<string, string>()
+    for (const key of new Set(cases.map((c) => c.chart))) {
+        const spec = specsByKey.get(key)
+        if (!spec) throw new Error(`cases.json references unknown chart ${key}`)
+        for (const condition of conditions)
+            docs.set(
+                `${key}|${condition}`,
+                await fetchDoc(spec, condition, branch)
+            )
+    }
+
+    const systemPromptFiles: Record<Condition, string> = {
+        today: path.join(runDir, "system-with-page.md"),
+        pr: path.join(runDir, "system-with-page.md"),
+        none: path.join(runDir, "system-without-page.md"),
+    }
+    fs.writeFileSync(systemPromptFiles.today, SYSTEM_PROMPT_WITH_PAGE)
+    fs.writeFileSync(systemPromptFiles.none, SYSTEM_PROMPT_WITHOUT_PAGE)
+    fs.writeFileSync(
+        path.join(runDir, "config.json"),
+        JSON.stringify(
+            {
+                model: argv.model,
+                effort: argv.effort ?? null,
+                conditions,
+                reps: argv.reps,
+                branch,
+                cases: cases.length,
+                filter: argv.filter ?? null,
+                startedAt: new Date().toISOString(),
+            },
+            null,
+            2
+        )
+    )
+
+    const resultsFile = path.join(runDir, "results.jsonl")
+    const errorsFile = path.join(runDir, "errors.jsonl")
+    const done = new Set(
+        readJsonl<ResultRow>(resultsFile).map(
+            (r) => `${r.case_id}|${r.condition}|${r.rep}`
+        )
+    )
+
+    interface Task {
+        evalCase: EvalCase
+        condition: Condition
+        rep: number
+    }
+    const tasks: Task[] = []
+    for (let rep = 0; rep < argv.reps; rep++)
+        for (const evalCase of cases)
+            for (const condition of conditions)
+                if (!done.has(`${evalCase.id}|${condition}|${rep}`))
+                    tasks.push({ evalCase, condition, rep })
+
+    console.log(
+        `${tasks.length} calls to make (${cases.length} cases × ${conditions.length} conditions × ${argv.reps} reps, ${done.size} already done) → ${path.relative(process.cwd(), runDir)}`
+    )
+
+    let completed = 0
+    let errors = 0
+    const tally: Record<
+        string,
+        { n: number; correct: number; grounded: number; hallucinated: number }
+    > = {}
+
+    const runTask = async ({
+        evalCase,
+        condition,
+        rep,
+    }: Task): Promise<void> => {
+        const doc = docs.get(`${evalCase.chart}|${condition}`) ?? ""
+        const message = userMessage(evalCase, condition, doc)
+        const options: RunOptions = {
+            model: argv.model,
+            effort: argv.effort,
+            timeoutMs: argv.timeoutS * 1000,
+            cwd,
+            systemPromptFile: systemPromptFiles[condition],
+        }
+        let attempts = 0
+        let lastError: CallError | undefined
+        const maxAttempts = 3
+        while (attempts < maxAttempts) {
+            attempts++
+            const started = Date.now()
+            try {
+                const parsed = await runClaude(message, options)
+                const latency = (Date.now() - started) / 1000
+                const answer = parsed.structured_output!
+                const graded = grade(evalCase, answer, doc)
+                const row: ResultRow = {
+                    prompt_id: `${evalCase.id}|${condition}`,
+                    case_id: evalCase.id,
+                    condition,
+                    rep,
+                    prompt: evalCase.question,
+                    tags: [evalCase.type, evalCase.chart, condition],
+                    status: "ok",
+                    stop_reason: parsed.stop_reason ?? null,
+                    grade: graded.grade,
+                    explanation: graded.explanation,
+                    answer,
+                    gold: evalCase.gold,
+                    model: servedModel(parsed),
+                    usage: usageOf(parsed),
+                    cost_usd: parsed.total_cost_usd ?? 0,
+                    latency_s: latency,
+                    attempts,
+                    doc_chars: doc.length,
+                    meta: evalCase.meta,
+                }
+                appendJsonl(resultsFile, row)
+                const traceDir = path.join(runDir, "traces", condition)
+                fs.mkdirSync(traceDir, { recursive: true })
+                fs.writeFileSync(
+                    path.join(
+                        traceDir,
+                        `${evalCase.id.replace(/\//g, "__")}_rep${rep}.json`
+                    ),
+                    JSON.stringify(
+                        [
+                            {
+                                role: "system",
+                                content: fs.readFileSync(
+                                    options.systemPromptFile,
+                                    "utf8"
+                                ),
+                            },
+                            { role: "user", content: message },
+                            {
+                                role: "assistant",
+                                content: JSON.stringify(answer, null, 2),
+                            },
+                        ],
+                        null,
+                        2
+                    )
+                )
+                const t = (tally[condition] ??= {
+                    n: 0,
+                    correct: 0,
+                    grounded: 0,
+                    hallucinated: 0,
+                })
+                t.n++
+                t.correct += graded.grade.correct
+                t.grounded += graded.grade.grounded
+                t.hallucinated += graded.grade.hallucinated
+                completed++
+                const mark = graded.grade.correct
+                    ? "✓"
+                    : graded.grade.abstained
+                      ? "∅"
+                      : "✗"
+                console.log(
+                    `[${completed + errors}/${tasks.length}] ${mark} ${condition.padEnd(5)} ${evalCase.id}  ${graded.explanation}  (${latency.toFixed(0)}s)`
+                )
+                return
+            } catch (error) {
+                if (!(error instanceof CallError)) throw error
+                lastError = error
+                const allowed = error.cls === "timeout" ? 2 : maxAttempts
+                if (!error.retryable || attempts >= allowed) break
+                const backoff =
+                    5000 * 2 ** (attempts - 1) * (0.5 + Math.random())
+                console.log(
+                    `    retry ${attempts} for ${evalCase.id}/${condition} after ${error.cls}: ${error.message.slice(0, 120)} (waiting ${(backoff / 1000).toFixed(0)}s)`
+                )
+                await sleep(backoff)
+            }
+        }
+        errors++
+        const row: ErrorRow = {
+            case_id: evalCase.id,
+            condition,
+            rep,
+            class: lastError!.cls,
+            attempts,
+            message: lastError!.message,
+            model: lastError!.parsed
+                ? servedModel(lastError!.parsed)
+                : undefined,
+            usage: lastError!.parsed ? usageOf(lastError!.parsed) : undefined,
+        }
+        appendJsonl(errorsFile, row)
+        console.log(
+            `[${completed + errors}/${tasks.length}] ! ${condition.padEnd(5)} ${evalCase.id}  ${row.class}: ${row.message.slice(0, 160)}`
+        )
+    }
+
+    const queue = [...tasks]
+    const workers = Array.from({ length: argv.concurrency }, async () => {
+        while (queue.length > 0) await runTask(queue.shift()!)
+    })
+    await Promise.all(workers)
+
+    console.log("\ncondition  n   correct  grounded  hallucinated")
+    for (const [condition, t] of Object.entries(tally)) {
+        const pct = (x: number): string =>
+            `${((100 * x) / t.n).toFixed(0)}%`.padStart(7)
+        console.log(
+            `${condition.padEnd(9)} ${String(t.n).padStart(3)} ${pct(t.correct)}  ${pct(t.grounded)}  ${pct(t.hallucinated)}`
+        )
+    }
+    if (errors > 0)
+        console.log(
+            `${errors} calls failed — see ${path.relative(process.cwd(), errorsFile)}`
+        )
+    console.log(
+        `\nReport: yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/buildReport.ts --run ${argv.name}`
+    )
+}
+
+// buildReport.ts imports grade() from here to re-grade stored answers, so only
+// run when invoked directly.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
+    void main()

--- a/devTools/agentEvals/runDocQa.ts
+++ b/devTools/agentEvals/runDocQa.ts
@@ -39,8 +39,22 @@ import { fetchTextCached } from "./lib/http.js"
 import { approxEqual } from "./lib/numbers.js"
 import type { EvalCase, Gold } from "./buildCases.js"
 
-export type Condition = "today" | "pr" | "none"
-const CONDITIONS: Condition[] = ["today", "pr", "none"]
+export type PageCondition = "today" | "pr" | "none" | "custom"
+/** A `+tools` suffix gives the agent Claude Code's tools (shell, web fetch) on top of the page. */
+export type Condition = PageCondition | `${PageCondition}+tools`
+const PAGE_CONDITIONS: PageCondition[] = ["today", "pr", "none", "custom"]
+
+export function pageOf(condition: Condition): PageCondition {
+    return condition.replace(/\+tools$/, "") as PageCondition
+}
+export function hasTools(condition: Condition): boolean {
+    return condition.endsWith("+tools")
+}
+
+export interface ToolCall {
+    name: string
+    input: string
+}
 
 export interface AgentAnswer {
     answer_number: number | null
@@ -81,6 +95,11 @@ export interface ResultRow {
     latency_s: number
     attempts: number
     doc_chars: number
+    /** Tool-enabled conditions only. */
+    tool_calls?: ToolCall[]
+    num_turns?: number
+    /** Whether the evidence quote was found in a tool result rather than the page. */
+    evidence_in_tool_output?: boolean
     meta: Record<string, unknown>
 }
 
@@ -123,6 +142,26 @@ Rules:
 - If the page does contain the answer, put the exact fragment you relied on into evidence: a verbatim copy of one table row or sentence from the page, with no commentary around it.
 - answer_number is a plain number in the unit the question asks for (write 609000000, not "609 million"; write 12.5 for 12.5%). answer_entity is the entity's name when the question asks which country or region.
 - answer_text is one or two sentences for the user.`
+
+const SYSTEM_PROMPT_WITH_PAGE_AND_TOOLS = `You are a careful research assistant answering a user's question about data published by Our World in Data.
+
+The user's tooling has already fetched the relevant page and pasted its text content into the message. You also have tools: you can run shell commands (curl, python3, jq, grep and so on) and fetch URLs, so you may follow links on the page to retrieve the underlying data if the page itself does not state the answer.
+
+Rules:
+- Answer only from the page content or from data you retrieve from ourworldindata.org by following the page's links. Do not fill gaps from memory and do not estimate. If neither the page nor the data contains the value, set found_in_page to false and leave answer_number and answer_entity null.
+- found_in_page is true when the answer comes from the page or from data you fetched via its links. Put the exact fragment you relied on into evidence: a verbatim copy of one table row, CSV line or sentence, with no commentary around it.
+- answer_number is a plain number in the unit the question asks for (write 609000000, not "609 million"; write 12.5 for 12.5%). answer_entity is the entity's name when the question asks which country or region.
+- answer_text is one or two sentences for the user, mentioning where the number came from.`
+
+const SYSTEM_PROMPT_WITHOUT_PAGE_WITH_TOOLS = `You are a careful research assistant answering a user's question about data published by Our World in Data.
+
+The user's tooling tried to fetch the relevant page but got no usable text. You have tools: you can run shell commands (curl, python3, jq, grep and so on) and fetch URLs, so you may retrieve data from ourworldindata.org yourself.
+
+Rules:
+- Answer only from data you retrieve from ourworldindata.org. Do not fill gaps from memory and do not estimate. If you cannot find the value, set found_in_page to false and leave answer_number and answer_entity null.
+- found_in_page is true when the answer comes from data you fetched. Put the exact fragment you relied on into evidence: a verbatim copy of one CSV line, table row or sentence, with no commentary around it.
+- answer_number is a plain number in the unit the question asks for (write 609000000, not "609 million"; write 12.5 for 12.5%). answer_entity is the entity's name when the question asks which country or region.
+- answer_text is one or two sentences for the user, mentioning where the number came from.`
 
 const SYSTEM_PROMPT_WITHOUT_PAGE = `You are a careful research assistant answering a user's question about data published by Our World in Data.
 
@@ -181,12 +220,14 @@ function matchesAtOwnPrecision(answer: number, gold: number): boolean {
 export function grade(
     evalCase: EvalCase,
     answer: AgentAnswer,
-    doc: string
+    doc: string,
+    evidenceInToolOutput = false
 ): { grade: Grade; explanation: string } {
     const gold = evalCase.gold
     const text = normalize(answer.answer_text ?? "")
     const grounded =
-        answer.found_in_page && evidenceIsInDoc(answer.evidence ?? "", doc)
+        answer.found_in_page &&
+        (evidenceIsInDoc(answer.evidence ?? "", doc) || evidenceInToolOutput)
 
     let answered: boolean
     let correct: boolean
@@ -266,7 +307,7 @@ export function grade(
     }
 }
 
-interface ClaudeResult {
+export interface ClaudeResult {
     is_error: boolean
     result?: string
     structured_output?: AgentAnswer
@@ -277,14 +318,84 @@ interface ClaudeResult {
     total_cost_usd?: number
     duration_api_ms?: number
     duration_ms?: number
+    num_turns?: number
 }
 
-interface RunOptions {
+export interface RunOptions {
     model: string
     effort?: string
     timeoutMs: number
     cwd: string
     systemPromptFile: string
+    /** Give the agent Claude Code's default tools instead of none. */
+    agentTools: boolean
+    /** Passed to --setting-sources; "project" with an empty cwd means no user-level skills or settings. */
+    settingSources?: string
+}
+
+interface StreamEvent {
+    type: string
+    message?: {
+        content?: Array<{
+            type: string
+            name?: string
+            input?: unknown
+            content?: string | Array<{ type: string; text?: string }>
+        }>
+    }
+}
+
+/**
+ * With tools on, the CLI streams one JSON event per line; the last one is the
+ * same result object the plain json format returns. Collect the tool calls and
+ * tool results on the way so the trace shows what the agent actually did.
+ */
+function parseStream(stdout: string): {
+    result: ClaudeResult | undefined
+    toolCalls: ToolCall[]
+    toolOutput: string
+} {
+    const toolCalls: ToolCall[] = []
+    const outputs: string[] = []
+    let result: ClaudeResult | undefined
+    for (const line of stdout.split("\n")) {
+        if (!line.trim()) continue
+        let event: StreamEvent & Partial<ClaudeResult>
+        try {
+            event = JSON.parse(line)
+        } catch {
+            continue
+        }
+        if (event.type === "result") result = event as ClaudeResult
+        for (const block of event.message?.content ?? []) {
+            if (block.type === "tool_use")
+                toolCalls.push({
+                    name: block.name ?? "?",
+                    input: JSON.stringify(block.input),
+                })
+            if (block.type === "tool_result") {
+                if (typeof block.content === "string")
+                    outputs.push(block.content)
+                else
+                    for (const part of block.content ?? [])
+                        if (part.text) outputs.push(part.text)
+            }
+        }
+    }
+    if (result && !result.structured_output && result.result) {
+        try {
+            result.structured_output = JSON.parse(result.result) as AgentAnswer
+        } catch {
+            // leave it undefined; the caller reports it as unparseable
+        }
+    }
+    return { result, toolCalls, toolOutput: outputs.join("\n") }
+}
+
+export interface CallOutcome {
+    parsed: ClaudeResult
+    toolCalls: ToolCall[]
+    toolOutput: string
 }
 
 class CallError extends Error {
@@ -298,26 +409,40 @@ class CallError extends Error {
     }
 }
 
-function runClaude(
+export function runClaude(
     userMessage: string,
-    options: RunOptions
-): Promise<ClaudeResult> {
+    options: RunOptions,
+    schema: object = ANSWER_SCHEMA
+): Promise<CallOutcome> {
     const args = [
         "-p",
         "--system-prompt-file",
         options.systemPromptFile,
-        "--tools",
-        "",
         "--model",
         options.model,
-        "--output-format",
-        "json",
         "--json-schema",
-        JSON.stringify(ANSWER_SCHEMA),
+        JSON.stringify(schema),
         "--no-session-persistence",
         "--strict-mcp-config",
     ]
+    if (options.agentTools) {
+        // Default tool set; the cwd is an empty temp dir, so bypassing the
+        // permission prompts (which headless mode cannot show) is contained.
+        args.push(
+            "--permission-mode",
+            "bypassPermissions",
+            "--max-turns",
+            "15",
+            "--output-format",
+            "stream-json",
+            "--verbose"
+        )
+    } else {
+        args.push("--tools", "", "--output-format", "json")
+    }
     if (options.effort) args.push("--effort", options.effort)
+    if (options.settingSources !== undefined)
+        args.push("--setting-sources", options.settingSources)
 
     return new Promise((resolve, reject) => {
         const child = spawn("claude", args, {
@@ -350,8 +475,18 @@ function runClaude(
                     )
                 )
             let parsed: ClaudeResult
+            let toolCalls: ToolCall[] = []
+            let toolOutput = ""
             try {
-                parsed = JSON.parse(stdout) as ClaudeResult
+                if (options.agentTools) {
+                    const stream = parseStream(stdout)
+                    if (!stream.result) throw new Error("no result event")
+                    parsed = stream.result
+                    toolCalls = stream.toolCalls
+                    toolOutput = stream.toolOutput
+                } else {
+                    parsed = JSON.parse(stdout) as ClaudeResult
+                }
             } catch {
                 return reject(
                     new CallError(
@@ -386,13 +521,13 @@ function runClaude(
                         parsed
                     )
                 )
-            resolve(parsed)
+            resolve({ parsed, toolCalls, toolOutput })
         })
         child.stdin.end(userMessage)
     })
 }
 
-function usageOf(parsed: ClaudeResult | undefined): ResultRow["usage"] {
+export function usageOf(parsed: ClaudeResult | undefined): ResultRow["usage"] {
     const u = parsed?.usage ?? {}
     return {
         input_tokens: u.input_tokens ?? 0,
@@ -402,7 +537,7 @@ function usageOf(parsed: ClaudeResult | undefined): ResultRow["usage"] {
     }
 }
 
-function servedModel(parsed: ClaudeResult | undefined): string {
+export function servedModel(parsed: ClaudeResult | undefined): string {
     return Object.keys(parsed?.modelUsage ?? {}).join("+") || "unknown"
 }
 
@@ -411,18 +546,24 @@ function userMessage(
     condition: Condition,
     doc: string
 ): string {
-    if (condition === "none")
+    if (pageOf(condition) === "none")
         return `I tried to fetch ${evalCase.url} but got no usable text back (the chart needs JavaScript).\n\nQuestion: ${evalCase.question}`
     return `I fetched the page ${evalCase.url} from ourworldindata.org. Here is its text content:\n\n<page_content>\n${doc}\n</page_content>\n\nQuestion: ${evalCase.question}`
 }
 
 async function fetchDoc(
     spec: ChartSpec,
-    condition: Condition,
+    condition: PageCondition,
     branch: string
 ): Promise<string> {
     if (condition === "none") return ""
     const file = path.join(RESULTS_DIR, "docs", condition, `${spec.key}.md`)
+    // A hand-edited page variant for experiments; nothing is fetched.
+    if (condition === "custom") {
+        if (!fs.existsSync(file))
+            throw new Error(`custom page missing: ${file}`)
+        return fs.readFileSync(file, "utf8")
+    }
     if (condition === "today") {
         const body = await fetchTextCached(prodPageUrl(spec), file, {
             accept: "text/markdown",
@@ -475,7 +616,7 @@ async function main(): Promise<void> {
         })
         .option("conditions", {
             type: "string",
-            default: CONDITIONS.join(","),
+            default: PAGE_CONDITIONS.join(","),
         })
         .option("model", {
             type: "string",
@@ -505,7 +646,8 @@ async function main(): Promise<void> {
     const branch = argv.branch ?? charts.prBranch
     const conditions = argv.conditions.split(",") as Condition[]
     for (const c of conditions)
-        if (!CONDITIONS.includes(c)) throw new Error(`unknown condition ${c}`)
+        if (!PAGE_CONDITIONS.includes(pageOf(c)))
+            throw new Error(`unknown condition ${c}`)
 
     let cases = JSON.parse(fs.readFileSync(argv.cases, "utf8")) as EvalCase[]
     if (argv.filter) {
@@ -532,20 +674,34 @@ async function main(): Promise<void> {
     for (const key of new Set(cases.map((c) => c.chart))) {
         const spec = specsByKey.get(key)
         if (!spec) throw new Error(`cases.json references unknown chart ${key}`)
-        for (const condition of conditions)
-            docs.set(
-                `${key}|${condition}`,
-                await fetchDoc(spec, condition, branch)
-            )
+        for (const page of new Set(conditions.map(pageOf)))
+            docs.set(`${key}|${page}`, await fetchDoc(spec, page, branch))
     }
 
-    const systemPromptFiles: Record<Condition, string> = {
-        today: path.join(runDir, "system-with-page.md"),
-        pr: path.join(runDir, "system-with-page.md"),
-        none: path.join(runDir, "system-without-page.md"),
+    const promptFile = (name: string, text: string): string => {
+        const file = path.join(runDir, name)
+        fs.writeFileSync(file, text)
+        return file
     }
-    fs.writeFileSync(systemPromptFiles.today, SYSTEM_PROMPT_WITH_PAGE)
-    fs.writeFileSync(systemPromptFiles.none, SYSTEM_PROMPT_WITHOUT_PAGE)
+    const systemPromptFor = (condition: Condition): string => {
+        const withPage = pageOf(condition) !== "none"
+        if (hasTools(condition))
+            return withPage
+                ? promptFile(
+                      "system-with-page-tools.md",
+                      SYSTEM_PROMPT_WITH_PAGE_AND_TOOLS
+                  )
+                : promptFile(
+                      "system-without-page-tools.md",
+                      SYSTEM_PROMPT_WITHOUT_PAGE_WITH_TOOLS
+                  )
+        return withPage
+            ? promptFile("system-with-page.md", SYSTEM_PROMPT_WITH_PAGE)
+            : promptFile("system-without-page.md", SYSTEM_PROMPT_WITHOUT_PAGE)
+    }
+    const systemPromptFiles = Object.fromEntries(
+        conditions.map((c) => [c, systemPromptFor(c)])
+    ) as Record<Condition, string>
     fs.writeFileSync(
         path.join(runDir, "config.json"),
         JSON.stringify(
@@ -600,7 +756,7 @@ async function main(): Promise<void> {
         condition,
         rep,
     }: Task): Promise<void> => {
-        const doc = docs.get(`${evalCase.chart}|${condition}`) ?? ""
+        const doc = docs.get(`${evalCase.chart}|${pageOf(condition)}`) ?? ""
         const message = userMessage(evalCase, condition, doc)
         const options: RunOptions = {
             model: argv.model,
@@ -608,6 +764,7 @@ async function main(): Promise<void> {
             timeoutMs: argv.timeoutS * 1000,
             cwd,
             systemPromptFile: systemPromptFiles[condition],
+            agentTools: hasTools(condition),
         }
         let attempts = 0
         let lastError: CallError | undefined
@@ -616,10 +773,21 @@ async function main(): Promise<void> {
             attempts++
             const started = Date.now()
             try {
-                const parsed = await runClaude(message, options)
+                const { parsed, toolCalls, toolOutput } = await runClaude(
+                    message,
+                    options
+                )
                 const latency = (Date.now() - started) / 1000
                 const answer = parsed.structured_output!
-                const graded = grade(evalCase, answer, doc)
+                const evidenceInToolOutput =
+                    toolOutput.length > 0 &&
+                    evidenceIsInDoc(answer.evidence ?? "", toolOutput)
+                const graded = grade(
+                    evalCase,
+                    answer,
+                    doc,
+                    evidenceInToolOutput
+                )
                 const row: ResultRow = {
                     prompt_id: `${evalCase.id}|${condition}`,
                     case_id: evalCase.id,
@@ -639,6 +807,13 @@ async function main(): Promise<void> {
                     latency_s: latency,
                     attempts,
                     doc_chars: doc.length,
+                    ...(options.agentTools
+                        ? {
+                              tool_calls: toolCalls,
+                              num_turns: parsed.num_turns,
+                              evidence_in_tool_output: evidenceInToolOutput,
+                          }
+                        : {}),
                     meta: evalCase.meta,
                 }
                 appendJsonl(resultsFile, row)
@@ -659,6 +834,19 @@ async function main(): Promise<void> {
                                 ),
                             },
                             { role: "user", content: message },
+                            ...toolCalls.map((call) => ({
+                                role: "tool_call",
+                                name: call.name,
+                                content: call.input,
+                            })),
+                            ...(toolOutput
+                                ? [
+                                      {
+                                          role: "tool_result",
+                                          content: toolOutput.slice(0, 200_000),
+                                      },
+                                  ]
+                                : []),
                             {
                                 role: "assistant",
                                 content: JSON.stringify(answer, null, 2),

--- a/devTools/agentEvals/runOpenWeb.ts
+++ b/devTools/agentEvals/runOpenWeb.ts
@@ -1,0 +1,414 @@
+#!/usr/bin/env tsx
+/**
+ * Where does an agent get its numbers when nobody points it at us?
+ *
+ * Generic questions with no mention of Our World in Data and no URL; the agent
+ * has web search and fetch and must name its source. Records every search
+ * query and every domain fetched, and compares the number to our CSV value.
+ *
+ * Two agents: Claude Code (`claude -p`, on the developer's subscription) and
+ * Gemini CLI (`gemini`, with GOOGLE_API_KEY). Both get an empty working
+ * directory and no user-level skills, memory files or hooks.
+ *
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runOpenWeb.ts --name open-web
+ *   yarn tsx --tsconfig tsconfig.tsx.json devTools/agentEvals/runOpenWeb.ts --agent gemini --model gemini-3.8-flash --name open-web-gemini
+ */
+import { spawn } from "child_process"
+import fs from "fs"
+import os from "os"
+import path from "path"
+import yargs from "yargs"
+import { hideBin } from "yargs/helpers"
+import { RESULTS_DIR } from "./lib/charts.js"
+import { approxEqual } from "./lib/numbers.js"
+import {
+    CallOutcome,
+    RunOptions,
+    ToolCall,
+    runClaude,
+    servedModel,
+    usageOf,
+} from "./runDocQa.js"
+
+interface OpenQuestion {
+    id: string
+    question: string
+    /** Our value, from the chart's CSV, and the chart it comes from. */
+    gold: number | string
+    unit: string
+    chart: string
+}
+
+const QUESTIONS: OpenQuestion[] = [
+    {
+        id: "zimbabwe-life-expectancy",
+        question: "What was life expectancy in Zimbabwe in 2023?",
+        gold: 62.7748,
+        unit: "years",
+        chart: "life-expectancy",
+    },
+    {
+        id: "highest-life-expectancy",
+        question: "Which country had the highest life expectancy in 2023?",
+        gold: "Monaco",
+        unit: "",
+        chart: "life-expectancy",
+    },
+    {
+        id: "namibia-co2-per-capita",
+        question: "What were Namibia's CO2 emissions per person in 2024?",
+        gold: 1.1448735,
+        unit: "tonnes per person",
+        chart: "co-emissions-per-capita",
+    },
+    {
+        id: "pakistan-extreme-poverty",
+        question:
+            "What share of Pakistan's population lived in extreme poverty in 2024?",
+        gold: 22.956307232379913,
+        unit: "% (World Bank $3/day line, 2021 PPP)",
+        chart: "share-of-population-in-extreme-poverty",
+    },
+    {
+        id: "slovakia-population",
+        question: "How many people lived in Slovakia in 2023?",
+        gold: 5518057,
+        unit: "people",
+        chart: "population",
+    },
+]
+
+const SYSTEM_PROMPT = `You are a research assistant answering a factual question with a number. You have web search and can fetch pages and run shell commands (curl, python3, jq and so on).
+
+Rules:
+- Find the answer on the web. Do not answer from memory alone; retrieve the value from a source you can name.
+- answer_number is a plain number in a sensible unit stated in answer_text (write 5500000, not "5.5 million"; write 12.5 for 12.5%). answer_entity is a country name when the question asks which country.
+- source_url is the URL of the page or file the number came from; source_name is the organisation behind it.
+- answer_text is one or two sentences for the user, including the unit and the source.`
+
+const SCHEMA = {
+    type: "object",
+    properties: {
+        answer_number: { type: ["number", "null"] },
+        answer_entity: { type: ["string", "null"] },
+        answer_text: { type: "string" },
+        source_url: { type: "string" },
+        source_name: { type: "string" },
+    },
+    required: [
+        "answer_number",
+        "answer_entity",
+        "answer_text",
+        "source_url",
+        "source_name",
+    ],
+    additionalProperties: false,
+}
+
+interface OpenAnswer {
+    answer_number: number | null
+    answer_entity: string | null
+    answer_text: string
+    source_url: string
+    source_name: string
+}
+
+function domainsOf(toolCalls: ToolCall[]): {
+    searches: string[]
+    fetched: string[]
+} {
+    const searches: string[] = []
+    const fetched: string[] = []
+    for (const call of toolCalls) {
+        let input: Record<string, unknown> = {}
+        try {
+            input = JSON.parse(call.input) as Record<string, unknown>
+        } catch {
+            continue
+        }
+        if (/search/i.test(call.name) && typeof input.query === "string") {
+            searches.push(input.query)
+            continue
+        }
+        for (const m of call.input.matchAll(/https?:\/\/([^/\s"'\\]+)/g))
+            fetched.push(m[1])
+    }
+    return { searches, fetched: [...new Set(fetched)] }
+}
+
+/** Gemini CLI has no structured output; ask for a JSON block and parse the last one. */
+function extractJson(text: string): OpenAnswer | undefined {
+    const fenced = [...text.matchAll(/```(?:json)?\s*([\s\S]*?)```/g)].map(
+        (m) => m[1]
+    )
+    const candidates = [...fenced.reverse(), text.slice(text.lastIndexOf("{"))]
+    for (const c of candidates) {
+        try {
+            const parsed = JSON.parse(c) as Partial<OpenAnswer>
+            if ("answer_text" in parsed || "answer_number" in parsed)
+                return {
+                    answer_number:
+                        typeof parsed.answer_number === "number"
+                            ? parsed.answer_number
+                            : null,
+                    answer_entity: parsed.answer_entity ?? null,
+                    answer_text: parsed.answer_text ?? "",
+                    source_url: parsed.source_url ?? "",
+                    source_name: parsed.source_name ?? "",
+                }
+        } catch {
+            // try the next candidate
+        }
+    }
+    return undefined
+}
+
+interface GeminiEvent {
+    type: string
+    role?: string
+    content?: unknown
+    tool_name?: string
+    parameters?: unknown
+    output?: unknown
+    stats?: Record<string, number>
+    status?: string
+}
+
+function runGemini(
+    question: string,
+    model: string,
+    timeoutMs: number
+): Promise<CallOutcome> {
+    // A private HOME: the CLI reads ~/.gemini/GEMINI.md as its global
+    // instructions (our system prompt) and ~/.gemini/settings.json for auth,
+    // and sees none of the developer's own memory files, hooks or extensions.
+    const home = fs.mkdtempSync(
+        path.join(os.tmpdir(), "agent-evals-gemini-home-")
+    )
+    fs.mkdirSync(path.join(home, ".gemini"))
+    fs.writeFileSync(
+        path.join(home, ".gemini", "GEMINI.md"),
+        `${SYSTEM_PROMPT}\n\nWhen you have the answer, end your reply with a single JSON object in a \`\`\`json fence with exactly these keys: answer_number (number or null), answer_entity (string or null), answer_text, source_url, source_name.`
+    )
+    fs.writeFileSync(
+        path.join(home, ".gemini", "settings.json"),
+        JSON.stringify({
+            security: { auth: { selectedType: "gemini-api-key" } },
+        })
+    )
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "agent-evals-gemini-"))
+    const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_API_KEY
+    if (!apiKey) throw new Error("GEMINI_API_KEY or GOOGLE_API_KEY is required")
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(
+            "gemini",
+            ["-m", model, "-o", "stream-json", "--yolo", question],
+            {
+                cwd,
+                env: { ...process.env, HOME: home, GEMINI_API_KEY: apiKey },
+                stdio: ["pipe", "pipe", "pipe"],
+            }
+        )
+        let stdout = ""
+        let stderr = ""
+        const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs)
+        child.stdout.on("data", (d) => (stdout += d))
+        child.stderr.on("data", (d) => (stderr += d))
+        child.on("error", reject)
+        child.on("close", (code) => {
+            clearTimeout(timer)
+            const toolCalls: ToolCall[] = []
+            const outputs: string[] = []
+            let lastAssistant = ""
+            let stats: Record<string, number> = {}
+            let turns = 0
+            for (const line of stdout.split("\n")) {
+                if (!line.trim()) continue
+                let event: GeminiEvent
+                try {
+                    event = JSON.parse(line) as GeminiEvent
+                } catch {
+                    continue
+                }
+                if (event.type === "tool_use")
+                    toolCalls.push({
+                        name: event.tool_name ?? "?",
+                        input: JSON.stringify(event.parameters ?? {}),
+                    })
+                if (event.type === "tool_result")
+                    outputs.push(
+                        typeof event.output === "string"
+                            ? event.output
+                            : JSON.stringify(
+                                  event.output ?? event.content ?? ""
+                              )
+                    )
+                // Assistant text arrives in chunks; concatenate them all.
+                if (event.type === "message" && event.role === "assistant") {
+                    turns++
+                    lastAssistant +=
+                        typeof event.content === "string"
+                            ? event.content
+                            : JSON.stringify(event.content)
+                }
+                if (event.type === "result") stats = event.stats ?? {}
+            }
+            fs.writeFileSync(path.join(cwd, "stream.jsonl"), stdout)
+            const answer = extractJson(lastAssistant)
+            if (!answer)
+                return reject(
+                    new Error(
+                        `exit ${code}; no JSON answer in: ${lastAssistant.slice(-300)} | raw stream: ${cwd}/stream.jsonl | stderr: ${stderr.slice(0, 120)}`
+                    )
+                )
+            resolve({
+                parsed: {
+                    is_error: false,
+                    structured_output:
+                        answer as unknown as CallOutcome["parsed"]["structured_output"],
+                    num_turns: turns,
+                    total_cost_usd: 0,
+                    modelUsage: { [model]: {} },
+                    usage: {
+                        input_tokens: stats.input ?? 0,
+                        output_tokens: stats.output_tokens ?? 0,
+                        cache_read_input_tokens: stats.cached ?? 0,
+                        cache_creation_input_tokens: 0,
+                    },
+                },
+                toolCalls,
+                toolOutput: outputs.join("\n"),
+            })
+        })
+        child.stdin.end()
+    })
+}
+
+async function main(): Promise<void> {
+    const argv = await yargs(hideBin(process.argv))
+        .option("name", { type: "string", default: "open-web" })
+        .option("agent", {
+            type: "string",
+            choices: ["claude", "gemini"],
+            default: "claude",
+        })
+        .option("model", { type: "string" })
+        .option("concurrency", { type: "number", default: 3 })
+        .option("timeout-s", { type: "number", default: 420 })
+        .option("filter", { type: "string" })
+        .parse()
+    const model =
+        argv.model ?? (argv.agent === "gemini" ? "gemini-3.8-flash" : "sonnet")
+
+    const runDir = path.join(RESULTS_DIR, "runs", argv.name)
+    fs.mkdirSync(path.join(runDir, "traces"), { recursive: true })
+    const systemPromptFile = path.join(runDir, "system.md")
+    fs.writeFileSync(systemPromptFile, SYSTEM_PROMPT)
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "agent-evals-web-"))
+    const resultsFile = path.join(runDir, "results.jsonl")
+    const done = new Set(
+        fs.existsSync(resultsFile)
+            ? fs
+                  .readFileSync(resultsFile, "utf8")
+                  .split("\n")
+                  .filter(Boolean)
+                  .map((l) => (JSON.parse(l) as { id: string }).id)
+            : []
+    )
+    const questions = QUESTIONS.filter(
+        (q) =>
+            !done.has(q.id) &&
+            (!argv.filter || new RegExp(argv.filter).test(q.id))
+    )
+    console.log(
+        `${questions.length} questions, agent ${argv.agent} (${model}) → ${path.relative(process.cwd(), runDir)}`
+    )
+
+    const claudeOptions: RunOptions = {
+        model,
+        timeoutMs: argv.timeoutS * 1000,
+        cwd,
+        systemPromptFile,
+        agentTools: true,
+        // No user-level skills: the agent must find its own way to the data.
+        settingSources: "project",
+    }
+
+    const runOne = async (q: OpenQuestion): Promise<void> => {
+        const started = Date.now()
+        try {
+            const outcome =
+                argv.agent === "gemini"
+                    ? await runGemini(q.question, model, argv.timeoutS * 1000)
+                    : await runClaude(q.question, claudeOptions, SCHEMA)
+            const answer = outcome.parsed
+                .structured_output as unknown as OpenAnswer
+            const { searches, fetched } = domainsOf(outcome.toolCalls)
+            const matches =
+                typeof q.gold === "number"
+                    ? answer.answer_number !== null &&
+                      approxEqual(answer.answer_number, q.gold, 0.01)
+                    : (answer.answer_entity ?? "")
+                          .toLowerCase()
+                          .includes(q.gold.toLowerCase())
+            const row = {
+                id: q.id,
+                agent: argv.agent,
+                question: q.question,
+                gold: q.gold,
+                unit: q.unit,
+                chart: q.chart,
+                answer,
+                matches_owid: matches,
+                searches,
+                fetched_domains: fetched,
+                tool_calls: outcome.toolCalls,
+                num_turns: outcome.parsed.num_turns,
+                model: servedModel(outcome.parsed),
+                usage: usageOf(outcome.parsed),
+                cost_usd: outcome.parsed.total_cost_usd ?? 0,
+                latency_s: (Date.now() - started) / 1000,
+            }
+            fs.appendFileSync(resultsFile, JSON.stringify(row) + "\n")
+            fs.writeFileSync(
+                path.join(runDir, "traces", `${q.id}.json`),
+                JSON.stringify(
+                    [
+                        { role: "system", content: SYSTEM_PROMPT },
+                        { role: "user", content: q.question },
+                        ...outcome.toolCalls.map((c) => ({
+                            role: "tool_call",
+                            name: c.name,
+                            content: c.input,
+                        })),
+                        {
+                            role: "tool_result",
+                            content: outcome.toolOutput.slice(0, 200_000),
+                        },
+                        {
+                            role: "assistant",
+                            content: JSON.stringify(answer, null, 2),
+                        },
+                    ],
+                    null,
+                    2
+                )
+            )
+            console.log(
+                `${matches ? "=" : "≠"} ${q.id}: ${answer.answer_number ?? answer.answer_entity} from ${answer.source_name} (${answer.source_url})\n    searched: ${searches.join(" | ")}\n    fetched: ${fetched.join(", ") || "nothing"}  (${row.latency_s.toFixed(0)}s, ${row.usage.input_tokens + row.usage.cache_read_input_tokens} in / ${row.usage.output_tokens} out tokens)`
+            )
+        } catch (error) {
+            console.log(`! ${q.id}: ${(error as Error).message.slice(0, 300)}`)
+        }
+    }
+
+    const queue = [...questions]
+    await Promise.all(
+        Array.from({ length: argv.concurrency }, async () => {
+            while (queue.length > 0) await runOne(queue.shift()!)
+        })
+    )
+}
+
+void main()

--- a/devTools/agentEvals/tsconfig.json
+++ b/devTools/agentEvals/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../tsconfigs/tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "../../itsJustJavascript/devTools",
+        "rootDir": ".."
+    },
+    // stagingHostname.ts belongs to no other project, so it is compiled here.
+    "include": ["*.ts", "lib/*.ts", "../stagingHostname.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
         { "path": "./adminSiteClient" },
         { "path": "./adminSiteServer" },
         { "path": "./bespoke/shared" },
+        { "path": "./devTools/agentEvals" },
         { "path": "./devTools/markdownTest" },
         { "path": "./devTools/regionsUpdater" },
         { "path": "./devTools/schema" },


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @Marigold at the wheel._

A small eval under `devTools/agentEvals/` for the text an AI agent gets from a `/grapher/<slug>` page. Built to judge #7224, reusable for anything that changes the agent-facing rendering (page markdown, values in the HTML, llms.txt). Results and the reasoning are in [Agents Reading Grapher Pages](https://claude.ai/code/artifact/119465ef-b18e-46a6-b783-9e9abd57ab89); the headline is that today's page text lets Claude Sonnet 5 answer 34% of factual questions about a chart and #7224's markdown 82%, paired +48 points [38, 58].

Three layers, cheapest first:

- **Value check, no model** (`checkMarkdownValues.ts`): parses the tables in `/grapher/<slug>.md` and compares every cell to the CSV. Seconds; exits non-zero on a mismatch. Found two real defects in #7224.
- **Document QA** (`buildCases.ts` → `runDocQa.ts` → `buildReport.ts`): ~110 template questions over 12 chart views with gold from the CSV and metadata endpoints, asked of `claude -p` under three renderings of the same URL (today's page via `Accept: text/markdown`, the PR's `.md`, no page), plus optional `+tools` variants where the agent may follow links with a shell. Programmatic grading; HTML report with paired bootstrap intervals.
- **Open-web probe** (`runOpenWeb.ts`): generic questions with no mention of us; records which sites Claude Code or Gemini CLI search, fetch and cite.

Everything runs on the developer's Claude subscription (and `GOOGLE_API_KEY` for Gemini); no Anthropic API key needed. Inputs (`charts.json`, `cases.json`) are committed; runs are gitignored.

Worth knowing: each question is a fresh `claude` process, so nothing is cached across calls and a full document-QA pass costs on the order of 350 calls. The README documents this; use `--filter`/`--limit` and run the full set only when the format changes.

<details>
<summary>Details</summary>

### Layout

| File | Purpose |
| --- | --- |
| `charts.json` | Chart views under test (line, map-default, scatter, stacked area, two multi-dim views, one with `country=`/`time=` params) and the PR branch whose staging server serves them. |
| `buildCases.ts` → `cases.json` | Seeded question generation from the full CSV, the filtered CSV (the view's selection), `metadata.json` and `values.json` (the view's start/end years). |
| `runDocQa.ts` | Fetches and caches page snapshots per condition, runs `claude -p --tools "" --json-schema …` from an empty temp cwd with `--setting-sources project` (no user skills), grades, appends `results.jsonl` per `(case, condition, rep)` (resumable), `errors.jsonl` for failed calls, `traces/`. `+tools` conditions run with Claude Code's default tools and record every tool call. A `custom` page condition reads a hand-edited snapshot for wording experiments. |
| `buildReport.ts` | Re-grades from stored answers (grader fixes need no re-run), writes `report.html`, opens Chrome. |
| `checkMarkdownValues.ts` | Layer 0; writes `results/check/findings.json`. |
| `runOpenWeb.ts` | Open-web probe for Claude Code and Gemini CLI; per question the searches, fetched domains, cited source and whether the number matches ours. |
| `lib/` | fetch with retries and disk cache, grapher CSV model, markdown table parser, grapher number-format parser (`1.18 million`, `<0.01 °C`), view loader. |
| `tsconfig.json` + root reference | Typechecked with the repo; compiles `devTools/stagingHostname.ts` since no other project owns it. |

### Grading

- number: within 1% of gold, or equal to gold rounded at the answer's own precision when that step is under 10% of the value (the page prints "0.9%" for 0.95).
- entity: any accepted name (ties, or "latest at end year" vs "each entity's own latest").
- unanswerable: correct iff no number given; `answer_entity` ignored because models echo the asked-about entity.
- unit / sources: token containment against `unit`/`shortUnit` and producers parsed from `citationShort`.
- traceable ("grounded"): `found_in_page` and the quoted evidence (whole, any quoted fragment, or any line) occurs in the page text or, with tools, in a tool result.

### Runner notes

- Timeouts are retried once with attempts recorded; one episode of every spawned `claude -p` hanging with no output cleared on retry.
- Concurrency above 3 got runs killed for memory on a laptop with other sessions open.
- The agent's fetcher (`WebFetch`) sends `Accept: text/markdown, text/html, */*`, measured against an echo endpoint; Gemini's sends `*/*`. This is why the "today" condition uses Cloudflare's markdown conversion.

### Not covered

Discovery of `.md` by agents (addressed on #7224 via content negotiation), prose-only questions (key insights, FAQ), multiple reps, other models beyond the two probed.

</details>
