### PR TITLE
Trap focus in the floating Subscribe and Feedback dialogs

### DIFF
--- a/site/Feedback.tsx
+++ b/site/Feedback.tsx
@@ -1,16 +1,12 @@
 import * as React from "react"
 import { observer } from "mobx-react"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
-import {
-    faCommentAlt,
-    faTimes,
-    faPaperPlane,
-} from "@fortawesome/free-solid-svg-icons"
+import { faCommentAlt, faPaperPlane } from "@fortawesome/free-solid-svg-icons"
 import { observable, action, toJS, computed, makeObservable } from "mobx"
 import classnames from "clsx"
 import { BAKED_BASE_URL } from "../settings/clientSettings.mjs"
 import { stringifyUnknownError } from "@ourworldindata/utils"
-import { SiteToolsButton } from "./SiteToolsButton.js"
+import { SiteToolsDialog } from "./SiteToolsDialog.js"
 
 const sendFeedback = async (feedback: Feedback) => {
     const json = {
@@ -213,58 +209,66 @@ const topicNotices = new Map<SpecialFeedbackTopic, React.ReactElement>([
     [SpecialFeedbackTopic.Teaching, teachingNotice],
 ])
 
-interface FeedbackFormProps {
-    onClose?: () => void
-    autofocus?: boolean
-}
-
-@observer
-export class FeedbackForm extends React.Component<FeedbackFormProps> {
+class FeedbackFormState {
     feedback: Feedback = new Feedback()
     loading: boolean = false
     done: boolean = false
     error: string | undefined
 
-    constructor(props: FeedbackFormProps) {
-        super(props)
-
+    constructor() {
         makeObservable(this, {
             loading: observable,
             done: observable,
             error: observable,
         })
     }
+}
+
+interface FeedbackFormProps {
+    onClose?: () => void
+    autofocus?: boolean
+    formState?: FeedbackFormState
+}
+
+@observer
+export class FeedbackForm extends React.Component<FeedbackFormProps> {
+    private readonly formState: FeedbackFormState
+
+    constructor(props: FeedbackFormProps) {
+        super(props)
+        this.formState = props.formState ?? new FeedbackFormState()
+    }
 
     async submit() {
         try {
-            await sendFeedback(this.feedback)
-            this.feedback.clear()
-            this.done = true
+            await sendFeedback(this.formState.feedback)
+            this.formState.feedback.clear()
+            this.formState.done = true
         } catch (err) {
-            this.error = stringifyUnknownError(err)
+            this.formState.error = stringifyUnknownError(err)
         } finally {
-            this.loading = false
+            this.formState.loading = false
         }
     }
 
     @action.bound onSubmit(e: React.SubmitEvent<HTMLFormElement>) {
         e.preventDefault()
-        this.done = false
-        this.error = undefined
-        this.loading = true
+        this.formState.done = false
+        this.formState.error = undefined
+        this.formState.loading = true
         void this.submit()
     }
 
     @action.bound onName(e: React.ChangeEvent<HTMLInputElement>) {
-        this.feedback.name = e.currentTarget.value
+        this.formState.feedback.name = e.currentTarget.value
     }
 
     @action.bound onEmail(e: React.ChangeEvent<HTMLInputElement>) {
-        this.feedback.email = e.currentTarget.value
+        this.formState.feedback.email = e.currentTarget.value
     }
 
     @action.bound onMessage(e: React.ChangeEvent<HTMLTextAreaElement>) {
-        this.feedback.message = e.currentTarget.value
+        this.formState.feedback.message = e.currentTarget.value
     }
 
     @action.bound onClose() {
@@ -272,17 +276,18 @@ export class FeedbackForm extends React.Component<FeedbackFormProps> {
             this.props.onClose()
         }
         // Clear the form after closing, in case the user has a 2nd message to send later.
-        this.done = false
+        this.formState.done = false
     }
 
     @computed private get specialTopic(): SpecialFeedbackTopic | undefined {
-        const { message } = this.feedback
+        const { message } = this.formState.feedback
         return topicMatchers.find((matcher) => matcher.regex.test(message))
             ?.topic
     }
 
     renderBody() {
-        const { loading, done, specialTopic } = this
+        const { loading, done } = this.formState
+        const { specialTopic } = this
         const autofocus = this.props.autofocus ?? true
 
         if (done) {
@@ -333,6 +338,8 @@ export class FeedbackForm extends React.Component<FeedbackFormProps> {
                             id="feedback.message"
                             className="sentry-mask"
                             onChange={this.onMessage}
+                            value={this.formState.feedback.message}
+                            autoFocus={autofocus}
                             rows={5}
                             minLength={30}
                             required
@@ -351,7 +358,7 @@ export class FeedbackForm extends React.Component<FeedbackFormProps> {
                             id="feedback.name"
                             className="sentry-mask"
                             onChange={this.onName}
-                            autoFocus={autofocus}
+                            value={this.formState.feedback.name}
                             disabled={loading}
                         />
                     </div>
@@ -361,6 +368,7 @@ export class FeedbackForm extends React.Component<FeedbackFormProps> {
                             id="feedback.email"
                             className="sentry-mask"
                             onChange={this.onEmail}
+                            value={this.formState.feedback.email}
                             type="email"
                             disabled={loading}
                         />
@@ -371,10 +379,12 @@ export class FeedbackForm extends React.Component<FeedbackFormProps> {
                             you.
                         </small>
                     </div>
-                    {this.error ? (
-                        <div style={{ color: "red" }}>{this.error}</div>
+                    {this.formState.error ? (
+                        <div style={{ color: "red" }}>
+                            {this.formState.error}
+                        </div>
                     ) : undefined}
-                    {this.done ? (
+                    {this.formState.done ? (
                         <div style={{ color: "green" }}>
                             Thanks for your feedback!
                         </div>
@@ -397,7 +407,7 @@ export class FeedbackForm extends React.Component<FeedbackFormProps> {
         return (
             <form
                 className={classnames("FeedbackForm", {
-                    loading: this.loading,
+                    loading: this.formState.loading,
                 })}
                 onSubmit={this.onSubmit}
             >
@@ -409,6 +419,8 @@ export class FeedbackForm extends React.Component<FeedbackFormProps> {
 
 @observer
 export class FeedbackPrompt extends React.Component {
+    // Keep drafts and pending submissions across modal close/reopen.
+    private readonly formState = new FeedbackFormState()
     isOpen: boolean = false
 
     constructor(props: Record<string, never>) {
@@ -419,49 +431,30 @@ export class FeedbackPrompt extends React.Component {
         })
     }
 
-    @action.bound toggleOpen() {
-        this.isOpen = !this.isOpen
+    @action.bound onOpenChange(isOpen: boolean) {
+        this.isOpen = isOpen
     }
 
     @action.bound onClose() {
         this.isOpen = false
     }
 
-    @action.bound onClickOutside() {
-        this.onClose()
-    }
-
     override render() {
         return (
-            <div
-                className={`feedbackPromptContainer${
-                    this.isOpen ? " active" : ""
-                }`}
+            <SiteToolsDialog
+                className="feedbackPromptContainer"
+                isOpen={this.isOpen}
+                onOpenChange={this.onOpenChange}
+                label="Feedback"
+                closeLabel="Close feedback form"
+                icon={faCommentAlt}
+                dataTrackNote="page_open_feedback"
             >
-                {/* We are keeping the form always rendered to avoid wiping all contents
-                when a user accidentally closes the form */}
-                <div style={{ display: this.isOpen ? "block" : "none" }}>
-                    <div className="overlay" onClick={this.onClickOutside} />
-                    <div className="box">
-                        <FeedbackForm onClose={this.onClose} />
-                    </div>
-                </div>
-                {this.isOpen ? (
-                    <SiteToolsButton
-                        icon={faTimes}
-                        label="Close feedback form"
-                        tooltip={false}
-                        onClick={this.toggleOpen}
-                    />
-                ) : (
-                    <SiteToolsButton
-                        icon={faCommentAlt}
-                        label="Feedback"
-                        dataTrackNote="page_open_feedback"
-                        onClick={this.toggleOpen}
-                    />
-                )}
-            </div>
+                <FeedbackForm
+                    onClose={this.onClose}
+                    formState={this.formState}
+                />
+            </SiteToolsDialog>
         )
     }
 }

--- a/site/NewsletterSubscription.tsx
+++ b/site/NewsletterSubscription.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react"
 import * as React from "react"
 import cx from "clsx"
-import { faTimes, faEnvelopeOpenText } from "@fortawesome/free-solid-svg-icons"
+import { faEnvelopeOpenText } from "@fortawesome/free-solid-svg-icons"
 import { SiteAnalytics } from "./SiteAnalytics.js"
 import { TextInput } from "@ourworldindata/components"
 import { NewsletterSubscriptionContext } from "./newsletter.js"
 import { NewsletterIcon } from "./gdocs/components/NewsletterIcon.js"
-import { SiteToolsButton } from "./SiteToolsButton.js"
+import { SiteToolsDialog } from "./SiteToolsDialog.js"
 
 const analytics = new SiteAnalytics()
 
@@ -19,40 +19,19 @@ export const NewsletterSubscription = ({
 }) => {
     const [isOpen, setIsOpen] = useState(false)
 
-    const subscribeText = "Subscribe"
-
     return (
-        <div className={`newsletter-subscription${isOpen ? " active" : ""}`}>
-            {isOpen && (
-                <>
-                    <div
-                        className="overlay"
-                        onClick={() => {
-                            setIsOpen(false)
-                        }}
-                    />
-                    <div className="box">
-                        <NewsletterSubscriptionHeader />
-                        <NewsletterSubscriptionForm context={context} />
-                    </div>
-                </>
-            )}
-            {isOpen ? (
-                <SiteToolsButton
-                    icon={faTimes}
-                    label="Close subscription form"
-                    tooltip={false}
-                    onClick={() => setIsOpen(false)}
-                />
-            ) : (
-                <SiteToolsButton
-                    icon={faEnvelopeOpenText}
-                    label={subscribeText}
-                    dataTrackNote="dialog_open_newsletter"
-                    onClick={() => setIsOpen(true)}
-                />
-            )}
-        </div>
+        <SiteToolsDialog
+            className="newsletter-subscription"
+            isOpen={isOpen}
+            onOpenChange={setIsOpen}
+            label="Subscribe"
+            closeLabel="Close subscription form"
+            icon={faEnvelopeOpenText}
+            dataTrackNote="dialog_open_newsletter"
+        >
+            <NewsletterSubscriptionHeader />
+            <NewsletterSubscriptionForm context={context} />
+        </SiteToolsDialog>
     )
 }
 

--- a/site/SiteToolsDialog.tsx
+++ b/site/SiteToolsDialog.tsx
@@ -1,0 +1,79 @@
+import { useLayoutEffect, useRef, useState } from "react"
+import type { ReactNode } from "react"
+import { Dialog, Modal, ModalOverlay } from "react-aria-components"
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core"
+import { faTimes } from "@fortawesome/free-solid-svg-icons"
+import { SiteToolsButton } from "./SiteToolsButton.js"
+
+export function SiteToolsDialog({
+    isOpen,
+    onOpenChange,
+    className,
+    label,
+    closeLabel,
+    icon,
+    dataTrackNote,
+    children,
+}: {
+    isOpen: boolean
+    onOpenChange: (isOpen: boolean) => void
+    className: string
+    label: string
+    closeLabel: string
+    icon: IconDefinition
+    dataTrackNote: string
+    children: ReactNode
+}) {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const [position, setPosition] = useState<{ left: number; bottom: number }>()
+
+    useLayoutEffect(() => {
+        if (!isOpen) return
+
+        const updatePosition = () => {
+            const bounds = containerRef.current?.getBoundingClientRect()
+            if (bounds?.width === 0) {
+                onOpenChange(false)
+            } else if (bounds) {
+                setPosition({
+                    left: bounds.left,
+                    bottom: window.innerHeight - bounds.bottom,
+                })
+            }
+        }
+        updatePosition()
+        window.addEventListener("resize", updatePosition)
+        return () => window.removeEventListener("resize", updatePosition)
+    }, [isOpen, onOpenChange])
+
+    return (
+        <div ref={containerRef} className={className}>
+            <SiteToolsButton
+                icon={icon}
+                label={label}
+                dataTrackNote={dataTrackNote}
+                onClick={() => onOpenChange(true)}
+            />
+            <ModalOverlay
+                className="site-tools__modal-overlay"
+                isOpen={isOpen && position !== undefined}
+                onOpenChange={onOpenChange}
+                isDismissable
+            >
+                {/* Align the close button with its trigger, while the form
+                    stays aligned with the right edge of the tool group. */}
+                <Modal className="site-tools__modal" style={position}>
+                    <Dialog className="site-tools__dialog" aria-label={label}>
+                        <div className="site-tools__box">{children}</div>
+                        <SiteToolsButton
+                            icon={faTimes}
+                            label={closeLabel}
+                            tooltip={false}
+                            onClick={() => onOpenChange(false)}
+                        />
+                    </Dialog>
+                </Modal>
+            </ModalOverlay>
+        </div>
+    )
+}

--- a/site/css/newsletter-subscription.scss
+++ b/site/css/newsletter-subscription.scss
@@ -100,7 +100,3 @@
 .homepage-subscribe .newsletter-subscription {
     flex: 1;
 }
-
-.site-tools .newsletter-subscription form {
-    padding: 32px 40px;
-}

--- a/site/css/site-tools.scss
+++ b/site/css/site-tools.scss
@@ -31,10 +31,6 @@ $site-tools-popover-inset: $header-height-md + $vertical-spacing * 3 +
         gap: $site-tools-button-gap;
     }
 
-    .site-tools > .active {
-        z-index: $zindex-popover;
-    }
-
     .site-tools__button {
         @include popover-box-button;
         display: flex;
@@ -55,18 +51,29 @@ $site-tools-popover-inset: $header-height-md + $vertical-spacing * 3 +
         }
     }
 
-    .site-tools .overlay {
+    .site-tools__modal-overlay {
         @include overlay;
+        z-index: $zindex-popover;
     }
 
-    .site-tools .box .FeedbackForm {
+    .site-tools__modal {
+        position: fixed;
+        right: $vertical-spacing;
+    }
+
+    .site-tools__dialog:focus-visible {
+        // The dialog has no visible box of its own; its controls keep their rings.
+        outline: none;
+    }
+
+    .site-tools__box .FeedbackForm {
         max-height: min(
             700px,
             calc(var(--viewport-height) - #{$site-tools-popover-inset})
         );
     }
 
-    .site-tools .box {
+    .site-tools__box {
         position: absolute;
         right: 0;
         bottom: 100%;
@@ -86,7 +93,7 @@ $site-tools-popover-inset: $header-height-md + $vertical-spacing * 3 +
         }
 
         .newsletter-subscription-form {
-            padding-top: 16px;
+            padding: 16px 40px 32px;
         }
     }
 }


### PR DESCRIPTION
> _Written by OpenAI GPT-6 — @mlbrgl at the wheel._

Keep keyboard focus inside the floating Subscribe and Feedback dialogs so Tab cannot reach the page behind them. Escape and backdrop clicks dismiss the dialog and restore focus to its trigger; feedback opens with the message field focused and preserves drafts when closed.

Stacked on #7106.

<details><summary>Details</summary>

- Share a `SiteToolsDialog` wrapper built with the existing `react-aria-components` dependency, using its default portal and positioning the dialog from the trigger's bounds.
- Keep feedback draft and submission state outside the mounted dialog, with controlled form fields.
- Preserve popup spacing and button placement; close the dialog when resizing hides the floating tools.
- Validation: TypeScript, lint, formatting, production site build, and local BundleMon size limits passed. Browser checks covered Tab/Shift+Tab wrapping, disabled controls, Escape, backdrop dismissal, restored focus, draft retention, and mobile resizing. Before/after screenshots were compared locally.
- The existing tall-popup clipping near the footer has identical measured bounds before and after this change.

</details>
