### PR TITLE
🔨 🤖 drop the dead document-level citation enrichment

### DIFF
--- a/db/model/Gdoc/GdocPost.ts
+++ b/db/model/Gdoc/GdocPost.ts
@@ -11,7 +11,7 @@ import {
     ArchiveContext,
 } from "@ourworldindata/types"
 import { excludeNullish, generateToc } from "@ourworldindata/utils"
-import { formatCitation, generateStickyNav } from "./archieToEnriched.js"
+import { generateStickyNav } from "./archieToEnriched.js"
 import { parseFaqs, parseLatestFeedExcerpt } from "./rawToEnriched.js"
 import { GdocBase } from "./GdocBase.js"
 import { KnexReadonlyTransaction, knexRaw } from "../../db.js"
@@ -89,8 +89,6 @@ export class GdocPost extends GdocBase implements OwidGdocPostInterface {
                 content["latest-feed-excerpt"]
             )
         }
-
-        content.citation = formatCitation(content.citation)
 
         content["sticky-nav"] = generateStickyNav(content as any)
 

--- a/db/model/Gdoc/archieToEnriched.ts
+++ b/db/model/Gdoc/archieToEnriched.ts
@@ -8,7 +8,6 @@ import {
     OwidGdocStickyNavItem,
     OwidGdocType,
     checkNodeIsSpan,
-    EnrichedBlockSimpleText,
     lowercaseObjectKeys,
     ALL_CHARTS_ID,
     KEY_INSIGHTS_ID,
@@ -21,7 +20,6 @@ import {
     parseText,
 } from "./rawToEnriched.js"
 import { extractUrl, parseAuthors } from "./gdocUtils.js"
-import { htmlToSimpleTextBlock } from "./htmlToEnriched.js"
 import { RESEARCH_AND_WRITING_DEFAULT_HEADING } from "@ourworldindata/types"
 
 // Topic page headings have predictable heading names which are used in the sticky nav.
@@ -94,14 +92,6 @@ export function generateStickyNav(
     )
 
     return stickyNavItems
-}
-
-export function formatCitation(
-    rawCitation?: string | string[]
-): undefined | EnrichedBlockSimpleText[] {
-    if (!rawCitation) return
-    const citationArray = _.isArray(rawCitation) ? rawCitation : [rawCitation]
-    return citationArray.map(htmlToSimpleTextBlock)
 }
 
 // Empty out the parts of an ArchieML document that the parser itself discards,

--- a/docs/agent-guidelines/gdocs-class-hierarchy.md
+++ b/docs/agent-guidelines/gdocs-class-hierarchy.md
@@ -25,7 +25,7 @@ This note complements the Google Docs CMS pipeline overview by mapping the serve
 ### `GdocPost` (`db/model/Gdoc/GdocPost.ts`)
 
 - Represents the majority of articles (article, topic page, linear topic page, fragment).
-- Generates derived structures: table of contents (`generateToc`), sticky nav (`generateStickyNav`), citations (`formatCitation`), FAQ parsing (`parseFaqs`), and summary text blocks.
+- Generates derived structures: table of contents (`generateToc`), sticky nav (`generateStickyNav`); FAQ parsing (`parseFaqs`), and summary text blocks.
 - Exposes FAQ, reference, and deprecation notice blocks via `_getSubclassEnrichedBlocks` for markdown conversion.
 - Validates required tags for certain components and ensures linked charts/indicators are present.
 


### PR DESCRIPTION
> _Written by Anthropic Claude Fable 5.1 — @mlbrgl at the wheel._

Post enrichment wrote a document-level `content.citation` on every article, topic page, linear topic page and fragment, but no content interface declares that key and nothing in the site, baker, admin or functions reads it. It is a leftover of the 2023 WordPress migration. This removes the assignment and the `formatCitation` helper it was the only caller of.

Block-level citations on blockquotes are a different field and are unaffected.

<details><summary>Details</summary>

- `db/model/Gdoc/GdocPost.ts`: drop `content.citation = formatCitation(content.citation)` from `_enrichSubclassContent`.
- `db/model/Gdoc/archieToEnriched.ts`: remove `formatCitation` and its two now-unused imports.
- `docs/agent-guidelines/gdocs-class-hierarchy.md`: drop the mention.
- Found by a forthcoming unit test on the writing-reference branch that checks the authored/computed key classification against what enrichment actually writes: `citation` showed up as a key enrichment writes that no interface declares.
- Verified: `yarn typecheck`, `yarn testLintChanged`, `yarn test run db/model/Gdoc/archieToEnriched.test.ts`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
