### PR TITLE
Log the Accept header on edge analytics events

### DIFF
--- a/functions/_common/analytics.test.ts
+++ b/functions/_common/analytics.test.ts
@@ -9,6 +9,7 @@ describe(getCommonEventParams, () => {
                 headers: {
                     referer: "https://ourworldindata.org/coronavirus",
                     "user-agent": "Mozilla/5.0 (test)",
+                    accept: "text/markdown, text/html, */*",
                     "cf-ipcountry": "US",
                 },
             }
@@ -31,6 +32,7 @@ describe(getCommonEventParams, () => {
         expect(params.pathname).toBe("/grapher/foo")
         expect(params.referrer).toBe("https://ourworldindata.org/coronavirus")
         expect(params.user_agent).toBe("Mozilla/5.0 (test)")
+        expect(params.accept).toBe("text/markdown, text/html, */*")
         expect(params.method).toBe("GET")
         expect(params.country).toBe("US")
         expect(params.sampling).toBe(0.25)

--- a/functions/_common/analytics.ts
+++ b/functions/_common/analytics.ts
@@ -59,6 +59,16 @@ export function getCommonEventParams(
     const fullUserAgent = request.headers.get("user-agent") || ""
     const user_agent = fullUserAgent.slice(0, 100)
 
+    // What the client asked for. Agent fetchers negotiate content: Claude Code's
+    // sends "text/markdown, text/html, */*", Gemini's and curl send "*/*",
+    // browsers lead with "text/html". That is the only signal separating
+    // markdown-preferring agents from everything else — user agents don't, and
+    // Cloudflare's bot fields are empty on our plan — and it is what tells us how
+    // many readers a markdown rendering of a page actually reaches. Truncated
+    // like the user agent; browser Accept strings run long, but the part that
+    // matters comes first.
+    const accept = (request.headers.get("accept") || "").slice(0, 100)
+
     // Network operator (ASN) of the request, derived by Cloudflare on `request.cf`
     // — same source as the country lookup. This is NOT the client IP (which we
     // don't have/forward); it's the owning org, e.g. "Amazon.com", "Google Cloud",
@@ -91,6 +101,7 @@ export function getCommonEventParams(
         pathname: url.pathname,
         referrer,
         user_agent,
+        accept,
         method: request.method,
         country: request.headers.get("cf-ipcountry") || "",
         as_org,


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @Marigold at the wheel._

Logs the request's `Accept` header as an `accept` param on the edge analytics events, next to `user_agent`.

Why: AI agents that fetch our pages negotiate content. Claude Code's fetcher sends `Accept: text/markdown, text/html, */*` and gets Cloudflare's markdown rendering; Gemini's fetcher and `curl` send `*/*` and get the HTML; browsers lead with `text/html`. The user agent alone does not separate these readers (measured in #7245), and Cloudflare's bot fields are empty on our plan. Today the edge logs record `user_agent` but not `Accept`, so there is no way to say what share of page requests come from markdown-preferring agents, which is the number #7224 (page markdown) needs to be judged on after it ships.

Truncated to 100 characters like the user agent; browser `Accept` strings run longer, but the media types that matter come first.

Follow-ups, not in this PR:

- `functions/_common/analytics.ts` is mirrored in `cloudflare-workers/utils/analytics.ts` (owid/cloudflare-workers#26); the same line needs adding there so the proxy workers emit it too.
- The `raw_traffic` dbt model in the analytics repo extracts params by name; it needs an `accept` column before the field is queryable in BigQuery.

<details>
<summary>Details</summary>

One new param in `getCommonEventParams`, `accept: (request.headers.get("accept") || "").slice(0, 100)`, plus an assertion in `analytics.test.ts`. GA4 Measurement Protocol allows 25 params per event; the fixed set is now 13 before `q_*` query params and `status_code`, which is where it was in practice already.

</details>
