### PR TITLE
Make the search country selector checkbox clickable

### DIFF
--- a/site/search/SearchCountrySelector.scss
+++ b/site/search/SearchCountrySelector.scss
@@ -197,6 +197,7 @@
     color: $blue-90;
     display: flex;
     align-items: center;
+    cursor: pointer;
 
     &:last-child {
         border-bottom: none;
@@ -228,7 +229,10 @@
         right: 8px;
         top: 50%;
         transform: translateY(-50%);
-        cursor: pointer;
+        // The checkbox only visualises the row's state: let clicks fall
+        // through to the row, which react-aria makes the press target.
+        // Without this, clicking the checkbox does nothing at all.
+        pointer-events: none;
     }
 }
 

--- a/site/search/SearchCountrySelector.tsx
+++ b/site/search/SearchCountrySelector.tsx
@@ -181,12 +181,17 @@ export const SearchCountrySelector = ({
                                     src={`/images/flags/${country.code}.svg`}
                                 />
                                 {country.name}
+                                {/* Purely decorative: the whole row is the
+                                click target, and children of a `role=option`
+                                element aren't exposed to screen readers. */}
                                 <input
                                     type="checkbox"
                                     checked={selectedRegionNames.includes(
                                         country.name
                                     )}
                                     readOnly
+                                    tabIndex={-1}
+                                    aria-hidden
                                 />
                             </ListBoxItem>
                         ))}

--- a/site/search/SearchCountrySelector.tsx
+++ b/site/search/SearchCountrySelector.tsx
@@ -181,12 +181,18 @@ export const SearchCountrySelector = ({
                                     src={`/images/flags/${country.code}.svg`}
                                 />
                                 {country.name}
+                                {/* Not a tab stop: React Aria's collection
+                                skips it going forwards, but Shift+Tab lands
+                                on the last one otherwise. Deliberately not
+                                aria-hidden — its checked state is all that
+                                tells assistive tech the row is selected. */}
                                 <input
                                     type="checkbox"
                                     checked={selectedRegionNames.includes(
                                         country.name
                                     )}
                                     readOnly
+                                    tabIndex={-1}
                                 />
                             </ListBoxItem>
                         ))}

--- a/site/search/SearchCountrySelector.tsx
+++ b/site/search/SearchCountrySelector.tsx
@@ -181,17 +181,12 @@ export const SearchCountrySelector = ({
                                     src={`/images/flags/${country.code}.svg`}
                                 />
                                 {country.name}
-                                {/* Purely decorative: the whole row is the
-                                click target, and children of a `role=option`
-                                element aren't exposed to screen readers. */}
                                 <input
                                     type="checkbox"
                                     checked={selectedRegionNames.includes(
                                         country.name
                                     )}
                                     readOnly
-                                    tabIndex={-1}
-                                    aria-hidden
                                 />
                             </ListBoxItem>
                         ))}

--- a/site/search/SearchCountrySelector.tsx
+++ b/site/search/SearchCountrySelector.tsx
@@ -181,18 +181,12 @@ export const SearchCountrySelector = ({
                                     src={`/images/flags/${country.code}.svg`}
                                 />
                                 {country.name}
-                                {/* Not a tab stop: React Aria's collection
-                                skips it going forwards, but Shift+Tab lands
-                                on the last one otherwise. Deliberately not
-                                aria-hidden — its checked state is all that
-                                tells assistive tech the row is selected. */}
                                 <input
                                     type="checkbox"
                                     checked={selectedRegionNames.includes(
                                         country.name
                                     )}
                                     readOnly
-                                    tabIndex={-1}
                                 />
                             </ListBoxItem>
                         ))}


### PR DESCRIPTION
> _Written by Anthropic Claude Opus 5 — @mlbrgl at the wheel._

The checkbox on each row of `/search`'s country selector did nothing when clicked, though clicking anywhere else on the row toggled the country.

React Aria's `usePress` ignores presses originating on a nested interactive element, so the click never reached the `ListBoxItem`'s `onAction`. The checkbox is `readOnly` with no `onChange`, so it did nothing on its own either.

- `pointer-events: none` on the checkbox, so clicks fall through to the row — the real press target.
- Moved `cursor: pointer` from the checkbox to the row. It was backwards: the only spot showing a pointer was the only spot that didn't work.

CSS-only in effect; the accessibility tree is unchanged from `master`.

### Possible follow-ups

Found while investigating, all pre-existing and left alone:

1. **Rows report the wrong selection to assistive tech.** With no `selectionMode`, there's no `aria-selected` in the DOM, so Chromium synthesises one from focus — arrow onto a row and it's reported as selected regardless of whether that country is chosen. `selectionMode="multiple"` with `selectedKeys`/`onSelectionChange` fixes it and lets the decorative `<input>` go away entirely (style the check off `data-selected`).
2. **Shift+Tab lands on a row's checkbox.** React Aria skips it going forwards, but backwards the focus scope wraps to the last tabbable element in the popover — a dead stop on an inert input. `tabIndex={-1}` fixes it; subsumed by 1 if the input goes.
3. **The popover doesn't hide the page behind it.** Focus is properly contained and Escape/outside-click restore focus to the trigger, but with no `<Dialog>` the rest of the page isn't `aria-hidden`, so a virtual cursor can wander out of it.

Verified with Playwright against a reconstruction of the component (clicks, taps, keyboard, tab order, Chromium's accessibility tree) — not on the live page. ~~`/search` needs the `staging-algolia` label to work on staging.~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lw1xTMYhJK2tS3immgxbLa